### PR TITLE
fix: 온보딩 제출 후 /home 리다이렉트 실패 수정

### DIFF
--- a/src/actions/onboarding.ts
+++ b/src/actions/onboarding.ts
@@ -3,7 +3,7 @@
 import { auth } from '@/lib/auth'
 import { prisma } from '@/lib/prisma'
 import { onboardingSchema } from '@/lib/schemas/onboarding'
-import { revalidatePath } from 'next/cache'
+import { redirect } from 'next/navigation'
 import type { OnboardingAnswers } from '@/types/onboarding'
 import type { ActionResult } from '@/types/action'
 
@@ -76,6 +76,6 @@ export async function submitOnboarding(data: OnboardingAnswers): Promise<ActionR
     // 로깅 실패 무시
   }
 
-  revalidatePath('/home')
-  return { success: true }
+  // 서버에서 직접 리다이렉트 → 클라이언트 Router Cache를 우회
+  redirect('/home')
 }

--- a/src/components/onboarding/OnboardingWizard.tsx
+++ b/src/components/onboarding/OnboardingWizard.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { useState } from 'react'
-import { useRouter } from 'next/navigation'
 import { toast } from 'sonner'
 import { ProgressBar } from './ProgressBar'
 import { Q1BrewingMethod } from './steps/Q1BrewingMethod'
@@ -31,7 +30,6 @@ interface OnboardingWizardProps {
 }
 
 export function OnboardingWizard({ roasteries }: OnboardingWizardProps) {
-  const router = useRouter()
   const [step, setStep] = useState<Step>('Q1')
   const [q1, setQ1] = useState<BrewingMethod[]>([])
   const [q2, setQ2] = useState<PurchaseStyle | null>(null)
@@ -47,12 +45,12 @@ export function OnboardingWizard({ roasteries }: OnboardingWizardProps) {
   async function handleSubmit(answers: OnboardingAnswers) {
     setIsLoading(true)
     const result = await submitOnboarding(answers)
-    if (!result.success) {
+    // 성공 시 서버가 redirect('/home')를 호출 → 이 코드에 도달하지 않음
+    // 실패 시 서버가 ActionResult를 반환 → 에러 토스트 표시
+    if (result && !result.success) {
       toast.error(result.error)
       setIsLoading(false)
-      return
     }
-    router.push('/home')
   }
 
   if (step === 'Q1') {


### PR DESCRIPTION
## 원인

`router.push('/home')`는 Next.js 클라이언트 **Router Cache**를 사용합니다.
최초 앱 접속 시 `/home` → `/onboarding` 리다이렉트 응답이 Router Cache에 저장되고,
온보딩 제출 후 `router.push('/home')`를 호출해도 **캐시된 리다이렉트**가 재사용되어
다시 `/onboarding`으로 돌아오는 현상이 발생했습니다.

서버 측의 `revalidatePath`는 **Full Route Cache(서버 캐시)**만 무효화하며
클라이언트 Router Cache에는 영향을 주지 않아 문제가 지속됩니다.

## 수정 방법

서버 액션에서 `redirect('/home')` 직접 호출로 변경.
서버 사이드 리다이렉트는 클라이언트 캐시를 완전히 우회합니다.

```diff
- revalidatePath('/home')
- return { success: true }
+ redirect('/home')
```

클라이언트(`OnboardingWizard`)에서는 `router.push` 제거, 에러 케이스만 처리.

## 테스트
- [x] E-12: Q4=FIRST_TIME 온보딩 완료 후 /home으로 리다이렉트 (8/8 통과)