### PR TITLE
fix: Vercel + Supabase 빌드 오류 수정

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # ── Database ────────────────────────────────────────
 # 개발: postgresql://localhost:5432/rocommend
-# 프로덕션: Prisma Accelerate connection string 사용
+# 프로덕션(Supabase): 포트 5432 Session Pooler (prepared statement 지원)
 DATABASE_URL=
 
 # ── Auth.js v5 ───────────────────────────────────────

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,5 +30,5 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "prisma"]
 }


### PR DESCRIPTION
## 변경 사항
- `tsconfig.json` exclude에 `prisma` 추가 → `seed.ts`가 Next.js 빌드 타입 체크에 포함되어 발생하던 오류 제거
- `.env.example` DATABASE_URL 주석을 Session Pooler (포트 5432) 기준으로 수정

## 배경
Prisma 7 + `@prisma/adapter-pg` 환경에서 Supabase Transaction Pooler(포트 6543)를 사용하면 `prepared statement "s1" already exists` 오류 발생. `?pgbouncer=true` 플래그는 Prisma 바이너리 엔진 전용이라 드라이버 어댑터에서는 동작하지 않음.

→ Session Pooler (포트 5432) 사용으로 해결

## Vercel 빌드 커맨드 수정 필요 (별도 작업)
Vercel 대시보드 → Settings → Build Command를 아래로 변경:
```
prisma generate && prisma migrate deploy && next build
```

## 테스트 방법
- [ ] `pnpm build` 로컬 빌드 성공 확인
- [ ] Vercel 빌드 성공 확인