### PR TITLE
feat: 추천·로스터리 페이지 비로그인 접근 허용

### DIFF
--- a/src/app/(main)/home/page.tsx
+++ b/src/app/(main)/home/page.tsx
@@ -4,14 +4,14 @@ import { getRecommendations } from '@/lib/recommender'
 import { HomeFeedClient } from '@/components/home/HomeFeedClient'
 import { FeedSkeleton } from '@/components/home/FeedSkeleton'
 
-async function HomeFeed({ userId }: { userId: string }) {
+async function HomeFeed({ userId }: { userId?: string }) {
   const result = await getRecommendations(userId)
   return <HomeFeedClient result={result} />
 }
 
 export default async function HomePage() {
   const session = await auth()
-  const userId = session!.user!.id!
+  const userId = session?.user?.id
 
   return (
     <div className="py-8 flex flex-col gap-6">

--- a/src/lib/auth.config.ts
+++ b/src/lib/auth.config.ts
@@ -7,7 +7,7 @@ import '@/types/auth'
 // Edge Runtime 호환 설정 (Prisma adapter 없음)
 // proxy.ts에서 import — Node.js 모듈 사용 불가
 
-const PUBLIC_PATHS = ['/login', '/error', '/api/auth', '/api/test', '/roasteries']
+const PUBLIC_PATHS = ['/login', '/error', '/api/auth', '/api/test', '/roasteries', '/home']
 
 function isPublicPath(pathname: string) {
   return PUBLIC_PATHS.some((p) => pathname.startsWith(p))

--- a/src/lib/recommender/index.ts
+++ b/src/lib/recommender/index.ts
@@ -5,7 +5,9 @@ import type { RecommendationResult } from './types'
 export type { RecommendationResult, RecommendationItem } from './types'
 export { computeAndSaveCF } from './item-cf'
 
-export async function getRecommendations(userId: string): Promise<RecommendationResult> {
+export async function getRecommendations(userId?: string): Promise<RecommendationResult> {
+  if (!userId) return getPopularFallback()
+
   const ratingCount = await getUserRatingCount(userId)
 
   if (ratingCount < 3) {

--- a/src/lib/recommender/popular.ts
+++ b/src/lib/recommender/popular.ts
@@ -3,7 +3,7 @@ import type { RecommendationResult } from './types'
 import type { PriceRange } from '@/types/roastery'
 
 export async function getPopularFallback(
-  userId: string,
+  userId?: string,
   preferredPriceRanges?: PriceRange[]
 ): Promise<RecommendationResult> {
   const roasteries = await getPopularRoasteries(userId, preferredPriceRanges)


### PR DESCRIPTION
## 변경 사항
- `PUBLIC_PATHS`에 `/home` 추가 — 비로그인 사용자도 추천 페이지 접근 가능
- `getRecommendations` / `getPopularFallback` `userId` 파라미터 optional 처리
- 비로그인 시 CF 대신 인기 로스터리 폴백 반환
- `/roasteries`(목록·상세)는 기존에 이미 공개 처리되어 있어 별도 변경 없음

## 동작 방식
| 경로 | 비로그인 | 로그인 |
|------|----------|--------|
| `/home` | 인기 로스터리 표시 | CF 추천 or 인기 폴백 |
| `/roasteries` | 전체 목록 표시 | 전체 목록 + 평가 필터 |
| `/roasteries/[id]` | 상세 조회 가능 | 평가·즐겨찾기 가능 |

## 테스트 방법
- [x] 비로그인 상태에서 `/home` 접근 시 로그인 페이지로 리다이렉트되지 않고 인기 로스터리 노출
- [x] 비로그인 상태에서 `/roasteries` 접근 시 목록 정상 노출
- [x] 비로그인 상태에서 `/roasteries/[id]` 접근 시 상세 정상 노출
- [x] 로그인 사용자는 기존과 동일하게 추천/평가/즐겨찾기 동작