### PR TITLE
release: v0.6.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rocommend-init",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/components/roastery/BeanList.tsx
+++ b/src/components/roastery/BeanList.tsx
@@ -1,83 +1,153 @@
+'use client'
+
+import { useState } from 'react'
 import { Badge } from '@/components/ui/badge'
-import { ROASTING_LEVEL_LABELS } from '@/types/roastery'
+import { ROASTING_LEVEL_LABELS, sortChannels } from '@/types/roastery'
 import type { BeanWithDetails } from '@/types/roastery'
+import { logClientEvent } from '@/actions/events'
 import Image from 'next/image'
 
 interface BeanListProps {
   beans: BeanWithDetails[]
-  selectedBeanId?: string | null
-  onBeanSelect?: (id: string) => void
+  roasteryId: string
 }
 
-export function BeanList({ beans, selectedBeanId, onBeanSelect }: BeanListProps) {
+function formatPrice(price: number): string {
+  return price.toLocaleString('ko-KR') + '원'
+}
+
+function BeanCard({ bean, roasteryId }: { bean: BeanWithDetails; roasteryId: string }) {
+  const [channelsOpen, setChannelsOpen] = useState(false)
+
+  const sortedChannels = sortChannels(bean.channelPrices)
+  const [primary, ...rest] = sortedChannels
+  const hasPurchase = sortedChannels.length > 0
+
+  function handlePurchaseClick(channelKey: string) {
+    logClientEvent({
+      event: 'purchase_link_clicked',
+      payload: { roasteryId, channelKey, beanId: bean.id },
+    })
+  }
+
+  return (
+    <li className="flex flex-col gap-3 rounded-xl border border-border p-4">
+      <div className="flex gap-4">
+        {bean.imageUrl && (
+          <div className="relative size-16 shrink-0 overflow-hidden rounded-lg">
+            <Image
+              src={bean.imageUrl}
+              alt={bean.name}
+              fill
+              className="object-cover"
+              sizes="64px"
+              unoptimized={bean.imageUrl.startsWith('/')}
+            />
+          </div>
+        )}
+        <div className="flex flex-col gap-1.5 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="font-medium text-sm">{bean.name}</span>
+            {bean.decaf && (
+              <Badge variant="secondary" className="text-xs">
+                디카페인
+              </Badge>
+            )}
+          </div>
+          <div className="flex items-center gap-1.5 flex-wrap">
+            <span className="text-xs text-muted-foreground">
+              {ROASTING_LEVEL_LABELS[bean.roastingLevel] ?? bean.roastingLevel}
+            </span>
+            {bean.origins.length > 0 && (
+              <>
+                <span className="text-muted-foreground/50">·</span>
+                <span className="text-xs text-muted-foreground">{bean.origins.join(', ')}</span>
+              </>
+            )}
+          </div>
+          {bean.cupNotes.length > 0 && (
+            <div className="flex gap-1 flex-wrap">
+              {bean.cupNotes.map((note) => (
+                <Badge key={note} variant="outline" className="text-xs h-4 px-1.5">
+                  {note}
+                </Badge>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {hasPurchase && (
+        <div className="flex flex-col gap-1">
+          <a
+            href={primary.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={() => handlePurchaseClick(primary.channelKey)}
+            className="flex items-center justify-between gap-3 rounded-lg bg-primary px-4 py-3 text-primary-foreground transition-opacity hover:opacity-90 min-h-[44px]"
+          >
+            <div className="flex items-center gap-2">
+              <span className="text-sm font-medium">{primary.label}</span>
+              {primary.price !== null && (
+                <span className="text-xs opacity-80">{formatPrice(primary.price)}</span>
+              )}
+            </div>
+            <span className="text-sm font-medium">구매하기 →</span>
+          </a>
+
+          {rest.length > 0 && (
+            <div className="flex flex-col gap-1">
+              <button
+                type="button"
+                onClick={() => setChannelsOpen((v) => !v)}
+                className="flex items-center gap-1 px-1 py-0.5 text-xs text-muted-foreground hover:text-foreground transition-colors w-fit cursor-pointer"
+              >
+                <span>{channelsOpen ? '▲' : '▼'}</span>
+                <span>다른 채널 {channelsOpen ? '닫기' : '보기'}</span>
+              </button>
+
+              {channelsOpen && (
+                <ul className="flex flex-col gap-1 pt-1">
+                  {rest.map((ch) => (
+                    <li key={ch.channelId}>
+                      <a
+                        href={ch.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        onClick={() => handlePurchaseClick(ch.channelKey)}
+                        className="flex items-center justify-between rounded-lg px-3 py-2 text-sm hover:bg-muted transition-colors"
+                      >
+                        <span className="text-foreground">{ch.label}</span>
+                        {ch.price !== null ? (
+                          <span className="text-muted-foreground text-xs">
+                            {formatPrice(ch.price)}
+                          </span>
+                        ) : (
+                          <span className="text-muted-foreground text-xs">→</span>
+                        )}
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </li>
+  )
+}
+
+export function BeanList({ beans, roasteryId }: BeanListProps) {
   if (beans.length === 0) {
     return <p className="text-sm text-muted-foreground">등록된 원두가 없습니다.</p>
   }
 
   return (
     <ul className="flex flex-col gap-4">
-      {beans.map((bean) => {
-        const isSelected = selectedBeanId === bean.id
-        const isClickable = !!onBeanSelect
-
-        return (
-          <li
-            key={bean.id}
-            onClick={() => onBeanSelect?.(bean.id)}
-            className={[
-              'flex gap-4 rounded-xl border p-4 transition-colors',
-              isClickable ? 'cursor-pointer' : '',
-              isSelected ? 'border-primary bg-primary/5' : 'border-border',
-              isClickable && !isSelected ? 'hover:border-border/70 hover:bg-muted/30' : '',
-            ]
-              .filter(Boolean)
-              .join(' ')}
-          >
-            {bean.imageUrl && (
-              <div className="relative size-16 shrink-0 overflow-hidden rounded-lg">
-                <Image
-                  src={bean.imageUrl}
-                  alt={bean.name}
-                  fill
-                  className="object-cover"
-                  sizes="64px"
-                  unoptimized={bean.imageUrl.startsWith('/')}
-                />
-              </div>
-            )}
-            <div className="flex flex-col gap-1.5 min-w-0">
-              <div className="flex items-center gap-2 flex-wrap">
-                <span className="font-medium text-sm">{bean.name}</span>
-                {bean.decaf && (
-                  <Badge variant="secondary" className="text-xs">
-                    디카페인
-                  </Badge>
-                )}
-              </div>
-              <div className="flex items-center gap-1.5 flex-wrap">
-                <span className="text-xs text-muted-foreground">
-                  {ROASTING_LEVEL_LABELS[bean.roastingLevel] ?? bean.roastingLevel}
-                </span>
-                {bean.origins.length > 0 && (
-                  <>
-                    <span className="text-muted-foreground/50">·</span>
-                    <span className="text-xs text-muted-foreground">{bean.origins.join(', ')}</span>
-                  </>
-                )}
-              </div>
-              {bean.cupNotes.length > 0 && (
-                <div className="flex gap-1 flex-wrap">
-                  {bean.cupNotes.map((note) => (
-                    <Badge key={note} variant="outline" className="text-xs h-4 px-1.5">
-                      {note}
-                    </Badge>
-                  ))}
-                </div>
-              )}
-            </div>
-          </li>
-        )
-      })}
+      {beans.map((bean) => (
+        <BeanCard key={bean.id} bean={bean} roasteryId={roasteryId} />
+      ))}
     </ul>
   )
 }

--- a/src/components/roastery/RoasteryBuyAndBeans.tsx
+++ b/src/components/roastery/RoasteryBuyAndBeans.tsx
@@ -1,6 +1,3 @@
-'use client'
-
-import { useState } from 'react'
 import { Separator } from '@/components/ui/separator'
 import { PurchaseSection } from './PurchaseSection'
 import { BeanList } from './BeanList'
@@ -13,29 +10,17 @@ interface RoasteryBuyAndBeansProps {
 }
 
 export function RoasteryBuyAndBeans({ roasteryId, baseChannels, beans }: RoasteryBuyAndBeansProps) {
-  const [selectedBeanId, setSelectedBeanId] = useState<string | null>(beans[0]?.id ?? null)
-
-  const selectedBean = beans.find((b) => b.id === selectedBeanId)
-  const channels: ChannelWithPrice[] =
-    selectedBean && selectedBean.channelPrices.length > 0
-      ? selectedBean.channelPrices
-      : baseChannels
-
-  const hasPurchase = channels.length > 0
-
   return (
     <>
-      {hasPurchase && <PurchaseSection roasteryId={roasteryId} channels={channels} />}
+      {baseChannels.length > 0 && (
+        <PurchaseSection roasteryId={roasteryId} channels={baseChannels} />
+      )}
 
       <Separator />
 
       <section className="flex flex-col gap-4">
         <h2 className="text-lg font-medium">원두 라인업 ({beans.length})</h2>
-        <BeanList
-          beans={beans}
-          selectedBeanId={hasPurchase ? selectedBeanId : undefined}
-          onBeanSelect={hasPurchase ? setSelectedBeanId : undefined}
-        />
+        <BeanList beans={beans} roasteryId={roasteryId} />
       </section>
     </>
   )

--- a/src/components/roastery/RoasteryDetail.tsx
+++ b/src/components/roastery/RoasteryDetail.tsx
@@ -28,45 +28,46 @@ export function RoasteryDetail({
     <div className="flex flex-col gap-8">
       <BackButton />
 
-      {/* 헤더 이미지 */}
-      {roastery.imageUrl && (
-        <div className="relative aspect-[16/7] w-full overflow-hidden rounded-2xl">
-          <Image
-            src={roastery.imageUrl}
-            alt={roastery.name}
-            fill
-            className="object-cover"
-            priority
-            sizes="(max-width: 768px) 100vw, (max-width: 1440px) 90vw, 1300px"
-            unoptimized={roastery.imageUrl.startsWith('/')}
-          />
-        </div>
-      )}
-
       {/* 기본 정보 */}
       <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-        <div className="flex flex-col gap-2">
-          <h1 className="text-2xl font-semibold">{roastery.name}</h1>
-          <div className="flex flex-col gap-0.5">
-            {regions.length > 0 && <p className="text-sm text-muted-foreground">{regions[0]}</p>}
-            {roastery.address && (
-              <p className="text-xs text-muted-foreground/70">{roastery.address}</p>
-            )}
-          </div>
-          {roastery.description && (
-            <p className="text-sm text-foreground leading-relaxed max-w-prose">
-              {roastery.description}
-            </p>
-          )}
-          {charTags.length > 0 && (
-            <div className="flex flex-wrap gap-1.5 pt-1">
-              {charTags.map((tag) => (
-                <Badge key={tag} variant="secondary" className="text-xs">
-                  {tag}
-                </Badge>
-              ))}
+        <div className="flex gap-4">
+          {/* 프로필 이미지 */}
+          {roastery.imageUrl && (
+            <div className="relative size-20 shrink-0 overflow-hidden rounded-xl">
+              <Image
+                src={roastery.imageUrl}
+                alt={roastery.name}
+                fill
+                className="object-cover"
+                priority
+                sizes="80px"
+                unoptimized={roastery.imageUrl.startsWith('/')}
+              />
             </div>
           )}
+          <div className="flex flex-col gap-2">
+            <h1 className="text-2xl font-semibold">{roastery.name}</h1>
+            <div className="flex flex-col gap-0.5">
+              {regions.length > 0 && <p className="text-sm text-muted-foreground">{regions[0]}</p>}
+              {roastery.address && (
+                <p className="text-xs text-muted-foreground/70">{roastery.address}</p>
+              )}
+            </div>
+            {roastery.description && (
+              <p className="text-sm text-foreground leading-relaxed max-w-prose">
+                {roastery.description}
+              </p>
+            )}
+            {charTags.length > 0 && (
+              <div className="flex flex-wrap gap-1.5 pt-1">
+                {charTags.map((tag) => (
+                  <Badge key={tag} variant="secondary" className="text-xs">
+                    {tag}
+                  </Badge>
+                ))}
+              </div>
+            )}
+          </div>
         </div>
 
         <div className="flex flex-col gap-3 shrink-0">


### PR DESCRIPTION
## 변경 사항
- feat: 원두 카드 인라인 구매 CTA 추가 (#70)
  - 원두별 channelPrices 기반 구매 버튼을 카드 하단에 직접 표시
  - 채널 2개 이상 시 '다른 채널 보기' 토글 지원
  - 상단 PurchaseSection은 로스터리 기본 채널(스토어 방문)로 단순화