### PR TITLE
fix: OG 이미지 Edge Function 크기 초과 해결

### DIFF
--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,6 +1,5 @@
 import { ImageResponse } from 'next/og'
 
-export const runtime = 'edge'
 export const alt = 'Rocommend — 스페셜티 커피 로스터리 추천'
 export const size = { width: 1200, height: 630 }
 export const contentType = 'image/png'


### PR DESCRIPTION
## 변경 사항
- `opengraph-image.tsx`에서 `export const runtime = 'edge'` 제거
- Node.js 런타임으로 전환 (크기 제한 없음)

## 원인
`next/og` (satori + resvg WASM) 번들이 약 2MB로 Vercel Edge Function 1MB 한도 초과

## 선택 이유
OG 이미지는 소셜 플랫폼(카카오, 트위터 등)이 최초 1회 요청 후 캐싱하므로 Edge 런타임의 속도 이점이 실질적으로 없음. Node.js 런타임으로 전환이 가장 단순하고 확실한 해결책.