### PR TITLE
feat: 개인정보처리방침 및 이용약관 페이지 추가

### DIFF
--- a/src/app/(main)/legal/privacy/page.tsx
+++ b/src/app/(main)/legal/privacy/page.tsx
@@ -4,7 +4,7 @@ export const metadata: Metadata = {
   title: '개인정보처리방침',
 }
 
-const EFFECTIVE_DATE = '2025년 1월 1일'
+const EFFECTIVE_DATE = '2026년 4월 20일'
 const SERVICE_NAME = 'Rocommend'
 const COMPANY_NAME = '[사업자명]'
 const CONTACT_EMAIL = 'privacy@rocommend.kr'

--- a/src/app/(main)/legal/privacy/page.tsx
+++ b/src/app/(main)/legal/privacy/page.tsx
@@ -131,7 +131,7 @@ export default function PrivacyPage() {
         <Section title="9. 개인정보 보호책임자">
           <p>이용자의 개인정보 관련 문의, 불만 처리, 피해 구제 등을 위해 아래와 같이 지정합니다.</p>
           <ul>
-            <li>성명: [담당자명]</li>
+            <li>성명: 이태호</li>
             <li>직책: 개인정보 보호책임자</li>
             <li>이메일: {CONTACT_EMAIL}</li>
           </ul>

--- a/src/app/(main)/legal/privacy/page.tsx
+++ b/src/app/(main)/legal/privacy/page.tsx
@@ -1,0 +1,175 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: '개인정보처리방침',
+}
+
+const EFFECTIVE_DATE = '2025년 1월 1일'
+const SERVICE_NAME = 'Rocommend'
+const COMPANY_NAME = '[사업자명]'
+const CONTACT_EMAIL = 'privacy@rocommend.kr'
+
+export default function PrivacyPage() {
+  return (
+    <div className="page-wrapper py-8">
+      <div className="flex flex-col gap-8 max-w-2xl">
+        <div className="flex flex-col gap-2">
+          <h1 className="text-xl font-semibold">개인정보처리방침</h1>
+          <p className="text-sm text-text-secondary">시행일: {EFFECTIVE_DATE}</p>
+        </div>
+
+        <p className="text-sm text-text-primary leading-relaxed">
+          {COMPANY_NAME}(이하 &quot;회사&quot;)는 {SERVICE_NAME} 서비스(이하 &quot;서비스&quot;)를
+          운영함에 있어 이용자의 개인정보를 중요시하며, 「개인정보 보호법」 및 「정보통신망 이용촉진
+          및 정보보호 등에 관한 법률」을 준수합니다.
+        </p>
+
+        <Section title="1. 수집하는 개인정보 항목 및 수집 방법">
+          <p>회사는 다음과 같은 개인정보를 수집합니다.</p>
+          <SubSection title="가. 소셜 로그인 시 수집 항목">
+            <ul>
+              <li>Google: 이름, 이메일 주소, 프로필 이미지</li>
+              <li>카카오: 이름(닉네임), 이메일 주소, 프로필 이미지</li>
+              <li>네이버: 이름, 이메일 주소, 프로필 이미지</li>
+            </ul>
+          </SubSection>
+          <SubSection title="나. 서비스 이용 과정에서 자동 수집">
+            <ul>
+              <li>서비스 이용 기록, 접속 로그, 쿠키, IP 주소</li>
+              <li>이용자가 직접 입력한 취향 설문 응답, 로스터리 평가 및 즐겨찾기 데이터</li>
+            </ul>
+          </SubSection>
+        </Section>
+
+        <Section title="2. 개인정보의 수집 및 이용 목적">
+          <ul>
+            <li>회원 식별 및 서비스 제공</li>
+            <li>로스터리 추천 알고리즘(협업 필터링) 운영</li>
+            <li>서비스 개선 및 신규 기능 개발</li>
+            <li>법령 및 이용약관 위반 행위 확인 및 제재</li>
+            <li>서비스 관련 공지사항 전달</li>
+          </ul>
+        </Section>
+
+        <Section title="3. 개인정보의 보유 및 이용 기간">
+          <p>
+            회사는 이용자의 개인정보를 회원 탈퇴 시 또는 개인정보 수집·이용 목적 달성 시 지체 없이
+            파기합니다. 단, 관련 법령에 따라 아래 기간 동안 보존합니다.
+          </p>
+          <ul>
+            <li>계약 또는 청약철회 등에 관한 기록: 5년 (전자상거래법)</li>
+            <li>소비자 불만 또는 분쟁처리 기록: 3년 (전자상거래법)</li>
+            <li>접속 로그: 3개월 (통신비밀보호법)</li>
+          </ul>
+        </Section>
+
+        <Section title="4. 개인정보의 제3자 제공">
+          <p>
+            회사는 이용자의 개인정보를 원칙적으로 외부에 제공하지 않습니다. 다만, 다음의 경우는
+            예외로 합니다.
+          </p>
+          <ul>
+            <li>이용자가 사전에 동의한 경우</li>
+            <li>
+              법령의 규정에 의거하거나 수사 목적으로 법령에 정해진 절차와 방법에 따라 수사기관의
+              요구가 있는 경우
+            </li>
+          </ul>
+        </Section>
+
+        <Section title="5. 개인정보 처리 위탁">
+          <p>회사는 서비스 제공을 위해 아래와 같이 개인정보 처리를 위탁합니다.</p>
+          <div className="overflow-x-auto">
+            <table>
+              <thead>
+                <tr>
+                  <th>수탁업체</th>
+                  <th>위탁 업무</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Vercel Inc.</td>
+                  <td>서비스 인프라 운영</td>
+                </tr>
+                <tr>
+                  <td>Supabase Inc.</td>
+                  <td>데이터베이스 운영</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </Section>
+
+        <Section title="6. 이용자의 권리와 행사 방법">
+          <p>이용자는 언제든지 다음의 권리를 행사할 수 있습니다.</p>
+          <ul>
+            <li>개인정보 열람 요청</li>
+            <li>개인정보 정정·삭제 요청</li>
+            <li>개인정보 처리 정지 요청</li>
+          </ul>
+          <p>
+            권리 행사는 서비스 내 &quot;계정 관리&quot; 메뉴 또는 아래 개인정보 보호책임자에게
+            이메일로 요청할 수 있습니다. 회원 탈퇴 시 수집된 개인정보는 즉시 파기됩니다.
+          </p>
+        </Section>
+
+        <Section title="7. 쿠키의 운용">
+          <p>
+            서비스는 이용자에게 맞춤화된 서비스를 제공하기 위해 쿠키(Cookie)를 사용합니다. 쿠키는
+            브라우저 설정을 통해 거부할 수 있으나, 일부 서비스 이용이 제한될 수 있습니다.
+          </p>
+        </Section>
+
+        <Section title="8. 개인정보의 파기">
+          <p>
+            보유 기간 만료 또는 처리 목적 달성 후 개인정보는 복구 불가능한 방법으로 즉시 파기합니다.
+            전자적 파일은 복구 불가능한 기술적 방법을 사용하며, 종이 문서는 분쇄 또는 소각합니다.
+          </p>
+        </Section>
+
+        <Section title="9. 개인정보 보호책임자">
+          <p>이용자의 개인정보 관련 문의, 불만 처리, 피해 구제 등을 위해 아래와 같이 지정합니다.</p>
+          <ul>
+            <li>성명: [담당자명]</li>
+            <li>직책: 개인정보 보호책임자</li>
+            <li>이메일: {CONTACT_EMAIL}</li>
+          </ul>
+          <p>개인정보 침해 관련 신고나 상담은 아래 기관에도 문의하실 수 있습니다.</p>
+          <ul>
+            <li>개인정보 침해신고센터: privacy.kisa.or.kr / 118</li>
+            <li>대검찰청 사이버수사과: www.spo.go.kr / 1301</li>
+            <li>경찰청 사이버안전국: cyberbureau.police.go.kr / 182</li>
+          </ul>
+        </Section>
+
+        <Section title="10. 방침 변경 고지">
+          <p>
+            본 개인정보처리방침은 법령·정책 변경에 따라 수정될 수 있으며, 변경 시 서비스 내 공지를
+            통해 사전 안내합니다.
+          </p>
+        </Section>
+      </div>
+    </div>
+  )
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="flex flex-col gap-3">
+      <h2 className="text-base font-semibold text-text-primary">{title}</h2>
+      <div className="flex flex-col gap-2 text-sm text-text-primary leading-relaxed [&_ul]:flex [&_ul]:flex-col [&_ul]:gap-1 [&_ul]:pl-4 [&_ul]:list-disc [&_table]:w-full [&_table]:border-collapse [&_th]:border [&_th]:border-border [&_th]:bg-surface [&_th]:px-3 [&_th]:py-2 [&_th]:text-left [&_th]:text-xs [&_th]:font-medium [&_td]:border [&_td]:border-border [&_td]:px-3 [&_td]:py-2 [&_td]:text-xs">
+        {children}
+      </div>
+    </section>
+  )
+}
+
+function SubSection({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-1">
+      <h3 className="text-sm font-medium text-text-secondary">{title}</h3>
+      {children}
+    </div>
+  )
+}

--- a/src/app/(main)/legal/terms/page.tsx
+++ b/src/app/(main)/legal/terms/page.tsx
@@ -1,0 +1,153 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: '이용약관',
+}
+
+const EFFECTIVE_DATE = '2025년 1월 1일'
+const SERVICE_NAME = 'Rocommend'
+const COMPANY_NAME = '[사업자명]'
+const CONTACT_EMAIL = 'support@rocommend.kr'
+
+export default function TermsPage() {
+  return (
+    <div className="page-wrapper py-8">
+      <div className="flex flex-col gap-8 max-w-2xl">
+        <div className="flex flex-col gap-2">
+          <h1 className="text-xl font-semibold">이용약관</h1>
+          <p className="text-sm text-text-secondary">시행일: {EFFECTIVE_DATE}</p>
+        </div>
+
+        <Section title="제1조 (목적)">
+          <p>
+            본 약관은 {COMPANY_NAME}(이하 &quot;회사&quot;)가 제공하는 {SERVICE_NAME} 서비스(이하
+            &quot;서비스&quot;)의 이용 조건 및 절차, 회사와 이용자 간의 권리·의무 및 책임사항을
+            규정함을 목적으로 합니다.
+          </p>
+        </Section>
+
+        <Section title="제2조 (정의)">
+          <ul>
+            <li>
+              <strong>&quot;서비스&quot;</strong>란 회사가 제공하는 한국 스페셜티 커피 로스터리 추천
+              웹 애플리케이션 및 관련 서비스를 의미합니다.
+            </li>
+            <li>
+              <strong>&quot;이용자&quot;</strong>란 본 약관에 동의하고 서비스를 이용하는 자를
+              의미합니다.
+            </li>
+            <li>
+              <strong>&quot;회원&quot;</strong>이란 소셜 로그인을 통해 계정을 생성하고 서비스를
+              이용하는 이용자를 의미합니다.
+            </li>
+            <li>
+              <strong>&quot;콘텐츠&quot;</strong>란 이용자가 서비스 내에서 작성한 평가, 한줄평 등의
+              정보를 의미합니다.
+            </li>
+          </ul>
+        </Section>
+
+        <Section title="제3조 (약관의 효력 및 변경)">
+          <p>
+            본 약관은 서비스 화면에 게시하거나 기타 방법으로 이용자에게 공지함으로써 효력이
+            발생합니다. 회사는 합리적인 사유가 있는 경우 관련 법령에 위배되지 않는 범위 내에서
+            약관을 변경할 수 있으며, 변경 시 시행 7일 전에 공지합니다. 이용자가 변경된 약관에
+            동의하지 않을 경우 서비스 이용을 중단하고 탈퇴할 수 있습니다.
+          </p>
+        </Section>
+
+        <Section title="제4조 (서비스 이용 계약)">
+          <p>
+            이용 계약은 이용자가 소셜 로그인을 통해 서비스에 가입하고 본 약관에 동의함으로써
+            성립합니다. 만 14세 미만의 경우 서비스를 이용할 수 없습니다.
+          </p>
+        </Section>
+
+        <Section title="제5조 (서비스 제공 및 변경)">
+          <p>회사는 다음 서비스를 제공합니다.</p>
+          <ul>
+            <li>한국 스페셜티 커피 로스터리 정보 제공</li>
+            <li>이용자 취향 기반 로스터리 추천</li>
+            <li>로스터리 평가 및 즐겨찾기 기능</li>
+            <li>기타 회사가 정하는 서비스</li>
+          </ul>
+          <p>회사는 서비스 내용을 변경할 수 있으며, 중요한 변경 사항은 사전에 공지합니다.</p>
+        </Section>
+
+        <Section title="제6조 (서비스 이용 시간 및 중단)">
+          <p>
+            서비스는 연중무휴 24시간 제공을 원칙으로 합니다. 단, 시스템 점검, 장애, 천재지변 등으로
+            인해 서비스가 일시 중단될 수 있습니다. 예정된 점검은 사전 공지합니다.
+          </p>
+        </Section>
+
+        <Section title="제7조 (이용자의 의무)">
+          <p>이용자는 다음 행위를 해서는 안 됩니다.</p>
+          <ul>
+            <li>타인의 정보를 도용하거나 허위 정보를 등록하는 행위</li>
+            <li>서비스 운영을 방해하거나 서버에 과도한 부하를 주는 행위</li>
+            <li>욕설, 혐오, 음란 등 불건전한 콘텐츠를 게시하는 행위</li>
+            <li>서비스를 이용해 얻은 정보를 회사의 사전 승낙 없이 상업적으로 이용하는 행위</li>
+            <li>기타 관련 법령에 위배되는 행위</li>
+          </ul>
+        </Section>
+
+        <Section title="제8조 (콘텐츠에 대한 권리)">
+          <p>
+            이용자가 서비스 내에 작성한 평가, 한줄평 등 콘텐츠의 저작권은 이용자에게 귀속됩니다. 단,
+            이용자는 회사가 서비스 제공·개선·홍보를 목적으로 해당 콘텐츠를 사용할 수 있도록
+            비독점적· 무상의 라이선스를 부여합니다. 회원 탈퇴 시 해당 콘텐츠는 삭제되거나
+            익명화됩니다.
+          </p>
+        </Section>
+
+        <Section title="제9조 (회원 탈퇴 및 자격 상실)">
+          <p>
+            회원은 언제든지 서비스 내 계정 관리 메뉴를 통해 탈퇴를 요청할 수 있습니다. 탈퇴 즉시
+            계정 정보 및 관련 데이터가 삭제됩니다. 회사는 이용자가 제7조를 위반한 경우 사전 통보
+            없이 이용을 제한하거나 계약을 해지할 수 있습니다.
+          </p>
+        </Section>
+
+        <Section title="제10조 (면책 조항)">
+          <ul>
+            <li>
+              회사는 천재지변, 전쟁, 서비스 제공업체의 장애 등 불가항력으로 인한 서비스 중단에 대해
+              책임지지 않습니다.
+            </li>
+            <li>
+              회사는 이용자가 서비스를 통해 얻은 정보의 정확성·완전성을 보장하지 않으며, 이로 인한
+              손해에 대해 책임지지 않습니다.
+            </li>
+            <li>
+              이용자 간 또는 이용자와 제3자 간의 분쟁에 대해 회사는 개입하지 않으며 책임지지
+              않습니다.
+            </li>
+          </ul>
+        </Section>
+
+        <Section title="제11조 (분쟁 해결)">
+          <p>
+            본 약관과 관련한 분쟁은 대한민국 법을 준거법으로 하며, 소송 관할법원은 민사소송법상 관할
+            법원으로 합니다.
+          </p>
+        </Section>
+
+        <Section title="제12조 (문의)">
+          <p>서비스 이용 관련 문의는 {CONTACT_EMAIL} 로 연락해 주시기 바랍니다.</p>
+        </Section>
+      </div>
+    </div>
+  )
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="flex flex-col gap-3">
+      <h2 className="text-base font-semibold text-text-primary">{title}</h2>
+      <div className="flex flex-col gap-2 text-sm text-text-primary leading-relaxed [&_ul]:flex [&_ul]:flex-col [&_ul]:gap-1 [&_ul]:pl-4 [&_ul]:list-disc [&_strong]:font-medium">
+        {children}
+      </div>
+    </section>
+  )
+}

--- a/src/app/(main)/legal/terms/page.tsx
+++ b/src/app/(main)/legal/terms/page.tsx
@@ -4,7 +4,7 @@ export const metadata: Metadata = {
   title: '이용약관',
 }
 
-const EFFECTIVE_DATE = '2025년 1월 1일'
+const EFFECTIVE_DATE = '2026년 4월 20일'
 const SERVICE_NAME = 'Rocommend'
 const COMPANY_NAME = '[사업자명]'
 const CONTACT_EMAIL = 'support@rocommend.kr'

--- a/src/app/(main)/profile/page.tsx
+++ b/src/app/(main)/profile/page.tsx
@@ -43,6 +43,54 @@ export default async function ProfilePage() {
         <FeedbackButton />
       </section>
 
+      <section className="flex flex-col gap-2">
+        <h2 className="text-sm font-medium text-text-secondary">법적 고지</h2>
+        <div className="flex flex-col rounded-xl bg-surface overflow-hidden">
+          <Link
+            href="/legal/privacy"
+            className="flex items-center justify-between px-4 py-3 text-sm text-text-primary hover:bg-bg transition-colors border-b border-border"
+          >
+            <span>개인정보처리방침</span>
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 16 16"
+              fill="none"
+              className="text-text-secondary"
+            >
+              <path
+                d="M6 4l4 4-4 4"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </Link>
+          <Link
+            href="/legal/terms"
+            className="flex items-center justify-between px-4 py-3 text-sm text-text-primary hover:bg-bg transition-colors"
+          >
+            <span>이용약관</span>
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 16 16"
+              fill="none"
+              className="text-text-secondary"
+            >
+              <path
+                d="M6 4l4 4-4 4"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </Link>
+        </div>
+      </section>
+
       <Link
         href="/account"
         className="w-full cursor-pointer rounded-lg border border-border bg-surface px-4 py-3 text-center text-sm font-medium text-text-primary transition-colors hover:bg-bg"

--- a/src/app/(main)/settings/page.tsx
+++ b/src/app/(main)/settings/page.tsx
@@ -20,6 +20,54 @@ export default async function SettingsPage() {
         <FeedbackButton />
       </section>
 
+      <section className="flex flex-col gap-2">
+        <h2 className="text-sm font-medium text-text-secondary">법적 고지</h2>
+        <div className="flex flex-col rounded-xl bg-surface overflow-hidden">
+          <Link
+            href="/legal/privacy"
+            className="flex items-center justify-between px-4 py-3 text-sm text-text-primary hover:bg-bg transition-colors border-b border-border"
+          >
+            <span>개인정보처리방침</span>
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 16 16"
+              fill="none"
+              className="text-text-secondary"
+            >
+              <path
+                d="M6 4l4 4-4 4"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </Link>
+          <Link
+            href="/legal/terms"
+            className="flex items-center justify-between px-4 py-3 text-sm text-text-primary hover:bg-bg transition-colors"
+          >
+            <span>이용약관</span>
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 16 16"
+              fill="none"
+              className="text-text-secondary"
+            >
+              <path
+                d="M6 4l4 4-4 4"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </Link>
+        </div>
+      </section>
+
       {!session?.user && (
         <section className="flex flex-col gap-2">
           <h2 className="text-sm font-medium text-text-secondary">계정</h2>

--- a/src/lib/auth.config.ts
+++ b/src/lib/auth.config.ts
@@ -7,6 +7,10 @@ import '@/types/auth'
 // Edge Runtime 호환 설정 (Prisma adapter 없음)
 // proxy.ts에서 import — Node.js 모듈 사용 불가
 
+// 공개 경로 관리 규칙:
+// - 새 페이지가 비로그인 접근 가능해야 하면 여기에 추가
+// - 그 외 경로는 자동으로 로그인 필요 (authorized 콜백에서 /login 리다이렉트)
+// - 어드민 전용은 별도 처리 (아래 /admin 블록)
 const PUBLIC_PATHS = [
   '/',
   '/login',
@@ -16,6 +20,7 @@ const PUBLIC_PATHS = [
   '/roasteries',
   '/home',
   '/settings',
+  '/legal', // 개인정보처리방침·이용약관 — 비로그인 접근 허용
 ]
 
 function isPublicPath(pathname: string) {


### PR DESCRIPTION
## 변경 사항
- `/legal/privacy`: 개인정보처리방침 페이지 (개보법·정통망법 기준 10개 조항)
- `/legal/terms`: 이용약관 페이지 (12개 조항)
- 설정 페이지에 법적 고지 섹션 추가 (chevron 링크 카드 UI)

## 테스트 방법
- [ ] 설정 페이지 → 법적 고지 섹션 노출 확인
- [ ] 개인정보처리방침 링크 클릭 → `/legal/privacy` 정상 표시
- [ ] 이용약관 링크 클릭 → `/legal/terms` 정상 표시
- [ ] 모바일/데스크탑 레이아웃 확인