### PR TITLE
feat: HTTP Security Headers 추가

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,68 @@
 import type { NextConfig } from 'next'
 import { withSentryConfig } from '@sentry/nextjs'
 
+const securityHeaders = [
+  // DNS 프리페칭 허용: 외부 도메인 DNS를 미리 조회해 페이지 로딩 속도 향상
+  // 미적용 시: 외부 리소스 첫 요청마다 DNS 조회 지연 발생
+  { key: 'X-DNS-Prefetch-Control', value: 'on' },
+
+  // HTTPS 강제 (HSTS): 브라우저가 1년간 이 사이트를 HTTPS로만 접근
+  // 미적용 시: HTTP로 접근 시 중간자 공격(MITM)으로 트래픽 탈취 가능
+  { key: 'Strict-Transport-Security', value: 'max-age=31536000; includeSubDomains' },
+
+  // 클릭재킹 방지: 동일 출처의 iframe만 허용
+  // 미적용 시: 악성 사이트가 iframe으로 이 페이지를 숨겨 사용자가 모르게 클릭 유도 가능
+  { key: 'X-Frame-Options', value: 'SAMEORIGIN' },
+
+  // MIME 스니핑 방지: 브라우저가 Content-Type을 임의로 추론하지 않음
+  // 미적용 시: 업로드된 파일을 브라우저가 JS로 해석해 XSS 실행 가능
+  { key: 'X-Content-Type-Options', value: 'nosniff' },
+
+  // Referrer 정보 제한: 외부 도메인으로 이동 시 출처 도메인만 전달 (경로·쿼리 제외)
+  // 미적용 시: URL에 포함된 사용자 식별 정보(쿼리스트링 등)가 외부로 유출 가능
+  { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+
+  // 브라우저 기능 접근 제한: 카메라·마이크·위치 정보 API 사용 차단
+  // 미적용 시: 공급망 공격(악성 npm 패키지 등)으로 사용자 기기 접근 가능
+  { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
+
+  // CSP: 허용된 리소스 출처만 로드·실행 가능하도록 화이트리스트 지정
+  // 미적용 시: XSS 공격 성공 시 악성 스크립트가 자유롭게 실행되고 데이터 외부 전송 가능
+  {
+    key: 'Content-Security-Policy',
+    value: [
+      // 미지정 리소스는 동일 출처만 허용
+      "default-src 'self'",
+      // Next.js App Router는 인라인 스크립트·eval 필요 (hydration, turbopack)
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+      // Tailwind CSS 등 CSS-in-JS는 인라인 스타일 필요
+      "style-src 'self' 'unsafe-inline'",
+      // 소셜 로그인 프로필 이미지 및 Vercel Blob 이미지 허용
+      [
+        "img-src 'self' data: blob:",
+        'https://lh3.googleusercontent.com',
+        'https://k.kakaocdn.net http://k.kakaocdn.net',
+        'https://phinf.pstatic.net https://ssl.pstatic.net',
+        'https://*.public.blob.vercel-storage.com',
+      ].join(' '),
+      // 웹폰트는 동일 출처만
+      "font-src 'self'",
+      // Sentry 에러 전송, Axiom 로그 전송 허용
+      "connect-src 'self' https://*.ingest.sentry.io https://api.axiom.co",
+      // iframe으로 이 페이지를 삽입하는 것 자체를 차단 (X-Frame-Options 보완)
+      "frame-ancestors 'none'",
+      // <base> 태그 출처 제한 (base href 하이재킹 방지)
+      "base-uri 'self'",
+      // 폼 제출 대상 제한
+      "form-action 'self'",
+    ].join('; '),
+  },
+]
+
 const nextConfig: NextConfig = {
+  async headers() {
+    return [{ source: '/(.*)', headers: securityHeaders }]
+  },
   images: {
     remotePatterns: [
       // Google 프로필 이미지


### PR DESCRIPTION
## 변경 사항

`next.config.ts`에 7개 HTTP Security Header를 추가했습니다.

| 헤더 | 값 | 목적 | 미적용 시 위험 |
|------|-----|------|---------------|
| `X-DNS-Prefetch-Control` | `on` | DNS 프리페치 허용으로 로딩 속도 향상 | 외부 리소스 첫 요청 시 DNS 지연 |
| `Strict-Transport-Security` | `max-age=31536000; includeSubDomains` | 브라우저가 1년간 HTTPS만 사용 강제 | HTTP 접근 시 중간자 공격으로 트래픽 탈취 가능 |
| `X-Frame-Options` | `SAMEORIGIN` | 동일 출처 iframe만 허용 | 악성 사이트가 iframe으로 숨겨 클릭 유도(클릭재킹) 가능 |
| `X-Content-Type-Options` | `nosniff` | 브라우저 MIME 타입 추론 차단 | 업로드 파일을 JS로 해석해 XSS 실행 가능 |
| `Referrer-Policy` | `strict-origin-when-cross-origin` | 외부 이동 시 경로·쿼리 제외하고 도메인만 전달 | URL 내 사용자 식별 정보가 외부로 유출 가능 |
| `Permissions-Policy` | `camera=(), microphone=(), geolocation=()` | 카메라·마이크·위치 API 접근 차단 | 공급망 공격으로 사용자 기기 접근 가능 |
| `Content-Security-Policy` | 화이트리스트 방식 | 허용된 출처의 리소스만 로드·실행 | XSS 성공 시 악성 스크립트가 자유롭게 실행되고 데이터 외부 전송 가능 |

### CSP 허용 목록
- **이미지**: Google, Kakao, Naver 프로필 이미지 / Vercel Blob
- **외부 통신**: Sentry(`*.ingest.sentry.io`), Axiom(`api.axiom.co`)
- **스크립트**: `unsafe-inline`, `unsafe-eval` 허용 (Next.js App Router hydration 필요)

## 테스트 방법
- [ ] 배포 후 브라우저 DevTools → Network → 응답 헤더에 위 헤더 확인
- [ ] 소셜 로그인 및 이미지 로딩 정상 동작 확인