### PR TITLE
feat: 피드백 이메일 수신자 어드민 설정

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,5 +18,9 @@ AUTH_KAKAO_SECRET=
 AUTH_NAVER_ID=
 AUTH_NAVER_SECRET=
 
+# ── Email (Resend) ───────────────────────────────────
+# https://resend.com/api-keys 에서 발급
+RESEND_API_KEY=
+
 # ── Test (E2E 세션 우회용, 절대 프로덕션에 설정 금지) ──
 TEST_SESSION_TOKEN=

--- a/prisma/migrations/20260413044025_add_user_receive_feedback_email/migration.sql
+++ b/prisma/migrations/20260413044025_add_user_receive_feedback_email/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "receiveFeedbackEmail" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -12,9 +12,10 @@ model User {
   emailVerified   DateTime?
   name            String?
   image           String?
-  role            Role             @default(USER)
-  preferences     Json?            // { onboardingVersion: number, inferredProfile: object }
-  createdAt       DateTime         @default(now())
+  role                 Role             @default(USER)
+  preferences          Json?            // { onboardingVersion: number, inferredProfile: object }
+  receiveFeedbackEmail Boolean          @default(false)
+  createdAt            DateTime         @default(now())
   accounts        Account[]
   sessions        Session[]
   onboarding      Onboarding?

--- a/src/actions/admin.ts
+++ b/src/actions/admin.ts
@@ -545,6 +545,43 @@ export async function deleteSection(id: string): Promise<ActionResult<void>> {
   }
 }
 
+// ── 피드백 이메일 수신자 설정 ────────────────────────────
+
+export async function getAdminUsers() {
+  const check = await requireAdmin()
+  if ('error' in check) redirect('/home')
+
+  return prisma.user.findMany({
+    where: { role: 'ADMIN' },
+    select: { id: true, name: true, email: true, receiveFeedbackEmail: true },
+    orderBy: { createdAt: 'asc' },
+  })
+}
+
+export async function toggleFeedbackEmail(userId: string): Promise<ActionResult> {
+  const check = await requireAdmin()
+  if ('error' in check) {
+    return { success: false, error: check.error, code: check.code }
+  }
+
+  try {
+    const user = await prisma.user.findUnique({
+      where: { id: userId, role: 'ADMIN' },
+      select: { receiveFeedbackEmail: true },
+    })
+    if (!user) {
+      return { success: false, error: '존재하지 않는 어드민입니다', code: 'VALIDATION' }
+    }
+    await prisma.user.update({
+      where: { id: userId },
+      data: { receiveFeedbackEmail: !user.receiveFeedbackEmail },
+    })
+    return { success: true }
+  } catch {
+    return { success: false, error: '저장 중 오류가 발생했습니다', code: 'DB_ERROR' }
+  }
+}
+
 export async function reorderSections(orderedIds: string[]): Promise<ActionResult<void>> {
   const check = await requireAdmin()
   if ('error' in check) {

--- a/src/actions/feedback.ts
+++ b/src/actions/feedback.ts
@@ -37,22 +37,30 @@ export async function submitFeedback(input: {
     return { success: false, error: '저장 중 오류가 발생했습니다', code: 'DB_ERROR' }
   }
 
-  const recipientEmail = process.env.FEEDBACK_RECIPIENT_EMAIL
-  if (recipientEmail && process.env.RESEND_API_KEY) {
+  // 수신 설정된 어드민들에게 이메일 발송
+  if (process.env.RESEND_API_KEY) {
     try {
-      await resend.emails.send({
-        from: 'roco <onboarding@resend.dev>',
-        to: recipientEmail,
-        subject: `[roco] 새로운 의견이 도착했어요${category ? ` — ${category}` : ''}`,
-        html: [
-          `<p><strong>보낸 사람</strong>: ${session.user.name ?? '(이름 없음)'} (${session.user.email ?? '이메일 없음'})</p>`,
-          category ? `<p><strong>카테고리</strong>: ${category}</p>` : '',
-          `<p><strong>내용</strong>:</p>`,
-          `<blockquote style="border-left:3px solid #ccc;margin:0;padding:0 1em;color:#555">${content.replace(/\n/g, '<br/>')}</blockquote>`,
-        ]
-          .filter(Boolean)
-          .join('\n'),
+      const recipients = await prisma.user.findMany({
+        where: { role: 'ADMIN', receiveFeedbackEmail: true },
+        select: { email: true },
       })
+      const emails = recipients.map((r) => r.email).filter((e): e is string => !!e)
+
+      if (emails.length > 0) {
+        await resend.emails.send({
+          from: 'roco <onboarding@resend.dev>',
+          to: emails,
+          subject: `[roco] 새로운 의견이 도착했어요${category ? ` — ${category}` : ''}`,
+          html: [
+            `<p><strong>보낸 사람</strong>: ${session.user.name ?? '(이름 없음)'} (${session.user.email ?? '이메일 없음'})</p>`,
+            category ? `<p><strong>카테고리</strong>: ${category}</p>` : '',
+            `<p><strong>내용</strong>:</p>`,
+            `<blockquote style="border-left:3px solid #ccc;margin:0;padding:0 1em;color:#555">${content.replace(/\n/g, '<br/>')}</blockquote>`,
+          ]
+            .filter(Boolean)
+            .join('\n'),
+        })
+      }
     } catch {
       // 이메일 실패는 무시 — DB 저장이 우선
     }

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -21,6 +21,9 @@ export default async function AdminLayout({ children }: { children: React.ReactN
             <Link href="/admin/sections" className="text-sm text-text-sub hover:text-text">
               추천 섹션
             </Link>
+            <Link href="/admin/settings" className="text-sm text-text-sub hover:text-text">
+              설정
+            </Link>
           </nav>
           <Link href="/home" className="text-xs text-text-sub hover:text-text">
             ← 서비스로 돌아가기

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -19,6 +19,13 @@ export default function AdminDashboardPage() {
           <h2 className="mb-1 text-lg font-semibold text-text">추천 섹션 관리</h2>
           <p className="text-sm text-text-sub">추천 페이지 섹션 생성 및 로스터리 큐레이션</p>
         </Link>
+        <Link
+          href="/admin/settings"
+          className="rounded-xl border border-border bg-surface p-6 hover:border-primary transition-colors"
+        >
+          <h2 className="mb-1 text-lg font-semibold text-text">설정</h2>
+          <p className="text-sm text-text-sub">피드백 이메일 수신자 등 서비스 설정 관리</p>
+        </Link>
       </div>
     </div>
   )

--- a/src/app/admin/settings/_components/FeedbackEmailToggle.tsx
+++ b/src/app/admin/settings/_components/FeedbackEmailToggle.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import { useTransition } from 'react'
+import { toast } from 'sonner'
+import { toggleFeedbackEmail } from '@/actions/admin'
+
+interface FeedbackEmailToggleProps {
+  userId: string
+  enabled: boolean
+}
+
+export function FeedbackEmailToggle({ userId, enabled }: FeedbackEmailToggleProps) {
+  const [isPending, startTransition] = useTransition()
+
+  function handleToggle() {
+    startTransition(async () => {
+      const result = await toggleFeedbackEmail(userId)
+      if (!result.success) toast.error(result.error)
+    })
+  }
+
+  return (
+    <button
+      onClick={handleToggle}
+      disabled={isPending}
+      aria-label={enabled ? '수신 끄기' : '수신 켜기'}
+      className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 ${
+        enabled ? 'bg-action' : 'bg-border'
+      }`}
+    >
+      <span
+        className={`pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow-sm transition-transform ${
+          enabled ? 'translate-x-5' : 'translate-x-0'
+        }`}
+      />
+    </button>
+  )
+}

--- a/src/app/admin/settings/page.tsx
+++ b/src/app/admin/settings/page.tsx
@@ -1,0 +1,39 @@
+import { getAdminUsers } from '@/actions/admin'
+import { FeedbackEmailToggle } from './_components/FeedbackEmailToggle'
+
+export default async function AdminSettingsPage() {
+  const admins = await getAdminUsers()
+
+  return (
+    <div className="flex flex-col gap-8">
+      <h1 className="text-2xl font-bold text-text">설정</h1>
+
+      <section className="flex flex-col gap-4">
+        <div>
+          <h2 className="text-lg font-semibold text-text">피드백 이메일 수신</h2>
+          <p className="mt-1 text-sm text-text-sub">
+            의견이 접수될 때 이메일 알림을 받을 어드민을 설정합니다.
+          </p>
+        </div>
+
+        <div className="flex flex-col gap-2">
+          {admins.map((admin) => (
+            <div
+              key={admin.id}
+              className="flex items-center justify-between rounded-xl border border-border bg-surface px-4 py-3"
+            >
+              <div className="flex flex-col gap-0.5">
+                <span className="text-sm font-medium text-text">{admin.name ?? '(이름 없음)'}</span>
+                <span className="text-xs text-text-sub">{admin.email ?? '(이메일 없음)'}</span>
+              </div>
+              <FeedbackEmailToggle userId={admin.id} enabled={admin.receiveFeedbackEmail} />
+            </div>
+          ))}
+          {admins.length === 0 && (
+            <p className="text-sm text-text-sub">등록된 어드민이 없습니다.</p>
+          )}
+        </div>
+      </section>
+    </div>
+  )
+}


### PR DESCRIPTION
## 변경 사항
- `User.receiveFeedbackEmail` 필드 추가 (기본값 false)
- 피드백 제출 시 `receiveFeedbackEmail: true`인 어드민 목록을 DB에서 조회해 일괄 발송
- `FEEDBACK_RECIPIENT_EMAIL` 환경변수 방식 제거
- `toggleFeedbackEmail` / `getAdminUsers` Server Action 추가
- `/admin/settings` 페이지: 어드민별 수신 토글 UI
- 어드민 헤더 · 대시보드에 "설정" 항목 추가
- `.env.example`에 `RESEND_API_KEY` 추가

## 테스트 방법
- [ ] `/admin/settings`에서 어드민 목록 확인
- [ ] 토글 켜기 → 피드백 제출 시 해당 어드민 이메일로 수신 확인
- [ ] 토글 끄기 → 더 이상 수신되지 않음 확인