### PR TITLE
feat: 의견 남기기 기능 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "prisma": "^7.4.2",
     "react": "19.2.3",
     "react-dom": "19.2.3",
+    "resend": "^6.10.0",
     "shadcn": "^4.0.2",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       react-dom:
         specifier: 19.2.3
         version: 19.2.3(react@19.2.3)
+      resend:
+        specifier: ^6.10.0
+        version: 6.10.0
       shadcn:
         specifier: ^4.0.2
         version: 4.0.2(@types/node@20.19.37)(typescript@5.9.3)
@@ -1199,6 +1202,9 @@ packages:
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
+
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -2381,6 +2387,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
@@ -3455,6 +3464,9 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
+  postal-mime@2.7.4:
+    resolution: {integrity: sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==}
+
   postcss-selector-parser@7.1.1:
     resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
     engines: {node: '>=4'}
@@ -3630,6 +3642,15 @@ packages:
 
   reselect@5.1.1:
     resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
+
+  resend@6.10.0:
+    resolution: {integrity: sha512-i7CwZpYj4Oho1RxsTpLcCUkO08+HiL4NXrm6jLJ2WzJ89UGI8eROSieLONJA3hnUrf1OYnCyfq5F6POnHUMv1Q==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@react-email/render': '*'
+    peerDependenciesMeta:
+      '@react-email/render':
+        optional: true
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -3813,6 +3834,9 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
@@ -3914,6 +3938,9 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  svix@1.88.0:
+    resolution: {integrity: sha512-vm/JrrUd3bVyBE+3L33TIyVSs8gS5fYx7lrISvKlDJXTYX1ACH4REX8P1tHxsSKoZi/rvifM1t0XRc5Vc45THw==}
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -4096,6 +4123,10 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  uuid@10.0.0:
+    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    hasBin: true
 
   valibot@1.2.0:
     resolution: {integrity: sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==}
@@ -5265,6 +5296,8 @@ snapshots:
   '@sec-ant/readable-stream@0.4.1': {}
 
   '@sindresorhus/merge-streams@4.0.0': {}
+
+  '@stablelib/base64@1.0.1': {}
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -6606,6 +6639,8 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-sha256@1.3.0: {}
+
   fast-uri@3.1.0: {}
 
   fastq@1.20.1:
@@ -7608,6 +7643,8 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
+  postal-mime@2.7.4: {}
+
   postcss-selector-parser@7.1.1:
     dependencies:
       cssesc: 3.0.0
@@ -7782,6 +7819,11 @@ snapshots:
   require-from-string@2.0.2: {}
 
   reselect@5.1.1: {}
+
+  resend@6.10.0:
+    dependencies:
+      postal-mime: 2.7.4
+      svix: 1.88.0
 
   resolve-from@4.0.0: {}
 
@@ -8079,6 +8121,11 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
   statuses@2.0.2: {}
 
   std-env@3.10.0: {}
@@ -8192,6 +8239,11 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  svix@1.88.0:
+    dependencies:
+      standardwebhooks: 1.0.0
+      uuid: 10.0.0
 
   symbol-tree@3.2.4: {}
 
@@ -8393,6 +8445,8 @@ snapshots:
       react: 19.2.3
 
   util-deprecate@1.0.2: {}
+
+  uuid@10.0.0: {}
 
   valibot@1.2.0(typescript@5.9.3):
     optionalDependencies:

--- a/prisma/migrations/20260412150411_add_feedback/migration.sql
+++ b/prisma/migrations/20260412150411_add_feedback/migration.sql
@@ -1,0 +1,26 @@
+-- CreateEnum
+CREATE TYPE "FeedbackStatus" AS ENUM ('PENDING', 'READ');
+
+-- CreateTable
+CREATE TABLE "Feedback" (
+    "id" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "category" TEXT,
+    "userId" TEXT NOT NULL,
+    "status" "FeedbackStatus" NOT NULL DEFAULT 'PENDING',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Feedback_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Feedback_userId_idx" ON "Feedback"("userId");
+
+-- CreateIndex
+CREATE INDEX "Feedback_status_idx" ON "Feedback"("status");
+
+-- CreateIndex
+CREATE INDEX "Feedback_createdAt_idx" ON "Feedback"("createdAt");
+
+-- AddForeignKey
+ALTER TABLE "Feedback" ADD CONSTRAINT "Feedback_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -21,6 +21,7 @@ model User {
   ratings         Rating[]
   bookmarks       Bookmark[]
   recommendations Recommendation[]
+  feedbacks       Feedback[]
 }
 
 model Onboarding {
@@ -274,4 +275,23 @@ enum TagCategory {
 enum Role {
   USER
   ADMIN
+}
+
+model Feedback {
+  id        String         @id @default(cuid())
+  content   String
+  category  String?
+  userId    String
+  user      User           @relation(fields: [userId], references: [id], onDelete: Cascade)
+  status    FeedbackStatus @default(PENDING)
+  createdAt DateTime       @default(now())
+
+  @@index([userId])
+  @@index([status])
+  @@index([createdAt])
+}
+
+enum FeedbackStatus {
+  PENDING
+  READ
 }

--- a/src/actions/feedback.ts
+++ b/src/actions/feedback.ts
@@ -1,0 +1,62 @@
+'use server'
+
+import { Resend } from 'resend'
+import { auth } from '@/lib/auth'
+import { prisma } from '@/lib/prisma'
+import { submitFeedbackSchema } from '@/lib/schemas/feedback'
+import type { ActionResult } from '@/types/action'
+
+const resend = new Resend(process.env.RESEND_API_KEY)
+
+export async function submitFeedback(input: {
+  content: string
+  category?: string
+}): Promise<ActionResult> {
+  const session = await auth()
+  if (!session?.user?.id) {
+    return { success: false, error: '로그인이 필요합니다', code: 'UNAUTHORIZED' }
+  }
+
+  const parsed = submitFeedbackSchema.safeParse(input)
+  if (!parsed.success) {
+    return {
+      success: false,
+      error: parsed.error.issues[0]?.message ?? '입력값이 올바르지 않습니다',
+      code: 'VALIDATION',
+    }
+  }
+
+  const userId = session.user.id
+  const { content, category } = parsed.data
+
+  try {
+    await prisma.feedback.create({
+      data: { userId, content, category },
+    })
+  } catch {
+    return { success: false, error: '저장 중 오류가 발생했습니다', code: 'DB_ERROR' }
+  }
+
+  const recipientEmail = process.env.FEEDBACK_RECIPIENT_EMAIL
+  if (recipientEmail && process.env.RESEND_API_KEY) {
+    try {
+      await resend.emails.send({
+        from: 'roco <onboarding@resend.dev>',
+        to: recipientEmail,
+        subject: `[roco] 새로운 의견이 도착했어요${category ? ` — ${category}` : ''}`,
+        html: [
+          `<p><strong>보낸 사람</strong>: ${session.user.name ?? '(이름 없음)'} (${session.user.email ?? '이메일 없음'})</p>`,
+          category ? `<p><strong>카테고리</strong>: ${category}</p>` : '',
+          `<p><strong>내용</strong>:</p>`,
+          `<blockquote style="border-left:3px solid #ccc;margin:0;padding:0 1em;color:#555">${content.replace(/\n/g, '<br/>')}</blockquote>`,
+        ]
+          .filter(Boolean)
+          .join('\n'),
+      })
+    } catch {
+      // 이메일 실패는 무시 — DB 저장이 우선
+    }
+  }
+
+  return { success: true }
+}

--- a/src/app/(main)/feedback/page.tsx
+++ b/src/app/(main)/feedback/page.tsx
@@ -1,0 +1,18 @@
+import { redirect } from 'next/navigation'
+import { auth } from '@/lib/auth'
+import { FeedbackPageClient } from '@/components/feedback/FeedbackPageClient'
+
+export default async function FeedbackPage() {
+  const session = await auth()
+  if (!session?.user?.id) redirect('/login')
+
+  return (
+    <div className="page-wrapper py-8 flex flex-col gap-6">
+      <h1 className="text-xl font-semibold">의견 남기기</h1>
+      <p className="text-sm text-text-secondary">
+        불편한 점, 개선 아이디어, 오류 등 편하게 남겨 주세요.
+      </p>
+      <FeedbackPageClient />
+    </div>
+  )
+}

--- a/src/components/feedback/FeedbackButton.tsx
+++ b/src/components/feedback/FeedbackButton.tsx
@@ -1,0 +1,48 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { toast } from 'sonner'
+import { useSession } from 'next-auth/react'
+import { MessageSquare } from 'lucide-react'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { FeedbackForm } from './FeedbackForm'
+
+export function FeedbackButton() {
+  const { data: session } = useSession()
+  const router = useRouter()
+  const [modalOpen, setModalOpen] = useState(false)
+
+  function handleClick() {
+    if (!session?.user) {
+      toast.error('로그인 후 이용할 수 있어요.')
+      return
+    }
+    if (window.innerWidth < 768) {
+      router.push('/feedback')
+      return
+    }
+    setModalOpen(true)
+  }
+
+  return (
+    <>
+      <button
+        onClick={handleClick}
+        className="flex w-full cursor-pointer items-center gap-2 px-2 py-1.5 text-sm text-text-primary transition-colors hover:bg-border rounded-md"
+      >
+        <MessageSquare className="size-4 text-text-secondary" />
+        의견 남기기
+      </button>
+
+      <Dialog open={modalOpen} onOpenChange={setModalOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>의견 남기기</DialogTitle>
+          </DialogHeader>
+          <FeedbackForm onSuccess={() => setModalOpen(false)} />
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/src/components/feedback/FeedbackForm.tsx
+++ b/src/components/feedback/FeedbackForm.tsx
@@ -1,0 +1,80 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import { submitFeedback } from '@/actions/feedback'
+
+interface FeedbackFormProps {
+  onSuccess: () => void
+}
+
+export function FeedbackForm({ onSuccess }: FeedbackFormProps) {
+  const [category, setCategory] = useState('')
+  const [content, setContent] = useState('')
+  const [isPending, startTransition] = useTransition()
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!content.trim()) {
+      toast.error('내용을 입력해 주세요.')
+      return
+    }
+
+    startTransition(async () => {
+      const result = await submitFeedback({
+        content: content.trim(),
+        category: category.trim() || undefined,
+      })
+      if (result.success) {
+        toast.success('의견을 남겼어요. 감사합니다!')
+        onSuccess()
+      } else {
+        toast.error(result.error)
+      }
+    })
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+      <div className="flex flex-col gap-1.5">
+        <label htmlFor="feedback-category" className="text-sm font-medium">
+          카테고리 <span className="font-normal text-text-secondary">(선택, 최대 50자)</span>
+        </label>
+        <input
+          id="feedback-category"
+          type="text"
+          value={category}
+          onChange={(e) => setCategory(e.target.value)}
+          maxLength={50}
+          placeholder="예: 버그 제보, 기능 제안, 기타"
+          className="w-full rounded-md border border-border bg-bg px-3 py-2 text-sm placeholder:text-text-disabled focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        />
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <label htmlFor="feedback-content" className="text-sm font-medium">
+          내용 <span className="font-normal text-text-secondary">(최대 1000자)</span>
+        </label>
+        <textarea
+          id="feedback-content"
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          maxLength={1000}
+          rows={6}
+          placeholder="불편한 점, 개선 아이디어, 오류 등 자유롭게 남겨 주세요."
+          className="w-full resize-none rounded-md border border-border bg-bg px-3 py-2 text-sm placeholder:text-text-disabled focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        />
+        <p className="text-right text-xs text-text-secondary">{content.length} / 1000</p>
+      </div>
+
+      <Button
+        type="submit"
+        disabled={isPending || !content.trim()}
+        className="w-full bg-action text-action-text hover:opacity-80"
+      >
+        {isPending ? '전송 중...' : '의견 보내기'}
+      </Button>
+    </form>
+  )
+}

--- a/src/components/feedback/FeedbackPageClient.tsx
+++ b/src/components/feedback/FeedbackPageClient.tsx
@@ -1,0 +1,10 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { FeedbackForm } from './FeedbackForm'
+
+export function FeedbackPageClient() {
+  const router = useRouter()
+
+  return <FeedbackForm onSuccess={() => router.back()} />
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -13,6 +13,7 @@ import {
   DropdownMenuSeparator,
 } from '@/components/ui/dropdown-menu'
 import { ThemeToggle } from '@/components/profile/ThemeToggle'
+import { FeedbackButton } from '@/components/feedback/FeedbackButton'
 import { cn } from '@/lib/utils'
 
 const authNavLinks = [
@@ -93,6 +94,9 @@ export function Header({ className }: { className?: string }) {
               <div className="px-2 py-1.5">
                 <ThemeToggle />
               </div>
+              <div className="px-2 py-0.5">
+                <FeedbackButton />
+              </div>
               <DropdownMenuSeparator />
               <DropdownMenuItem
                 variant="destructive"
@@ -112,6 +116,9 @@ export function Header({ className }: { className?: string }) {
               <DropdownMenuContent align="end" className="w-52">
                 <div className="px-2 py-1.5">
                   <ThemeToggle />
+                </div>
+                <div className="px-2 py-0.5">
+                  <FeedbackButton />
                 </div>
               </DropdownMenuContent>
             </DropdownMenu>

--- a/src/components/layout/Navigation.test.tsx
+++ b/src/components/layout/Navigation.test.tsx
@@ -19,6 +19,11 @@ vi.mock('next/image', () => ({
   default: ({ alt, src }: { alt: string; src: string }) => <img alt={alt} src={src} />,
 }))
 
+// FeedbackButton은 서버 액션·next-auth 내부를 로드하므로 렌더링 테스트에서는 stub 처리
+vi.mock('@/components/feedback/FeedbackButton', () => ({
+  FeedbackButton: () => null,
+}))
+
 describe('Navigation', () => {
   // C-25: lg 미만 화면 — BottomTab 표시, Header 숨김
   it('Header는 lg 미만에서 hidden 클래스를 갖는다', () => {

--- a/src/lib/schemas/feedback.ts
+++ b/src/lib/schemas/feedback.ts
@@ -1,0 +1,6 @@
+import { z } from 'zod'
+
+export const submitFeedbackSchema = z.object({
+  content: z.string().min(1, '내용을 입력해 주세요').max(1000, '1000자 이내로 입력해 주세요'),
+  category: z.string().max(50, '50자 이내로 입력해 주세요').optional(),
+})


### PR DESCRIPTION
## 변경 사항
- Feedback DB 모델 추가 (content 필수, category 선택, status PENDING/READ)
- submitFeedback Server Action: DB 저장 + Resend 이메일 발송 (FEEDBACK_RECIPIENT_EMAIL 설정 시)
- FeedbackButton: 드롭다운 하단에 배치
  - 비로그인 → 토스트 "로그인 후 이용할 수 있어요"
  - 로그인 + 데스크탑(md+) → 모달
  - 로그인 + 모바일 → /feedback 페이지
- 로그인·비로그인 양쪽 드롭다운에 공통 적용
- resend 패키지 추가

## 필요한 환경변수 (Vercel에 추가 필요)
- `RESEND_API_KEY` — Resend 대시보드에서 발급
- `FEEDBACK_RECIPIENT_EMAIL` — 의견 수신할 이메일 주소

## 테스트 방법
- [ ] 비로그인 상태에서 "의견 남기기" 클릭 → 토스트 안내 확인
- [ ] 로그인 후 데스크탑에서 클릭 → 모달 오픈, 제출 → 토스트 성공
- [ ] 로그인 후 모바일에서 클릭 → /feedback 페이지 이동, 제출 → 이전 페이지 복귀
- [ ] 카테고리 없이 내용만 제출 가능 확인
- [ ] DB에 Feedback 레코드 생성 확인