### PR TITLE
feat: 로그인 페이지 뒤로 가기 링크 추가

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,5 +1,11 @@
+import type { Metadata } from 'next'
 import { LoginButton } from '@/components/auth/LoginButton'
 import { ErrorAlert } from '@/components/auth/ErrorAlert'
+import { BackLink } from '@/components/auth/BackLink'
+
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+}
 
 interface Props {
   searchParams: Promise<{ error?: string; provider?: string }>
@@ -10,6 +16,7 @@ export default async function LoginPage({ searchParams }: Props) {
 
   return (
     <div className="w-full max-w-sm space-y-8">
+      <BackLink />
       {/* 로고 + 슬로건 */}
       <div className="space-y-2 text-center">
         <h1 className="text-2xl font-bold text-text-primary">Rocommend</h1>

--- a/src/components/auth/BackLink.tsx
+++ b/src/components/auth/BackLink.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+
+export function BackLink() {
+  const router = useRouter()
+
+  return (
+    <button
+      onClick={() => router.back()}
+      className="flex items-center gap-1 text-sm text-text-secondary hover:text-text-primary transition-colors w-fit cursor-pointer"
+    >
+      ← 뒤로 가기
+    </button>
+  )
+}


### PR DESCRIPTION
## 변경 사항
- `BackLink` 클라이언트 컴포넌트 생성 (`router.back()` 사용)
- 로그인 페이지 상단에 뒤로 가기 링크 추가
- 로스터리 상세 등 어느 페이지에서 접근해도 이전 페이지로 복귀

## 테스트 방법
- [ ] 홈에서 로그인 페이지 진입 → 뒤로 가기 클릭 시 홈으로 이동
- [ ] 로스터리 상세에서 로그인 페이지 진입 → 뒤로 가기 클릭 시 상세 페이지로 이동