### PR TITLE
fix: 프로덕션 배포 실패 해결 — stub 마이그레이션 멱등성 추가

### DIFF
--- a/prisma/migrations/20260413141427_add_bean_price_snapshot/migration.sql
+++ b/prisma/migrations/20260413141427_add_bean_price_snapshot/migration.sql
@@ -1,5 +1,5 @@
--- CreateTable
-CREATE TABLE "BeanChannelPriceSnapshot" (
+-- CreateTable (idempotent)
+CREATE TABLE IF NOT EXISTS "BeanChannelPriceSnapshot" (
     "id" TEXT NOT NULL,
     "beanId" TEXT NOT NULL,
     "channelId" TEXT NOT NULL,
@@ -8,11 +8,22 @@ CREATE TABLE "BeanChannelPriceSnapshot" (
     CONSTRAINT "BeanChannelPriceSnapshot_pkey" PRIMARY KEY ("id")
 );
 
--- CreateIndex
-CREATE INDEX "BeanChannelPriceSnapshot_beanId_channelId_idx" ON "BeanChannelPriceSnapshot"("beanId", "channelId");
+-- CreateIndex (idempotent)
+CREATE INDEX IF NOT EXISTS "BeanChannelPriceSnapshot_beanId_channelId_idx" ON "BeanChannelPriceSnapshot"("beanId", "channelId");
 
--- CreateIndex
-CREATE INDEX "BeanChannelPriceSnapshot_snappedAt_idx" ON "BeanChannelPriceSnapshot"("snappedAt");
+-- CreateIndex (idempotent)
+CREATE INDEX IF NOT EXISTS "BeanChannelPriceSnapshot_snappedAt_idx" ON "BeanChannelPriceSnapshot"("snappedAt");
 
--- AddForeignKey
-ALTER TABLE "BeanChannelPriceSnapshot" ADD CONSTRAINT "BeanChannelPriceSnapshot_beanId_channelId_fkey" FOREIGN KEY ("beanId", "channelId") REFERENCES "BeanChannelPrice"("beanId", "channelId") ON DELETE CASCADE ON UPDATE CASCADE;
+-- AddForeignKey (idempotent)
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE constraint_name = 'BeanChannelPriceSnapshot_beanId_channelId_fkey'
+  ) THEN
+    ALTER TABLE "BeanChannelPriceSnapshot"
+      ADD CONSTRAINT "BeanChannelPriceSnapshot_beanId_channelId_fkey"
+      FOREIGN KEY ("beanId", "channelId")
+      REFERENCES "BeanChannelPrice"("beanId", "channelId")
+      ON DELETE CASCADE ON UPDATE CASCADE;
+  END IF;
+END $$;

--- a/prisma/migrations/20260414113846_add_size_grams_to_bean_channel_price/migration.sql
+++ b/prisma/migrations/20260414113846_add_size_grams_to_bean_channel_price/migration.sql
@@ -1,3 +1,3 @@
--- AlterTable
-ALTER TABLE "BeanChannelPrice" ADD COLUMN "sizeGrams" INTEGER;
-ALTER TABLE "BeanChannelPrice" ADD COLUMN "sourceUrl" TEXT;
+-- AlterTable (idempotent)
+ALTER TABLE "BeanChannelPrice" ADD COLUMN IF NOT EXISTS "sizeGrams" INTEGER;
+ALTER TABLE "BeanChannelPrice" ADD COLUMN IF NOT EXISTS "sourceUrl" TEXT;


### PR DESCRIPTION
## 변경 사항
- `20260413141427_add_bean_price_snapshot`: `CREATE TABLE IF NOT EXISTS`, `CREATE INDEX IF NOT EXISTS`, FK는 DO $$ IF NOT EXISTS 패턴으로 변경
- `20260414113846_add_size_grams_to_bean_channel_price`: `ADD COLUMN IF NOT EXISTS`으로 변경

## 원인
Supabase 프로덕션 DB에 이미 해당 컬럼/테이블이 존재한 상태에서 `prisma migrate deploy`가 stub 마이그레이션을 적용하려다 `P3018 (42701 column already exists)` 에러 발생.

## 테스트 방법
- [ ] Vercel 재배포 후 `prisma migrate deploy` 성공 확인