### PR TITLE
fix: OG 이미지 빌드 시 폰트 fetch 오류 수정

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -77,12 +77,12 @@ const nextConfig: NextConfig = {
       { protocol: 'https', hostname: '*.public.blob.vercel-storage.com', pathname: '/**' },
     ],
   },
+  outputFileTracingIncludes: {
+    '/opengraph-image': ['./src/app/fonts/Pretendard-Bold.ttf'],
+  },
   experimental: {
     serverActions: {
       bodySizeLimit: '4mb',
-    },
-    outputFileTracingIncludes: {
-      '/opengraph-image': ['./src/app/fonts/Pretendard-Bold.ttf'],
     },
   },
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -81,6 +81,9 @@ const nextConfig: NextConfig = {
     serverActions: {
       bodySizeLimit: '4mb',
     },
+    outputFileTracingIncludes: {
+      '/opengraph-image': ['./src/app/fonts/Pretendard-Bold.ttf'],
+    },
   },
 }
 

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,3 +1,5 @@
+import { readFile } from 'fs/promises'
+import { join } from 'path'
 import { ImageResponse } from 'next/og'
 
 export const alt = 'Rocommend — 스페셜티 커피 로스터리 추천'
@@ -6,9 +8,8 @@ export const contentType = 'image/png'
 
 async function loadFont(): Promise<ArrayBuffer | null> {
   try {
-    return fetch(new URL('./fonts/Pretendard-Bold.ttf', import.meta.url)).then((r) =>
-      r.arrayBuffer()
-    )
+    const buf = await readFile(join(process.cwd(), 'src/app/fonts/Pretendard-Bold.ttf'))
+    return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer
   } catch {
     return null
   }


### PR DESCRIPTION
## 변경 사항
- `opengraph-image.tsx`: `fetch(file://)` → `fs.readFile`로 교체
- `next.config.ts`: `outputFileTracingIncludes`로 Vercel 번들에 폰트 포함

## 원인
Node.js 런타임 빌드 시 프리렌더링 중 `fetch(new URL('./fonts/...', import.meta.url))`가 `file://` URL을 생성하는데, Next.js 빌드 환경에서 `file://` fetch가 미지원 ("not implemented... yet...")