### PR TITLE
fix: 모바일 필터 레이아웃 및 iOS safe area 대응

### DIFF
--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -18,7 +18,9 @@ export default async function MainLayout({ children }: { children: React.ReactNo
     <div className="flex min-h-screen flex-col bg-bg">
       <Navigation />
       {/* 모바일: BottomTab 높이(64px)만큼 하단 패딩 */}
-      <main className="flex-1 pb-16 lg:pb-0">{children}</main>
+      <main className="flex-1 pb-[calc(4rem+env(safe-area-inset-bottom,0px))] lg:pb-0">
+        {children}
+      </main>
     </div>
   )
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from 'next'
+import type { Metadata, Viewport } from 'next'
 import { Analytics } from '@vercel/analytics/next'
 import { SpeedInsights } from '@vercel/speed-insights/next'
 import { auth } from '@/lib/auth'
@@ -6,6 +6,10 @@ import { SessionProvider } from '@/components/layout/SessionProvider'
 import { ThemeProvider } from '@/components/layout/ThemeProvider'
 import { Toaster } from '@/components/ui/sonner'
 import './globals.css'
+
+export const viewport: Viewport = {
+  viewportFit: 'cover',
+}
 
 export const metadata: Metadata = {
   metadataBase: new URL('https://rocommend.com'),

--- a/src/components/layout/BottomTab.tsx
+++ b/src/components/layout/BottomTab.tsx
@@ -27,11 +27,12 @@ export function BottomTab({ className }: { className?: string }) {
   return (
     <nav
       className={cn(
-        'fixed bottom-0 left-0 right-0 z-40 h-16 border-t border-border bg-surface',
+        'fixed bottom-0 left-0 right-0 z-40 border-t border-border bg-surface',
+        'pb-[env(safe-area-inset-bottom,0px)]',
         className
       )}
     >
-      <ul className="flex h-full w-full">
+      <ul className="flex h-16 w-full">
         {tabs.map(({ href, label, Icon }) => {
           const isActive = pathname.startsWith(href)
           return (

--- a/src/components/roastery/FilterPanel.tsx
+++ b/src/components/roastery/FilterPanel.tsx
@@ -115,7 +115,7 @@ export function FilterPanel({ filter, sort, isLoggedIn }: FilterPanelProps) {
           onKeyDown={(e) => {
             if (e.key === 'Enter') navigate({ q: inputValue.trim() })
           }}
-          className="flex-1 rounded-md border border-border bg-background px-3 py-1.5 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+          className="flex-1 rounded-md border border-border bg-background px-3 py-1.5 text-[16px] leading-snug text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
           aria-label="로스터리 이름 검색"
         />
         <Sheet>
@@ -124,7 +124,10 @@ export function FilterPanel({ filter, sort, isLoggedIn }: FilterPanelProps) {
             필터
             {isFiltered && <span className="h-2 w-2 rounded-full bg-accent" aria-hidden="true" />}
           </SheetTrigger>
-          <SheetContent side="bottom" className="max-h-[80vh] overflow-y-auto">
+          <SheetContent
+            side="bottom"
+            className="max-h-[80dvh] overflow-y-auto pb-[env(safe-area-inset-bottom,0px)]"
+          >
             <SheetHeader>
               <SheetTitle>필터</SheetTitle>
             </SheetHeader>

--- a/src/components/roastery/FilterPanel.tsx
+++ b/src/components/roastery/FilterPanel.tsx
@@ -115,7 +115,7 @@ export function FilterPanel({ filter, sort, isLoggedIn }: FilterPanelProps) {
           onKeyDown={(e) => {
             if (e.key === 'Enter') navigate({ q: inputValue.trim() })
           }}
-          className="flex-1 rounded-md border border-border bg-background px-3 py-1.5 text-[16px] leading-snug text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+          className="min-w-0 flex-1 rounded-md border border-border bg-background px-3 py-1.5 text-[16px] leading-snug text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
           aria-label="로스터리 이름 검색"
         />
         <Sheet>

--- a/src/components/roastery/SortSelector.tsx
+++ b/src/components/roastery/SortSelector.tsx
@@ -32,7 +32,7 @@ export function SortSelector({ sort }: SortSelectorProps) {
       onChange={(e) => handleChange(e.target.value as SortOption)}
       disabled={isPending}
       aria-label="정렬 기준"
-      className="rounded-md border border-border bg-background px-3 py-1.5 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
+      className="rounded-md border border-border bg-background px-3 py-1.5 text-[16px] leading-snug text-foreground focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
     >
       {SORT_OPTIONS.map((opt) => (
         <option key={opt.value} value={opt.value}>

--- a/src/components/roastery/SortSelector.tsx
+++ b/src/components/roastery/SortSelector.tsx
@@ -47,7 +47,7 @@ export function SortSelector({ sort }: SortSelectorProps) {
         onClick={() => setOpen((v) => !v)}
         disabled={isPending}
         aria-label="정렬 기준"
-        className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-border bg-background px-3 py-1.5 text-sm text-foreground transition-colors hover:bg-accent/10 disabled:opacity-50"
+        className="inline-flex shrink-0 cursor-pointer items-center gap-1.5 whitespace-nowrap rounded-md border border-border bg-background px-3 py-1.5 text-sm text-foreground transition-colors hover:bg-accent/10 disabled:opacity-50"
       >
         {currentLabel}
         <ChevronDown

--- a/src/components/roastery/SortSelector.tsx
+++ b/src/components/roastery/SortSelector.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import { useTransition } from 'react'
+import { useEffect, useRef, useState, useTransition } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
+import { ChevronDown } from 'lucide-react'
 import type { SortOption } from '@/types/roastery'
 
 const SORT_OPTIONS: { value: SortOption; label: string }[] = [
@@ -17,8 +18,20 @@ export function SortSelector({ sort }: SortSelectorProps) {
   const router = useRouter()
   const searchParams = useSearchParams()
   const [isPending, startTransition] = useTransition()
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
 
-  function handleChange(value: SortOption) {
+  useEffect(() => {
+    if (!open) return
+    function handleClickOutside(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false)
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [open])
+
+  function handleSelect(value: SortOption) {
+    setOpen(false)
     const params = new URLSearchParams(searchParams.toString())
     params.set('sort', value)
     startTransition(() => {
@@ -26,19 +39,37 @@ export function SortSelector({ sort }: SortSelectorProps) {
     })
   }
 
+  const currentLabel = SORT_OPTIONS.find((o) => o.value === sort)?.label ?? '인기순'
+
   return (
-    <select
-      value={sort}
-      onChange={(e) => handleChange(e.target.value as SortOption)}
-      disabled={isPending}
-      aria-label="정렬 기준"
-      className="rounded-md border border-border bg-background px-3 py-1.5 text-[16px] leading-snug text-foreground focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
-    >
-      {SORT_OPTIONS.map((opt) => (
-        <option key={opt.value} value={opt.value}>
-          {opt.label}
-        </option>
-      ))}
-    </select>
+    <div ref={ref} className="relative">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        disabled={isPending}
+        aria-label="정렬 기준"
+        className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-border bg-background px-3 py-1.5 text-sm text-foreground transition-colors hover:bg-accent/10 disabled:opacity-50"
+      >
+        {currentLabel}
+        <ChevronDown
+          className={`h-3.5 w-3.5 transition-transform duration-150 ${open ? 'rotate-180' : ''}`}
+        />
+      </button>
+
+      {open && (
+        <div className="absolute right-0 top-full z-50 mt-1 min-w-[7rem] rounded-xl border border-border bg-background py-1 shadow-lg">
+          {SORT_OPTIONS.map((opt) => (
+            <button
+              key={opt.value}
+              onClick={() => handleSelect(opt.value)}
+              className={`w-full cursor-pointer px-4 py-2 text-left text-sm transition-colors hover:bg-accent/10 ${
+                opt.value === sort ? 'font-medium text-foreground' : 'text-muted-foreground'
+              }`}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
   )
 }


### PR DESCRIPTION
## 변경 사항
- `viewport-fit=cover` 추가 — iPhone safe area CSS 변수(`env(safe-area-inset-bottom)`) 활성화
- `BottomTab`: 하단 safe area 패딩 추가 — 홈 인디케이터 영역 배경색 일관성 유지
- `main` layout: 하단 패딩을 `calc(4rem + env(safe-area-inset-bottom))` 으로 업데이트
- `FilterPanel` 검색 input: `font-size: 16px` 적용 — iOS Safari 오토줌 방지 (16px 미만 시 자동 확대 트리거)
- `FilterPanel` SheetContent: `max-h-[80dvh]`로 변경(dvh = dynamic viewport height), 하단 safe area 패딩 추가

## 테스트 방법
- [ ] iPhone Safari에서 `/roasteries` 접속 후 검색 input 탭 → 페이지 확대 없이 정상 포커스 확인
- [ ] 필터 버튼 탭 → bottom sheet 배경이 홈 인디케이터 영역까지 이어지는지 확인
- [ ] bottom tab bar 하단이 홈 인디케이터와 겹치지 않는지 확인