### PR TITLE
test: E2E 테스트 DB 시드 자동화 및 selector 수정

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,6 +8,7 @@ dotenv.config({ path: '.env.test', override: true })
 
 export default defineConfig({
   testDir: './tests',
+  globalSetup: './tests/global-setup.ts',
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,

--- a/tests/e2e/roastery.spec.ts
+++ b/tests/e2e/roastery.spec.ts
@@ -16,9 +16,10 @@ test('E-14: 정렬 선택 시 URL에 sort 파라미터가 반영된다', async (
   await loginComplete(page)
   await page.goto('/roasteries')
 
-  const sortSelect = page.getByRole('combobox', { name: '정렬 기준' })
-  await expect(sortSelect).toBeEnabled()
-  await sortSelect.selectOption('name')
+  const sortButton = page.getByRole('button', { name: '정렬 기준' }).first()
+  await expect(sortButton).toBeEnabled()
+  await sortButton.click()
+  await page.getByRole('button', { name: '이름순' }).click()
 
   await expect(page).toHaveURL(/sort=name/)
 })

--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -1,0 +1,25 @@
+import { execSync } from 'child_process'
+import dotenv from 'dotenv'
+
+dotenv.config({ path: '.env.local' })
+dotenv.config({ path: '.env.test', override: true })
+
+export default async function globalSetup() {
+  const testDbUrl = process.env.DATABASE_URL
+  if (!testDbUrl) throw new Error('DATABASE_URL not set in .env.test')
+
+  const env = {
+    ...process.env,
+    DATABASE_URL: testDbUrl,
+    // DIRECT_URL이 .env.local에 설정돼 있으면 테스트 DB로 덮어쓴다
+    DIRECT_URL: testDbUrl,
+  }
+
+  console.log('\n[E2E global-setup] 테스트 DB 마이그레이션 중...')
+  execSync('pnpm prisma migrate deploy', { env, stdio: 'inherit' })
+
+  console.log('[E2E global-setup] 테스트 DB 시드 중...')
+  execSync('tsx prisma/seed.ts', { env, stdio: 'inherit' })
+
+  console.log('[E2E global-setup] 완료\n')
+}


### PR DESCRIPTION
## 변경 사항
- `playwright.config.ts`에 `globalSetup` 추가 (`tests/global-setup.ts`)
- E2E 실행 전 `rocommend_test` DB에 migrate deploy → seed 자동 실행
  - `DATABASE_URL` / `DIRECT_URL`을 `.env.test` 기준으로 덮어써 dev DB 오염 방지
- E-14 테스트: `combobox` role → `button` + `aria-label "정렬 기준"` selector 수정
  (SortSelector가 native `<select>` 아닌 커스텀 드롭다운으로 구현돼 있어 불일치)

## 원인
E2E 테스트 60개 중 13개 실패의 근본 원인은 테스트 DB 미시드.  
`rocommend_test`에 로스터리 데이터가 없어 카드 클릭 타임아웃 발생.

## 테스트
- [x] `pnpm test` — 127개 통과
- [x] `pnpm test:e2e` — 60개 전부 통과 (기존 47/60 → 60/60)