### PR TITLE
fix: 로스터리 상세 페이지 이미지 배너 → 프로필 사진으로 변경

### DIFF
--- a/src/components/roastery/RoasteryDetail.tsx
+++ b/src/components/roastery/RoasteryDetail.tsx
@@ -28,45 +28,46 @@ export function RoasteryDetail({
     <div className="flex flex-col gap-8">
       <BackButton />
 
-      {/* 헤더 이미지 */}
-      {roastery.imageUrl && (
-        <div className="relative aspect-[16/7] w-full overflow-hidden rounded-2xl">
-          <Image
-            src={roastery.imageUrl}
-            alt={roastery.name}
-            fill
-            className="object-cover"
-            priority
-            sizes="(max-width: 768px) 100vw, (max-width: 1440px) 90vw, 1300px"
-            unoptimized={roastery.imageUrl.startsWith('/')}
-          />
-        </div>
-      )}
-
       {/* 기본 정보 */}
       <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-        <div className="flex flex-col gap-2">
-          <h1 className="text-2xl font-semibold">{roastery.name}</h1>
-          <div className="flex flex-col gap-0.5">
-            {regions.length > 0 && <p className="text-sm text-muted-foreground">{regions[0]}</p>}
-            {roastery.address && (
-              <p className="text-xs text-muted-foreground/70">{roastery.address}</p>
-            )}
-          </div>
-          {roastery.description && (
-            <p className="text-sm text-foreground leading-relaxed max-w-prose">
-              {roastery.description}
-            </p>
-          )}
-          {charTags.length > 0 && (
-            <div className="flex flex-wrap gap-1.5 pt-1">
-              {charTags.map((tag) => (
-                <Badge key={tag} variant="secondary" className="text-xs">
-                  {tag}
-                </Badge>
-              ))}
+        <div className="flex gap-4">
+          {/* 프로필 이미지 */}
+          {roastery.imageUrl && (
+            <div className="relative size-20 shrink-0 overflow-hidden rounded-xl">
+              <Image
+                src={roastery.imageUrl}
+                alt={roastery.name}
+                fill
+                className="object-cover"
+                priority
+                sizes="80px"
+                unoptimized={roastery.imageUrl.startsWith('/')}
+              />
             </div>
           )}
+          <div className="flex flex-col gap-2">
+            <h1 className="text-2xl font-semibold">{roastery.name}</h1>
+            <div className="flex flex-col gap-0.5">
+              {regions.length > 0 && <p className="text-sm text-muted-foreground">{regions[0]}</p>}
+              {roastery.address && (
+                <p className="text-xs text-muted-foreground/70">{roastery.address}</p>
+              )}
+            </div>
+            {roastery.description && (
+              <p className="text-sm text-foreground leading-relaxed max-w-prose">
+                {roastery.description}
+              </p>
+            )}
+            {charTags.length > 0 && (
+              <div className="flex flex-wrap gap-1.5 pt-1">
+                {charTags.map((tag) => (
+                  <Badge key={tag} variant="secondary" className="text-xs">
+                    {tag}
+                  </Badge>
+                ))}
+              </div>
+            )}
+          </div>
         </div>
 
         <div className="flex flex-col gap-3 shrink-0">


### PR DESCRIPTION
## 변경 사항
- 전체 너비 `aspect-[16/7]` 배너 이미지 제거 (저해상도 이미지 깨짐 문제 해결)
- 기본 정보 섹션 왼쪽에 `size-20`(80px) 고정 크기 프로필 사진 배치
- `rounded-xl`, `object-cover` 유지
- 이미지 없는 경우 조건부 렌더링 유지

## 테스트 방법
- [ ] 이미지가 있는 로스터리 상세 페이지 접속 → 이름 왼쪽에 80px 프로필 사진 표시 확인
- [ ] 이미지가 없는 로스터리 상세 페이지 접속 → 이미지 영역 없이 정상 표시 확인
- [ ] 모바일/데스크탑 레이아웃 이상 없음 확인