### PR TITLE
release: v0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rocommend-init",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,5 +1,11 @@
+import type { Metadata } from 'next'
 import { LoginButton } from '@/components/auth/LoginButton'
 import { ErrorAlert } from '@/components/auth/ErrorAlert'
+import { BackLink } from '@/components/auth/BackLink'
+
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+}
 
 interface Props {
   searchParams: Promise<{ error?: string; provider?: string }>
@@ -10,6 +16,7 @@ export default async function LoginPage({ searchParams }: Props) {
 
   return (
     <div className="w-full max-w-sm space-y-8">
+      <BackLink />
       {/* 로고 + 슬로건 */}
       <div className="space-y-2 text-center">
         <h1 className="text-2xl font-bold text-text-primary">Rocommend</h1>

--- a/src/app/(main)/profile/page.tsx
+++ b/src/app/(main)/profile/page.tsx
@@ -6,7 +6,6 @@ import { getProfileSummary } from '@/lib/queries/profile'
 import { ProfileCard } from '@/components/profile/ProfileCard'
 import { ActivitySummary } from '@/components/profile/ActivitySummary'
 import { LogoutButton } from '@/components/profile/LogoutButton'
-import { ThemeToggle } from '@/components/profile/ThemeToggle'
 
 export default async function ProfilePage() {
   const session = await auth()
@@ -38,8 +37,6 @@ export default async function ProfilePage() {
       >
         계정 관리
       </Link>
-
-      <ThemeToggle />
 
       <LogoutButton />
     </div>

--- a/src/app/(main)/settings/page.tsx
+++ b/src/app/(main)/settings/page.tsx
@@ -1,0 +1,30 @@
+import Link from 'next/link'
+import { auth } from '@/lib/auth'
+import { ThemeToggle } from '@/components/profile/ThemeToggle'
+
+export default async function SettingsPage() {
+  const session = await auth()
+
+  return (
+    <div className="page-wrapper py-8 flex flex-col gap-6">
+      <h1 className="text-xl font-semibold">설정</h1>
+
+      <section className="flex flex-col gap-2">
+        <h2 className="text-sm font-medium text-text-secondary">테마</h2>
+        <ThemeToggle />
+      </section>
+
+      {!session?.user && (
+        <section className="flex flex-col gap-2">
+          <h2 className="text-sm font-medium text-text-secondary">계정</h2>
+          <Link
+            href="/login"
+            className="flex w-full items-center justify-center rounded-lg border border-border bg-surface px-4 py-3 text-sm font-medium text-text-primary transition-colors hover:bg-bg"
+          >
+            로그인
+          </Link>
+        </section>
+      )}
+    </div>
+  )
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -25,7 +25,7 @@ export default async function RootLayout({
         {/* FOUC 방지 — hydration 전에 저장된 테마 적용 */}
         <script
           dangerouslySetInnerHTML={{
-            __html: `(function(){var t=localStorage.getItem('theme')||'light';document.documentElement.setAttribute('data-theme',t);})();`,
+            __html: `(function(){var t=localStorage.getItem('theme')||'system';var r=t==='system'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;document.documentElement.setAttribute('data-theme',r);})();`,
           }}
         />
       </head>

--- a/src/components/auth/BackLink.tsx
+++ b/src/components/auth/BackLink.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+
+export function BackLink() {
+  const router = useRouter()
+
+  return (
+    <button
+      onClick={() => router.back()}
+      className="flex items-center gap-1 text-sm text-text-secondary hover:text-text-primary transition-colors w-fit cursor-pointer"
+    >
+      ← 뒤로 가기
+    </button>
+  )
+}

--- a/src/components/layout/BottomTab.tsx
+++ b/src/components/layout/BottomTab.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { useSession } from 'next-auth/react'
-import { Home, Coffee, Bookmark, User, LogIn } from 'lucide-react'
+import { Home, Coffee, Bookmark, User, Settings } from 'lucide-react'
 import { cn } from '@/lib/utils'
 
 const authTabs = [
@@ -16,7 +16,7 @@ const authTabs = [
 const guestTabs = [
   { href: '/home', label: '홈', Icon: Home },
   { href: '/roasteries', label: '로스터리', Icon: Coffee },
-  { href: '/login', label: '로그인', Icon: LogIn },
+  { href: '/settings', label: '설정', Icon: Settings },
 ]
 
 export function BottomTab({ className }: { className?: string }) {

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { useSession, signOut } from 'next-auth/react'
 import Image from 'next/image'
+import { MoreVertical } from 'lucide-react'
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -11,17 +12,24 @@ import {
   DropdownMenuItem,
   DropdownMenuSeparator,
 } from '@/components/ui/dropdown-menu'
+import { ThemeToggle } from '@/components/profile/ThemeToggle'
 import { cn } from '@/lib/utils'
 
-const navLinks = [
+const authNavLinks = [
   { href: '/home', label: '홈' },
   { href: '/roasteries', label: '로스터리' },
   { href: '/bookmarks', label: '즐겨찾기' },
 ]
 
+const guestNavLinks = [
+  { href: '/home', label: '홈' },
+  { href: '/roasteries', label: '로스터리' },
+]
+
 export function Header({ className }: { className?: string }) {
   const pathname = usePathname()
   const { data: session } = useSession()
+  const navLinks = session?.user ? authNavLinks : guestNavLinks
 
   return (
     <header className={cn('sticky top-0 z-40 w-full border-b border-border bg-surface', className)}>
@@ -55,8 +63,9 @@ export function Header({ className }: { className?: string }) {
           ))}
         </nav>
 
-        {/* 아바타 드롭다운 / 로그인 버튼 */}
+        {/* 우측 영역 */}
         {session?.user ? (
+          /* 로그인: 아바타 드롭다운 */
           <DropdownMenu>
             <DropdownMenuTrigger className="flex size-8 cursor-pointer items-center justify-center overflow-hidden rounded-full bg-border focus:outline-none focus-visible:ring-2 focus-visible:ring-ring">
               {session.user.image ? (
@@ -74,12 +83,16 @@ export function Header({ className }: { className?: string }) {
                 </span>
               )}
             </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-40">
+            <DropdownMenuContent align="end" className="w-52">
               <DropdownMenuItem>
                 <Link href="/profile" className="w-full">
                   프로필
                 </Link>
               </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <div className="px-2 py-1.5">
+                <ThemeToggle />
+              </div>
               <DropdownMenuSeparator />
               <DropdownMenuItem
                 variant="destructive"
@@ -90,12 +103,25 @@ export function Header({ className }: { className?: string }) {
             </DropdownMenuContent>
           </DropdownMenu>
         ) : (
-          <Link
-            href="/login"
-            className="text-sm font-medium text-text-secondary transition-colors hover:text-text-primary"
-          >
-            로그인
-          </Link>
+          /* 비로그인: ⋮ 드롭다운 + 로그인 버튼 */
+          <div className="flex items-center gap-3">
+            <DropdownMenu>
+              <DropdownMenuTrigger className="flex size-8 cursor-pointer items-center justify-center rounded-md text-text-secondary transition-colors hover:text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-ring">
+                <MoreVertical className="size-5" />
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-52">
+                <div className="px-2 py-1.5">
+                  <ThemeToggle />
+                </div>
+              </DropdownMenuContent>
+            </DropdownMenu>
+            <Link
+              href="/login"
+              className="rounded-md bg-action px-3 py-1.5 text-sm font-medium text-action-text transition-opacity hover:opacity-80"
+            >
+              로그인
+            </Link>
+          </div>
         )}
       </div>
     </header>

--- a/src/components/layout/ThemeProvider.tsx
+++ b/src/components/layout/ThemeProvider.tsx
@@ -2,38 +2,65 @@
 
 import { createContext, useContext, useEffect, useState } from 'react'
 
-type Theme = 'light' | 'dark'
+export type Theme = 'light' | 'dark' | 'system'
+type ResolvedTheme = 'light' | 'dark'
 
 interface ThemeContextValue {
   theme: Theme
-  toggleTheme: () => void
+  resolvedTheme: ResolvedTheme
+  mounted: boolean
+  setTheme: (theme: Theme) => void
 }
 
 const ThemeContext = createContext<ThemeContextValue | null>(null)
 
-export function ThemeProvider({ children }: { children: React.ReactNode }) {
-  // 항상 'light'로 초기화 — FOUC는 layout.tsx 인라인 스크립트가 처리
-  // hydration mismatch 방지 (서버/클라이언트 초기값 통일)
-  const [theme, setTheme] = useState<Theme>('light')
+function getSystemTheme(): ResolvedTheme {
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+}
 
-  // 마운트 후 localStorage와 DOM 동기화 (toggle 없이 페이지 이동 시에도 테마 유지)
+function resolveTheme(theme: Theme): ResolvedTheme {
+  if (theme === 'system') return getSystemTheme()
+  return theme
+}
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [{ theme, mounted }, setState] = useState<{ theme: Theme; mounted: boolean }>({
+    theme: 'light',
+    mounted: false,
+  })
+
+  // 마운트 후 localStorage와 동기화 (FOUC는 layout.tsx 인라인 스크립트가 처리)
   useEffect(() => {
     const stored = localStorage.getItem('theme') as Theme | null
-    if (stored && stored !== theme) {
-      setTheme(stored)
-    }
-    // theme을 의존성에 포함하면 무한루프 — 마운트 시 1회만 실행
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setState({ theme: stored ?? 'light', mounted: true })
   }, [])
 
-  const toggleTheme = () => {
-    const next: Theme = theme === 'light' ? 'dark' : 'light'
-    setTheme(next)
+  // system 모드일 때 미디어 쿼리 변화 감지
+  useEffect(() => {
+    if (theme !== 'system') return
+
+    const mq = window.matchMedia('(prefers-color-scheme: dark)')
+    const handler = (e: MediaQueryListEvent) => {
+      document.documentElement.setAttribute('data-theme', e.matches ? 'dark' : 'light')
+    }
+    mq.addEventListener('change', handler)
+    return () => mq.removeEventListener('change', handler)
+  }, [theme])
+
+  const setTheme = (next: Theme) => {
+    setState((prev) => ({ ...prev, theme: next }))
     localStorage.setItem('theme', next)
-    document.documentElement.setAttribute('data-theme', next)
+    document.documentElement.setAttribute('data-theme', resolveTheme(next))
   }
 
-  return <ThemeContext.Provider value={{ theme, toggleTheme }}>{children}</ThemeContext.Provider>
+  const resolvedTheme: ResolvedTheme = typeof window !== 'undefined' ? resolveTheme(theme) : 'light'
+
+  return (
+    <ThemeContext.Provider value={{ theme, resolvedTheme, mounted, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  )
 }
 
 export function useTheme() {

--- a/src/components/profile/ThemeToggle.tsx
+++ b/src/components/profile/ThemeToggle.tsx
@@ -1,23 +1,39 @@
 'use client'
 
-import { Moon, Sun } from 'lucide-react'
-import { useTheme } from '@/components/layout/ThemeProvider'
+import { Sun, Moon, Monitor } from 'lucide-react'
+import { useTheme, type Theme } from '@/components/layout/ThemeProvider'
+import { cn } from '@/lib/utils'
+
+const options: { value: Theme; label: string; Icon: React.ElementType }[] = [
+  { value: 'light', label: '라이트', Icon: Sun },
+  { value: 'dark', label: '다크', Icon: Moon },
+  { value: 'system', label: '시스템', Icon: Monitor },
+]
 
 export function ThemeToggle() {
-  const { theme, toggleTheme } = useTheme()
-  const isDark = theme === 'dark'
+  const { theme, setTheme, mounted } = useTheme()
+
+  if (!mounted) {
+    return <div className="h-10 w-full rounded-lg bg-border" />
+  }
 
   return (
-    <button
-      onClick={toggleTheme}
-      className="flex w-full cursor-pointer items-center justify-between rounded-lg border border-border bg-surface px-4 py-3 text-sm font-medium text-text-primary transition-colors hover:bg-bg"
-    >
-      <span>{isDark ? '다크 모드' : '라이트 모드'}</span>
-      {isDark ? (
-        <Moon className="size-4 text-text-secondary" />
-      ) : (
-        <Sun className="size-4 text-text-secondary" />
-      )}
-    </button>
+    <div className="flex w-full overflow-hidden rounded-lg border border-border bg-surface">
+      {options.map(({ value, label, Icon }) => (
+        <button
+          key={value}
+          onClick={() => setTheme(value)}
+          aria-label={label}
+          className={cn(
+            'flex flex-1 cursor-pointer items-center justify-center py-2.5 transition-colors',
+            theme === value
+              ? 'bg-action text-action-text'
+              : 'text-text-disabled hover:bg-border hover:text-text-primary'
+          )}
+        >
+          <Icon className="size-4" />
+        </button>
+      ))}
+    </div>
   )
 }

--- a/src/lib/auth.config.ts
+++ b/src/lib/auth.config.ts
@@ -7,7 +7,16 @@ import '@/types/auth'
 // Edge Runtime 호환 설정 (Prisma adapter 없음)
 // proxy.ts에서 import — Node.js 모듈 사용 불가
 
-const PUBLIC_PATHS = ['/', '/login', '/error', '/api/auth', '/api/test', '/roasteries', '/home']
+const PUBLIC_PATHS = [
+  '/',
+  '/login',
+  '/error',
+  '/api/auth',
+  '/api/test',
+  '/roasteries',
+  '/home',
+  '/settings',
+]
 
 function isPublicPath(pathname: string) {
   return PUBLIC_PATHS.some((p) => (p === '/' ? pathname === '/' : pathname.startsWith(p)))


### PR DESCRIPTION
## v0.6.0

### 변경 사항
- 비로그인 테마 설정 지원 (라이트 / 다크 / 시스템)
- ThemeProvider 시스템 모드 추가 — OS `prefers-color-scheme` 실시간 감지
- 데스크탑 Header 유튜브 스타일 재설계
  - 로그인: 아바타 드롭다운에 테마 토글 통합
  - 비로그인: ⋮ 드롭다운(테마 토글) + 로그인 버튼(primary CTA)
- `/settings` 페이지 신규 생성 (인증 불필요)
- 모바일 BottomTab: 비로그인 시 "설정" 탭으로 변경
- 새로고침 시 테마 깜빡임(FOUC) 해결 — `mounted` 패턴 적용