### PR TITLE
fix: 로스터리 상세 구매 채널 섹션 UI 개편

### DIFF
--- a/src/components/roastery/PurchaseSection.tsx
+++ b/src/components/roastery/PurchaseSection.tsx
@@ -52,13 +52,15 @@ export function PurchaseSection({ roasteryId, channels }: PurchaseSectionProps) 
 
   return (
     <div className="flex flex-col rounded-xl border border-border bg-surface overflow-hidden">
-      {/* 트리거 */}
-      <button
-        type="button"
-        onClick={() => setOpen((v) => !v)}
-        className="flex min-h-[44px] w-full cursor-pointer items-center justify-between px-4 transition-colors hover:bg-muted"
-      >
-        <div className="flex items-center gap-2">
+      {/* 트리거: 왼쪽은 primary 링크, 오른쪽은 토글 */}
+      <div className="flex min-h-[44px] items-stretch">
+        <a
+          href={primary.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={() => handleClick(primary.channelKey)}
+          className="flex flex-1 items-center gap-2 px-4 transition-colors hover:bg-muted"
+        >
           <span className="text-sm font-medium">{primary.label}</span>
           <span className="rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
             최저가
@@ -66,16 +68,23 @@ export function PurchaseSection({ roasteryId, channels }: PurchaseSectionProps) 
           {primary.price !== null && (
             <span className="text-sm font-medium">{formatPrice(primary.price)}</span>
           )}
-        </div>
-        <ChevronDown
-          className={`size-4 shrink-0 text-muted-foreground transition-transform duration-200 ${open ? 'rotate-180' : ''}`}
-        />
-      </button>
+        </a>
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          className="flex items-center justify-center border-l border-border px-3 transition-colors hover:bg-muted"
+          aria-label={open ? '채널 목록 닫기' : '다른 채널 보기'}
+        >
+          <ChevronDown
+            className={`size-4 text-muted-foreground transition-transform duration-200 ${open ? 'rotate-180' : ''}`}
+          />
+        </button>
+      </div>
 
-      {/* 확장 목록 */}
+      {/* 확장 목록: primary 제외한 나머지만 */}
       {open && (
         <ul className="flex flex-col border-t border-border px-1 pb-1">
-          {sorted.map((ch, i) => (
+          {rest.map((ch) => (
             <li key={ch.channelId}>
               <a
                 href={ch.url}
@@ -87,23 +96,10 @@ export function PurchaseSection({ roasteryId, channels }: PurchaseSectionProps) 
                 }}
                 className="flex min-h-[44px] cursor-pointer items-center justify-between rounded-lg px-3 py-2 transition-colors hover:bg-muted"
               >
-                <div className="flex items-center gap-2">
-                  <span className="text-sm">{ch.label}</span>
-                  {i === 0 && (
-                    <span className="rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
-                      최저가
-                    </span>
-                  )}
-                </div>
-                <div className="flex items-center gap-1 text-sm">
-                  {ch.price !== null ? (
-                    <span className={i === 0 ? 'font-medium' : 'text-muted-foreground'}>
-                      {formatPrice(ch.price)}
-                    </span>
-                  ) : (
-                    <span className="text-muted-foreground text-xs">→</span>
-                  )}
-                </div>
+                <span className="text-sm">{ch.label}</span>
+                <span className="text-muted-foreground text-sm">
+                  {ch.price !== null ? formatPrice(ch.price) : '→'}
+                </span>
               </a>
             </li>
           ))}

--- a/src/components/roastery/PurchaseSection.tsx
+++ b/src/components/roastery/PurchaseSection.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import { useState } from 'react'
+import { ChevronDown } from 'lucide-react'
 import { logClientEvent } from '@/actions/events'
 import type { ChannelWithPrice } from '@/types/roastery'
 import { sortChannels } from '@/types/roastery'
@@ -14,41 +16,101 @@ function formatPrice(price: number): string {
 }
 
 export function PurchaseSection({ roasteryId, channels }: PurchaseSectionProps) {
+  const [open, setOpen] = useState(false)
+
   if (channels.length === 0) return null
 
   const sorted = sortChannels(channels)
+  const [primary, ...rest] = sorted
 
   function handleClick(channelKey: string) {
     logClientEvent({ event: 'purchase_link_clicked', payload: { roasteryId, channelKey } })
   }
 
+  // 채널이 1개면 드롭다운 없이 바로 링크
+  if (rest.length === 0) {
+    return (
+      <a
+        href={primary.url}
+        target="_blank"
+        rel="noopener noreferrer"
+        onClick={() => handleClick(primary.channelKey)}
+        className="flex min-h-[44px] cursor-pointer items-center justify-between rounded-xl border border-border bg-surface px-4 transition-colors hover:bg-muted"
+      >
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium">{primary.label}</span>
+          <span className="rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
+            최저가
+          </span>
+        </div>
+        {primary.price !== null && (
+          <span className="text-sm font-medium">{formatPrice(primary.price)}</span>
+        )}
+      </a>
+    )
+  }
+
   return (
-    <div className="flex flex-col gap-2 rounded-xl border border-border bg-surface p-2">
-      <ul className="flex flex-col gap-1">
-        {sorted.map((ch, i) => (
-          <li key={ch.channelId}>
-            <a
-              href={ch.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              onClick={() => handleClick(ch.channelKey)}
-              className="flex min-h-[44px] cursor-pointer items-center justify-between rounded-lg px-3 py-2 transition-colors hover:bg-muted"
-            >
-              <span className={`text-sm ${i === 0 ? 'font-medium' : 'text-foreground'}`}>
-                {ch.label}
-              </span>
-              <div className="flex items-center gap-2 text-sm">
-                {ch.price !== null && (
-                  <span className={i === 0 ? 'font-medium' : 'text-muted-foreground text-xs'}>
-                    {formatPrice(ch.price)}
-                  </span>
-                )}
-                <span className="text-muted-foreground text-xs">→</span>
-              </div>
-            </a>
-          </li>
-        ))}
-      </ul>
+    <div className="relative">
+      {/* 드롭다운 트리거 */}
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex min-h-[44px] w-full cursor-pointer items-center justify-between rounded-xl border border-border bg-surface px-4 transition-colors hover:bg-muted"
+      >
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium">{primary.label}</span>
+          <span className="rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
+            최저가
+          </span>
+          {primary.price !== null && (
+            <span className="text-sm font-medium">{formatPrice(primary.price)}</span>
+          )}
+        </div>
+        <ChevronDown
+          className={`size-4 shrink-0 text-muted-foreground transition-transform duration-200 ${open ? 'rotate-180' : ''}`}
+        />
+      </button>
+
+      {/* 드롭다운 목록 */}
+      {open && (
+        <div className="absolute left-0 right-0 top-[calc(100%+4px)] z-10 rounded-xl border border-border bg-surface shadow-md">
+          <ul className="flex flex-col p-1">
+            {sorted.map((ch, i) => (
+              <li key={ch.channelId}>
+                <a
+                  href={ch.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  onClick={() => {
+                    handleClick(ch.channelKey)
+                    setOpen(false)
+                  }}
+                  className="flex min-h-[44px] cursor-pointer items-center justify-between rounded-lg px-3 py-2 transition-colors hover:bg-muted"
+                >
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm">{ch.label}</span>
+                    {i === 0 && (
+                      <span className="rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
+                        최저가
+                      </span>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-1 text-sm">
+                    {ch.price !== null ? (
+                      <span className={i === 0 ? 'font-medium' : 'text-muted-foreground'}>
+                        {formatPrice(ch.price)}
+                      </span>
+                    ) : (
+                      <span className="text-muted-foreground text-xs">→</span>
+                    )}
+                  </div>
+                </a>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/components/roastery/PurchaseSection.tsx
+++ b/src/components/roastery/PurchaseSection.tsx
@@ -51,12 +51,12 @@ export function PurchaseSection({ roasteryId, channels }: PurchaseSectionProps) 
   }
 
   return (
-    <div className="relative">
-      {/* 드롭다운 트리거 */}
+    <div className="flex flex-col rounded-xl border border-border bg-surface overflow-hidden">
+      {/* 트리거 */}
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
-        className="flex min-h-[44px] w-full cursor-pointer items-center justify-between rounded-xl border border-border bg-surface px-4 transition-colors hover:bg-muted"
+        className="flex min-h-[44px] w-full cursor-pointer items-center justify-between px-4 transition-colors hover:bg-muted"
       >
         <div className="flex items-center gap-2">
           <span className="text-sm font-medium">{primary.label}</span>
@@ -72,44 +72,42 @@ export function PurchaseSection({ roasteryId, channels }: PurchaseSectionProps) 
         />
       </button>
 
-      {/* 드롭다운 목록 */}
+      {/* 확장 목록 */}
       {open && (
-        <div className="absolute left-0 right-0 top-[calc(100%+4px)] z-10 rounded-xl border border-border bg-surface shadow-md">
-          <ul className="flex flex-col p-1">
-            {sorted.map((ch, i) => (
-              <li key={ch.channelId}>
-                <a
-                  href={ch.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  onClick={() => {
-                    handleClick(ch.channelKey)
-                    setOpen(false)
-                  }}
-                  className="flex min-h-[44px] cursor-pointer items-center justify-between rounded-lg px-3 py-2 transition-colors hover:bg-muted"
-                >
-                  <div className="flex items-center gap-2">
-                    <span className="text-sm">{ch.label}</span>
-                    {i === 0 && (
-                      <span className="rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
-                        최저가
-                      </span>
-                    )}
-                  </div>
-                  <div className="flex items-center gap-1 text-sm">
-                    {ch.price !== null ? (
-                      <span className={i === 0 ? 'font-medium' : 'text-muted-foreground'}>
-                        {formatPrice(ch.price)}
-                      </span>
-                    ) : (
-                      <span className="text-muted-foreground text-xs">→</span>
-                    )}
-                  </div>
-                </a>
-              </li>
-            ))}
-          </ul>
-        </div>
+        <ul className="flex flex-col border-t border-border px-1 pb-1">
+          {sorted.map((ch, i) => (
+            <li key={ch.channelId}>
+              <a
+                href={ch.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={() => {
+                  handleClick(ch.channelKey)
+                  setOpen(false)
+                }}
+                className="flex min-h-[44px] cursor-pointer items-center justify-between rounded-lg px-3 py-2 transition-colors hover:bg-muted"
+              >
+                <div className="flex items-center gap-2">
+                  <span className="text-sm">{ch.label}</span>
+                  {i === 0 && (
+                    <span className="rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
+                      최저가
+                    </span>
+                  )}
+                </div>
+                <div className="flex items-center gap-1 text-sm">
+                  {ch.price !== null ? (
+                    <span className={i === 0 ? 'font-medium' : 'text-muted-foreground'}>
+                      {formatPrice(ch.price)}
+                    </span>
+                  ) : (
+                    <span className="text-muted-foreground text-xs">→</span>
+                  )}
+                </div>
+              </a>
+            </li>
+          ))}
+        </ul>
       )}
     </div>
   )

--- a/src/components/roastery/PurchaseSection.tsx
+++ b/src/components/roastery/PurchaseSection.tsx
@@ -23,7 +23,7 @@ export function PurchaseSection({ roasteryId, channels }: PurchaseSectionProps) 
   }
 
   return (
-    <div className="flex flex-col rounded-xl border border-border bg-surface overflow-hidden">
+    <div className="flex flex-col rounded-xl border border-border overflow-hidden">
       <ul className="flex flex-col">
         {sorted.map((ch, i) => (
           <li key={ch.channelId} className={i > 0 ? 'border-t border-border' : ''}>

--- a/src/components/roastery/PurchaseSection.tsx
+++ b/src/components/roastery/PurchaseSection.tsx
@@ -1,7 +1,5 @@
 'use client'
 
-import { useState } from 'react'
-import { ChevronDown } from 'lucide-react'
 import { logClientEvent } from '@/actions/events'
 import type { ChannelWithPrice } from '@/types/roastery'
 import { sortChannels } from '@/types/roastery'
@@ -16,95 +14,41 @@ function formatPrice(price: number): string {
 }
 
 export function PurchaseSection({ roasteryId, channels }: PurchaseSectionProps) {
-  const [open, setOpen] = useState(false)
-
   if (channels.length === 0) return null
 
   const sorted = sortChannels(channels)
-  const [primary, ...rest] = sorted
 
   function handleClick(channelKey: string) {
     logClientEvent({ event: 'purchase_link_clicked', payload: { roasteryId, channelKey } })
   }
 
-  // 채널이 1개면 드롭다운 없이 바로 링크
-  if (rest.length === 0) {
-    return (
-      <a
-        href={primary.url}
-        target="_blank"
-        rel="noopener noreferrer"
-        onClick={() => handleClick(primary.channelKey)}
-        className="flex min-h-[44px] cursor-pointer items-center justify-between rounded-xl border border-border bg-surface px-4 transition-colors hover:bg-muted"
-      >
-        <div className="flex items-center gap-2">
-          <span className="text-sm font-medium">{primary.label}</span>
-          <span className="rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
-            최저가
-          </span>
-        </div>
-        {primary.price !== null && (
-          <span className="text-sm font-medium">{formatPrice(primary.price)}</span>
-        )}
-      </a>
-    )
-  }
-
   return (
     <div className="flex flex-col rounded-xl border border-border bg-surface overflow-hidden">
-      {/* 트리거: 왼쪽은 primary 링크, 오른쪽은 토글 */}
-      <div className="flex min-h-[44px] items-stretch">
-        <a
-          href={primary.url}
-          target="_blank"
-          rel="noopener noreferrer"
-          onClick={() => handleClick(primary.channelKey)}
-          className="flex flex-1 items-center gap-2 px-4 transition-colors hover:bg-muted"
-        >
-          <span className="text-sm font-medium">{primary.label}</span>
-          <span className="rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
-            최저가
-          </span>
-          {primary.price !== null && (
-            <span className="text-sm font-medium">{formatPrice(primary.price)}</span>
-          )}
-        </a>
-        <button
-          type="button"
-          onClick={() => setOpen((v) => !v)}
-          className="flex items-center justify-center border-l border-border px-3 transition-colors hover:bg-muted"
-          aria-label={open ? '채널 목록 닫기' : '다른 채널 보기'}
-        >
-          <ChevronDown
-            className={`size-4 text-muted-foreground transition-transform duration-200 ${open ? 'rotate-180' : ''}`}
-          />
-        </button>
-      </div>
-
-      {/* 확장 목록: primary 제외한 나머지만 */}
-      {open && (
-        <ul className="flex flex-col border-t border-border px-1 pb-1">
-          {rest.map((ch) => (
-            <li key={ch.channelId}>
-              <a
-                href={ch.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                onClick={() => {
-                  handleClick(ch.channelKey)
-                  setOpen(false)
-                }}
-                className="flex min-h-[44px] cursor-pointer items-center justify-between rounded-lg px-3 py-2 transition-colors hover:bg-muted"
-              >
-                <span className="text-sm">{ch.label}</span>
-                <span className="text-muted-foreground text-sm">
-                  {ch.price !== null ? formatPrice(ch.price) : '→'}
-                </span>
-              </a>
-            </li>
-          ))}
-        </ul>
-      )}
+      <ul className="flex flex-col">
+        {sorted.map((ch, i) => (
+          <li key={ch.channelId} className={i > 0 ? 'border-t border-border' : ''}>
+            <a
+              href={ch.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() => handleClick(ch.channelKey)}
+              className="flex min-h-[44px] cursor-pointer items-center justify-between px-4 py-2 transition-colors hover:bg-muted"
+            >
+              <div className="flex items-center gap-2">
+                <span className={`text-sm ${i === 0 ? 'font-medium' : ''}`}>{ch.label}</span>
+                {i === 0 && (
+                  <span className="rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
+                    최저가
+                  </span>
+                )}
+              </div>
+              <span className={`text-sm ${i === 0 ? 'font-medium' : 'text-muted-foreground'}`}>
+                {ch.price !== null ? formatPrice(ch.price) : '→'}
+              </span>
+            </a>
+          </li>
+        ))}
+      </ul>
     </div>
   )
 }

--- a/src/components/roastery/PurchaseSection.tsx
+++ b/src/components/roastery/PurchaseSection.tsx
@@ -36,7 +36,11 @@ export function PurchaseSection({ roasteryId, channels }: PurchaseSectionProps) 
             >
               <div className="flex items-center gap-2">
                 <span className="text-sm">{ch.label}</span>
-                {i === 0 && <span className="text-xs text-muted-foreground">최저가</span>}
+                {i === 0 && (
+                  <span className="rounded-full border border-border px-2 py-0.5 text-xs text-muted-foreground">
+                    최저가
+                  </span>
+                )}
               </div>
               <span className="text-sm text-muted-foreground">
                 {ch.price !== null ? formatPrice(ch.price) : '→'}

--- a/src/components/roastery/PurchaseSection.tsx
+++ b/src/components/roastery/PurchaseSection.tsx
@@ -34,7 +34,7 @@ export function PurchaseSection({ roasteryId, channels }: PurchaseSectionProps) 
         target="_blank"
         rel="noopener noreferrer"
         onClick={() => handleClick(primary.channelKey)}
-        className="flex items-center justify-between gap-3 rounded-lg bg-primary px-4 py-3 text-primary-foreground transition-opacity hover:opacity-90"
+        className="flex items-center justify-between gap-3 rounded-lg bg-primary px-3 py-2 text-primary-foreground transition-opacity hover:opacity-90"
       >
         <div className="flex items-center gap-2">
           <span className="text-sm font-medium">{primary.label}</span>

--- a/src/components/roastery/PurchaseSection.tsx
+++ b/src/components/roastery/PurchaseSection.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { useState } from 'react'
 import { logClientEvent } from '@/actions/events'
 import type { ChannelWithPrice } from '@/types/roastery'
 import { sortChannels } from '@/types/roastery'
@@ -15,72 +14,41 @@ function formatPrice(price: number): string {
 }
 
 export function PurchaseSection({ roasteryId, channels }: PurchaseSectionProps) {
-  const [open, setOpen] = useState(false)
-
   if (channels.length === 0) return null
 
   const sorted = sortChannels(channels)
-  const [primary, ...rest] = sorted
 
   function handleClick(channelKey: string) {
     logClientEvent({ event: 'purchase_link_clicked', payload: { roasteryId, channelKey } })
   }
 
   return (
-    <div className="flex flex-col gap-2 rounded-xl border border-border bg-surface p-4">
-      {/* 메인 CTA — 최저가 채널 */}
-      <a
-        href={primary.url}
-        target="_blank"
-        rel="noopener noreferrer"
-        onClick={() => handleClick(primary.channelKey)}
-        className="flex items-center justify-between gap-3 rounded-lg bg-primary px-3 py-2 text-primary-foreground transition-opacity hover:opacity-90"
-      >
-        <div className="flex items-center gap-2">
-          <span className="text-sm font-medium">{primary.label}</span>
-          {primary.price !== null && (
-            <span className="text-xs opacity-80">{formatPrice(primary.price)}</span>
-          )}
-        </div>
-        <span className="text-sm font-medium">구매하기 →</span>
-      </a>
-
-      {/* 다른 채널 토글 */}
-      {rest.length > 0 && (
-        <div className="flex flex-col gap-1">
-          <button
-            type="button"
-            onClick={() => setOpen((v) => !v)}
-            className="flex items-center gap-1 px-1 py-0.5 text-xs text-muted-foreground hover:text-foreground transition-colors w-fit"
-          >
-            <span>{open ? '▲' : '▼'}</span>
-            <span>다른 채널 {open ? '닫기' : '보기'}</span>
-          </button>
-
-          {open && (
-            <ul className="flex flex-col gap-1 pt-1">
-              {rest.map((ch) => (
-                <li key={ch.channelId}>
-                  <a
-                    href={ch.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    onClick={() => handleClick(ch.channelKey)}
-                    className="flex items-center justify-between rounded-lg px-3 py-2 text-sm hover:bg-muted transition-colors"
-                  >
-                    <span className="text-foreground">{ch.label}</span>
-                    {ch.price !== null ? (
-                      <span className="text-muted-foreground text-xs">{formatPrice(ch.price)}</span>
-                    ) : (
-                      <span className="text-muted-foreground text-xs">→</span>
-                    )}
-                  </a>
-                </li>
-              ))}
-            </ul>
-          )}
-        </div>
-      )}
+    <div className="flex flex-col gap-2 rounded-xl border border-border bg-surface p-2">
+      <ul className="flex flex-col gap-1">
+        {sorted.map((ch, i) => (
+          <li key={ch.channelId}>
+            <a
+              href={ch.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() => handleClick(ch.channelKey)}
+              className="flex min-h-[44px] cursor-pointer items-center justify-between rounded-lg px-3 py-2 transition-colors hover:bg-muted"
+            >
+              <span className={`text-sm ${i === 0 ? 'font-medium' : 'text-foreground'}`}>
+                {ch.label}
+              </span>
+              <div className="flex items-center gap-2 text-sm">
+                {ch.price !== null && (
+                  <span className={i === 0 ? 'font-medium' : 'text-muted-foreground text-xs'}>
+                    {formatPrice(ch.price)}
+                  </span>
+                )}
+                <span className="text-muted-foreground text-xs">→</span>
+              </div>
+            </a>
+          </li>
+        ))}
+      </ul>
     </div>
   )
 }

--- a/src/components/roastery/PurchaseSection.tsx
+++ b/src/components/roastery/PurchaseSection.tsx
@@ -35,14 +35,10 @@ export function PurchaseSection({ roasteryId, channels }: PurchaseSectionProps) 
               className="flex min-h-[44px] cursor-pointer items-center justify-between px-4 py-2 transition-colors hover:bg-muted"
             >
               <div className="flex items-center gap-2">
-                <span className={`text-sm ${i === 0 ? 'font-medium' : ''}`}>{ch.label}</span>
-                {i === 0 && (
-                  <span className="rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
-                    최저가
-                  </span>
-                )}
+                <span className="text-sm">{ch.label}</span>
+                {i === 0 && <span className="text-xs text-muted-foreground">최저가</span>}
               </div>
-              <span className={`text-sm ${i === 0 ? 'font-medium' : 'text-muted-foreground'}`}>
+              <span className="text-sm text-muted-foreground">
                 {ch.price !== null ? formatPrice(ch.price) : '→'}
               </span>
             </a>

--- a/src/components/roastery/RoasteryDetail.tsx
+++ b/src/components/roastery/RoasteryDetail.tsx
@@ -29,11 +29,11 @@ export function RoasteryDetail({
       <BackButton />
 
       {/* 기본 정보 */}
-      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-        <div className="flex gap-4">
-          {/* 프로필 이미지 */}
-          {roastery.imageUrl && (
-            <div className="relative size-20 shrink-0 overflow-hidden rounded-xl">
+      <div className="flex flex-col gap-2">
+        {/* 이미지 + 이름 행 */}
+        <div className="flex gap-4 items-start">
+          <div className="relative size-20 shrink-0 overflow-hidden rounded-xl bg-muted">
+            {roastery.imageUrl && (
               <Image
                 src={roastery.imageUrl}
                 alt={roastery.name}
@@ -43,47 +43,23 @@ export function RoasteryDetail({
                 sizes="80px"
                 unoptimized={roastery.imageUrl.startsWith('/')}
               />
-            </div>
-          )}
-          <div className="flex flex-col gap-2">
-            <h1 className="text-2xl font-semibold">{roastery.name}</h1>
-            <div className="flex flex-col gap-0.5">
-              {regions.length > 0 && <p className="text-sm text-muted-foreground">{regions[0]}</p>}
-              {roastery.address && (
-                <p className="text-xs text-muted-foreground/70">{roastery.address}</p>
+            )}
+          </div>
+          <div className="flex flex-col gap-1.5 flex-1 min-w-0">
+            <div className="flex items-start justify-between gap-2">
+              <h1 className="text-2xl font-semibold leading-tight">{roastery.name}</h1>
+              {isLoggedIn && (
+                <BookmarkButton roasteryId={roastery.id} initialIsBookmarked={isBookmarked} />
               )}
             </div>
-            {roastery.description && (
-              <p className="text-sm text-foreground leading-relaxed max-w-prose">
-                {roastery.description}
-              </p>
-            )}
-            {charTags.length > 0 && (
-              <div className="flex flex-wrap gap-1.5 pt-1">
-                {charTags.map((tag) => (
-                  <Badge key={tag} variant="secondary" className="text-xs">
-                    {tag}
-                  </Badge>
-                ))}
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-1">
+                <RatingDisplay
+                  avgRating={roastery.avgRating}
+                  ratingCount={roastery.ratingCount}
+                  size="lg"
+                />
               </div>
-            )}
-          </div>
-        </div>
-
-        <div className="flex flex-col gap-3 shrink-0">
-          <div className="flex items-center gap-2 flex-wrap">
-            <Badge variant="outline">{PRICE_RANGE_LABELS[roastery.priceRange]}</Badge>
-            {roastery.decaf && <Badge variant="secondary">디카페인</Badge>}
-          </div>
-          <div className="flex items-center gap-1 text-sm">
-            <RatingDisplay
-              avgRating={roastery.avgRating}
-              ratingCount={roastery.ratingCount}
-              size="lg"
-            />
-          </div>
-          {isLoggedIn && (
-            <div className="flex items-center gap-2">
               <RatingButton
                 roasteryId={roastery.id}
                 roasteryName={roastery.name}
@@ -91,17 +67,37 @@ export function RoasteryDetail({
                 existingScore={userRating?.score}
                 existingComment={userRating?.comment}
               />
-              <BookmarkButton roasteryId={roastery.id} initialIsBookmarked={isBookmarked} />
             </div>
-          )}
-          {!isLoggedIn && (
-            <RatingButton
-              roasteryId={roastery.id}
-              roasteryName={roastery.name}
-              isLoggedIn={false}
-            />
+          </div>
+        </div>
+
+        {/* 지역 + 주소 */}
+        <div className="flex flex-col gap-0.5">
+          {regions.length > 0 && <p className="text-sm text-muted-foreground">{regions[0]}</p>}
+          {roastery.address && (
+            <p className="text-xs text-muted-foreground/70">{roastery.address}</p>
           )}
         </div>
+
+        {/* 설명 */}
+        {roastery.description && (
+          <p className="text-sm text-foreground leading-relaxed max-w-prose">
+            {roastery.description}
+          </p>
+        )}
+
+        {/* 가격 뱃지 + 디카페인 + 특성 태그 통합 */}
+        {(charTags.length > 0 || roastery.decaf || roastery.priceRange) && (
+          <div className="flex flex-wrap gap-1.5 pt-1">
+            <Badge variant="outline">{PRICE_RANGE_LABELS[roastery.priceRange]}</Badge>
+            {roastery.decaf && <Badge variant="secondary">디카페인</Badge>}
+            {charTags.map((tag) => (
+              <Badge key={tag} variant="secondary" className="text-xs">
+                {tag}
+              </Badge>
+            ))}
+          </div>
+        )}
       </div>
 
       {/* 구매하기 + 원두 라인업 */}

--- a/src/lib/queries/roastery.ts
+++ b/src/lib/queries/roastery.ts
@@ -170,8 +170,20 @@ export async function getRoasteryById(id: string): Promise<RoasteryDetail | null
 
   if (!roastery) return null
 
-  // 로스터리 기본 채널 (가격 없음)
-  const baseChannels = flattenChannels(roastery.channels)
+  // 채널별 최저가 집계 (전체 원두 기준)
+  const minPriceByChannelId = new Map<string, number>()
+  for (const bean of roastery.beans) {
+    for (const bp of bean.channelPrices) {
+      const prev = minPriceByChannelId.get(bp.channel.id)
+      if (prev === undefined || bp.price < prev) {
+        minPriceByChannelId.set(bp.channel.id, bp.price)
+      }
+    }
+  }
+  const baseChannels = flattenChannels(
+    roastery.channels,
+    minPriceByChannelId.size > 0 ? minPriceByChannelId : undefined
+  )
 
   // 원두별 채널 가격
   const beans: RoasteryDetail['beans'] = roastery.beans.map((bean) => {


### PR DESCRIPTION
## 변경 사항
- `bg-primary` CTA 버튼 제거 — 구매 링크는 보조 정보이므로 강조 불필요
- "다른 채널 보기" 토글 제거 → 전체 채널 flat 리스트로 표시
- `min-h-[44px]` 터치 타겟 확보 (UX 가이드라인 CRITICAL)
- 최저가 채널 `font-medium` 으로 최소 강조 유지
- `hover:bg-muted cursor-pointer` 인터랙션 피드백

## 테스트 방법
- [ ] 로스터리 상세 페이지에서 구매 채널 섹션 확인
- [ ] 채널 1개 / 다수일 때 각각 확인
- [ ] 모바일에서 터치 타겟 크기 확인