### PR TITLE
hotfix: Prisma 싱글톤 프로덕션 미적용 버그 수정

### DIFF
--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -13,4 +13,4 @@ function createPrismaClient() {
 
 export const prisma = globalForPrisma.prisma ?? createPrismaClient()
 
-if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma
+globalForPrisma.prisma = prisma


### PR DESCRIPTION
## 변경 사항
- `prisma.ts`에서 `NODE_ENV !== 'production'` 조건 제거
- 환경 무관하게 `globalForPrisma`에 PrismaClient 인스턴스 저장

## 원인
프로덕션에서 싱글톤이 저장되지 않아 동일 warm 함수 재사용 시에도 매 요청마다 `new PrismaClient()` + `new pg.Pool()`이 생성됨. Supabase PgBouncer가 Postgres 측 커넥션은 보호해도, 앱 → PgBouncer 구간은 매 요청마다 새 TCP 연결 + 인증 핸드셰이크가 발생해 LCP 3초+ 지연 유발.

## 효과
동일 Vercel warm 함수 내에서 `pg.Pool`을 재사용해 PgBouncer 재연결 오버헤드 제거.