### PR TITLE
chore: Vercel 배포 설정

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "prisma generate && next build",
     "start": "next start",
     "lint": "eslint src/",
     "format": "prettier --write \"src/**/*.{ts,tsx}\"",

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -5,5 +5,5 @@ import { authConfig } from '@/lib/auth.config'
 export default NextAuth(authConfig).auth
 
 export const config = {
-  matcher: ['/((?!_next/static|_next/image|favicon.ico|logo.svg|icons/).*)'],
+  matcher: ['/((?!_next/static|_next/image|favicon.ico|brand/|icons/).*)'],
 }


### PR DESCRIPTION
## Summary
- `build` 스크립트에 `prisma generate` 추가 — Prisma 7 빌드 시 필수
- `proxy.ts` matcher에서 `brand/` 경로 제외 — 로고 등 정적 에셋에 인증 미적용

## Test plan
- [ ] `pnpm build` 로컬에서 정상 동작 확인
- [ ] 로그인 없이 `/brand/logo.svg` 접근 가능 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)