### PR TITLE
fix: 로스터리 수정 시 원두 채널 가격 소실 버그 수정

### DIFF
--- a/src/actions/admin.ts
+++ b/src/actions/admin.ts
@@ -203,29 +203,44 @@ export async function updateRoastery(
   try {
     const tagIds = await upsertTags(input.regions, input.tags)
 
-    const roastery = await prisma.roastery.update({
-      where: { id },
-      data: {
-        name: input.name.trim(),
-        description: input.description.trim() || null,
-        address: input.address.trim() || null,
-        priceRange: input.priceRange,
-        decaf: input.decaf,
-        imageUrl: input.imageUrl.trim() || null,
-        isOnboardingCandidate: input.isOnboardingCandidate,
-        tags: {
-          deleteMany: {},
-          create: tagIds.map(({ id: tagId, isPrimary }) => ({ tagId, isPrimary })),
+    const newChannels = input.channels.filter((c) => c.channelKey && c.url.trim())
+    const newChannelKeys = newChannels.map((c) => c.channelKey)
+
+    const [roastery] = await prisma.$transaction([
+      prisma.roastery.update({
+        where: { id },
+        data: {
+          name: input.name.trim(),
+          description: input.description.trim() || null,
+          address: input.address.trim() || null,
+          priceRange: input.priceRange,
+          decaf: input.decaf,
+          imageUrl: input.imageUrl.trim() || null,
+          isOnboardingCandidate: input.isOnboardingCandidate,
+          tags: {
+            deleteMany: {},
+            create: tagIds.map(({ id: tagId, isPrimary }) => ({ tagId, isPrimary })),
+          },
         },
-        channels: {
-          deleteMany: {},
-          create: input.channels
-            .filter((c) => c.channelKey && c.url.trim())
-            .map((c) => ({ channelKey: c.channelKey, url: c.url.trim() })),
-        },
-      },
-      select: { id: true },
-    })
+        select: { id: true },
+      }),
+      // 제거된 채널만 삭제 (BeanChannelPrice cascade 방지를 위해 upsert 방식 사용)
+      prisma.roasteryChannel.deleteMany({
+        where: { roasteryId: id, channelKey: { notIn: newChannelKeys } },
+      }),
+    ])
+
+    // 채널 upsert: 기존 채널은 ID 보존(→ BeanChannelPrice 유지), 신규 채널은 생성
+    await Promise.all(
+      newChannels.map((c) =>
+        prisma.roasteryChannel.upsert({
+          where: { roasteryId_channelKey: { roasteryId: id, channelKey: c.channelKey } },
+          update: { url: c.url.trim() },
+          create: { roasteryId: id, channelKey: c.channelKey, url: c.url.trim() },
+        })
+      )
+    )
+
     return { success: true, data: { id: roastery.id } }
   } catch {
     return { success: false, error: '저장 중 오류가 발생했습니다', code: 'DB_ERROR' }


### PR DESCRIPTION
## 변경 사항
- `updateRoastery`에서 채널을 `deleteMany → create` 방식으로 처리하면 `BeanChannelPrice(onDelete: Cascade)`가 연쇄 삭제되는 문제 수정
- 채널을 `upsert` 방식으로 교체: 기존 채널 ID 보존, 없어진 채널만 선택 삭제
- 이로써 로스터리 이미지 업로드 후 저장해도 원두 가격이 유지됨

## 원인 분석
1. `RoasteryChannel`과 `BeanChannelPrice`는 `onDelete: Cascade` 관계
2. `updateRoastery` 호출 시 `channels: { deleteMany: {} }` → 채널 전체 삭제 → `BeanChannelPrice` cascade 삭제
3. 이미지만 변경해도 `updateRoastery`가 호출되어 모든 원두 가격이 사라지는 버그

## 테스트 방법
- [ ] 채널 가격이 입력된 원두가 있는 로스터리 수정 페이지 진입
- [ ] 이미지만 변경 후 저장
- [ ] 원두 편집 페이지에서 가격이 그대로 유지되는지 확인
- [ ] 채널 자체를 추가/삭제 후 저장해도 나머지 채널 가격 유지 확인