### PR TITLE
release: v0.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rocommend-init",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/actions/onboarding.ts
+++ b/src/actions/onboarding.ts
@@ -1,12 +1,12 @@
 'use server'
 
 import { after } from 'next/server'
-import { auth } from '@/lib/auth'
+import { auth, unstable_update } from '@/lib/auth'
 import { prisma } from '@/lib/prisma'
+import { Prisma } from '@prisma/client'
 import { onboardingSchema } from '@/lib/schemas/onboarding'
 import { computeAndSaveCF } from '@/lib/recommender'
 import { redirect } from 'next/navigation'
-import { unstable_update } from '@/lib/auth'
 import type { OnboardingAnswers } from '@/types/onboarding'
 import type { ActionResult } from '@/types/action'
 
@@ -66,7 +66,16 @@ export async function submitOnboarding(data: OnboardingAnswers): Promise<ActionR
         },
       })
     })
-  } catch {
+  } catch (err) {
+    console.error('[submitOnboarding] transaction failed:', err)
+    // FK 위반 = JWT의 userId가 DB User 테이블에 없음 (세션 불일치)
+    if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2003') {
+      return {
+        success: false,
+        error: '세션이 만료되었습니다. 다시 로그인해주세요.',
+        code: 'UNAUTHORIZED',
+      }
+    }
     return {
       success: false,
       error: '저장 중 오류가 발생했습니다. 다시 시도해주세요.',

--- a/src/components/onboarding/OnboardingWizard.tsx
+++ b/src/components/onboarding/OnboardingWizard.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import { signOut } from 'next-auth/react'
 import { toast } from 'sonner'
 import { ProgressBar } from './ProgressBar'
 import { Q1BrewingMethod } from './steps/Q1BrewingMethod'
@@ -46,9 +47,14 @@ export function OnboardingWizard({ roasteries }: OnboardingWizardProps) {
     setIsLoading(true)
     const result = await submitOnboarding(answers)
     // 성공 시 서버가 redirect('/home')를 호출 → 이 코드에 도달하지 않음
-    // 실패 시 서버가 ActionResult를 반환 → 에러 토스트 표시
+    // 실패 시 서버가 ActionResult를 반환 → 에러 처리
     if (result && !result.success) {
       toast.error(result.error)
+      // FK 위반 (userId가 DB에 없음) → 세션 만료 → 로그아웃 후 /login
+      if (result.code === 'UNAUTHORIZED') {
+        await signOut({ callbackUrl: '/login' })
+        return
+      }
       setIsLoading(false)
     }
   }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -38,11 +38,13 @@ export const { handlers, auth, signIn, signOut, unstable_update } = NextAuth({
       if (user?.role) token.role = user.role
       // 최초 로그인, 세션 갱신, 또는 토큰에 onboardingVersion이 없을 때 DB 조회
       if (trigger === 'signIn' || trigger === 'update' || !('onboardingVersion' in token)) {
-        const onboarding = await prisma.onboarding.findUnique({
-          where: { userId: token.sub! },
-          select: { version: true },
+        // User 존재 여부 검증 — race condition(동시 소셜 로그인)으로 User row 미생성 시 토큰 무효화
+        const dbUser = await prisma.user.findUnique({
+          where: { id: token.sub! },
+          select: { id: true, onboarding: { select: { version: true } } },
         })
-        token.onboardingVersion = onboarding?.version ?? null
+        if (!dbUser) return null // 토큰 무효화 → NextAuth가 세션 종료 처리
+        token.onboardingVersion = dbUser.onboarding?.version ?? null
       }
       return token
     },


### PR DESCRIPTION
## v0.5.2

### 버그 수정

- 소셜 로그인 race condition으로 발생하는 온보딩 stuck 상태 수정
  - jwt callback에서 User 존재 검증 (User 없으면 토큰 무효화)
  - P2003 FK 위반 감지 시 자동 로그아웃으로 `/login` 이동
  - iPhone Safari 등 쿠키 삭제가 어려운 환경에서도 탈출 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)