### PR TITLE
fix: 모바일 의견 남기기·다크모드 누락 및 어드민 토글 갱신 수정

### DIFF
--- a/src/actions/admin.ts
+++ b/src/actions/admin.ts
@@ -3,6 +3,7 @@
 import { auth } from '@/lib/auth'
 import { prisma } from '@/lib/prisma'
 import { redirect } from 'next/navigation'
+import { revalidatePath } from 'next/cache'
 import type { ActionResult } from '@/types/action'
 import type { PriceRange } from '@prisma/client'
 import { flattenTags } from '@/types/roastery'
@@ -576,6 +577,7 @@ export async function toggleFeedbackEmail(userId: string): Promise<ActionResult>
       where: { id: userId },
       data: { receiveFeedbackEmail: !user.receiveFeedbackEmail },
     })
+    revalidatePath('/admin/settings')
     return { success: true }
   } catch {
     return { success: false, error: '저장 중 오류가 발생했습니다', code: 'DB_ERROR' }

--- a/src/app/(main)/profile/page.tsx
+++ b/src/app/(main)/profile/page.tsx
@@ -6,6 +6,8 @@ import { getProfileSummary } from '@/lib/queries/profile'
 import { ProfileCard } from '@/components/profile/ProfileCard'
 import { ActivitySummary } from '@/components/profile/ActivitySummary'
 import { LogoutButton } from '@/components/profile/LogoutButton'
+import { ThemeToggle } from '@/components/profile/ThemeToggle'
+import { FeedbackButton } from '@/components/feedback/FeedbackButton'
 
 export default async function ProfilePage() {
   const session = await auth()
@@ -30,6 +32,16 @@ export default async function ProfilePage() {
       />
 
       <ActivitySummary ratingCount={summary.ratingCount} bookmarkCount={summary.bookmarkCount} />
+
+      <section className="flex flex-col gap-2">
+        <h2 className="text-sm font-medium text-text-secondary">테마</h2>
+        <ThemeToggle />
+      </section>
+
+      <section className="flex flex-col gap-2">
+        <h2 className="text-sm font-medium text-text-secondary">피드백</h2>
+        <FeedbackButton />
+      </section>
 
       <Link
         href="/account"

--- a/src/app/(main)/settings/page.tsx
+++ b/src/app/(main)/settings/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import { auth } from '@/lib/auth'
 import { ThemeToggle } from '@/components/profile/ThemeToggle'
+import { FeedbackButton } from '@/components/feedback/FeedbackButton'
 
 export default async function SettingsPage() {
   const session = await auth()
@@ -12,6 +13,11 @@ export default async function SettingsPage() {
       <section className="flex flex-col gap-2">
         <h2 className="text-sm font-medium text-text-secondary">테마</h2>
         <ThemeToggle />
+      </section>
+
+      <section className="flex flex-col gap-2">
+        <h2 className="text-sm font-medium text-text-secondary">피드백</h2>
+        <FeedbackButton />
       </section>
 
       {!session?.user && (

--- a/src/components/feedback/FeedbackButton.tsx
+++ b/src/components/feedback/FeedbackButton.tsx
@@ -1,48 +1,37 @@
 'use client'
 
-import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { toast } from 'sonner'
 import { useSession } from 'next-auth/react'
 import { MessageSquare } from 'lucide-react'
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
-import { FeedbackForm } from './FeedbackForm'
 
-export function FeedbackButton() {
+interface FeedbackButtonProps {
+  onOpenModal?: () => void
+}
+
+export function FeedbackButton({ onOpenModal }: FeedbackButtonProps) {
   const { data: session } = useSession()
   const router = useRouter()
-  const [modalOpen, setModalOpen] = useState(false)
 
   function handleClick() {
     if (!session?.user) {
       toast.error('로그인 후 이용할 수 있어요.')
       return
     }
-    if (window.innerWidth < 768) {
+    if (!onOpenModal || window.innerWidth < 768) {
       router.push('/feedback')
       return
     }
-    setModalOpen(true)
+    onOpenModal()
   }
 
   return (
-    <>
-      <button
-        onClick={handleClick}
-        className="flex w-full cursor-pointer items-center gap-2 px-2 py-1.5 text-sm text-text-primary transition-colors hover:bg-border rounded-md"
-      >
-        <MessageSquare className="size-4 text-text-secondary" />
-        의견 남기기
-      </button>
-
-      <Dialog open={modalOpen} onOpenChange={setModalOpen}>
-        <DialogContent className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle>의견 남기기</DialogTitle>
-          </DialogHeader>
-          <FeedbackForm onSuccess={() => setModalOpen(false)} />
-        </DialogContent>
-      </Dialog>
-    </>
+    <button
+      onClick={handleClick}
+      className="flex w-full cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm text-text-primary transition-colors hover:bg-border"
+    >
+      <MessageSquare className="size-4 text-text-secondary" />
+      의견 남기기
+    </button>
   )
 }


### PR DESCRIPTION
## 변경 사항
- 모바일 비로그인(`/settings`) 페이지에 의견 남기기 버튼 추가
- 모바일 로그인(`/profile`) 페이지에 테마 설정 및 의견 남기기 버튼 추가
- `FeedbackButton`의 `onOpenModal` prop을 optional로 변경 (없으면 `/feedback` 페이지로 이동)
- 어드민 피드백 이메일 토글 후 `revalidatePath` 누락으로 UI가 갱신되지 않던 문제 수정

## 테스트 방법
- [ ] 모바일 크기(768px 미만)에서 비로그인 상태로 `/settings` 접근 → 의견 남기기 버튼 노출 확인
- [ ] 모바일 크기에서 로그인 상태로 `/profile` 접근 → 테마 설정 및 의견 남기기 버튼 노출 확인
- [ ] `/admin/settings`에서 피드백 이메일 토글 클릭 시 즉시 상태 반영 확인