### PR TITLE
fix: robots/sitemap BASE_URL 환경변수로 교체 및 홈 URL 수정

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,10 @@
 # 프로덕션(Supabase): 포트 5432 Session Pooler (prepared statement 지원)
 DATABASE_URL=
 
+# ── App ─────────────────────────────────────────────
+# 개발: http://localhost:3000 / 프로덕션: https://rocommend.com
+NEXT_PUBLIC_APP_URL=
+
 # ── Auth.js v5 ───────────────────────────────────────
 # 생성: openssl rand -base64 32
 AUTH_SECRET=

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,5 +1,7 @@
 import type { MetadataRoute } from 'next'
 
+const BASE_URL = process.env.NEXT_PUBLIC_APP_URL ?? 'https://rocommend.com'
+
 export default function robots(): MetadataRoute.Robots {
   return {
     rules: {
@@ -7,6 +9,6 @@ export default function robots(): MetadataRoute.Robots {
       allow: '/',
       disallow: ['/login', '/onboarding', '/admin/', '/api/'],
     },
-    sitemap: 'https://rocommend.com/sitemap.xml',
+    sitemap: `${BASE_URL}/sitemap.xml`,
   }
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,7 +1,7 @@
 import type { MetadataRoute } from 'next'
 import { prisma } from '@/lib/prisma'
 
-const BASE_URL = 'https://rocommend.com'
+const BASE_URL = process.env.NEXT_PUBLIC_APP_URL ?? 'https://rocommend.com'
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const roasteries = await prisma.roastery.findMany({
@@ -16,7 +16,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
   return [
     {
-      url: `${BASE_URL}/home`,
+      url: `${BASE_URL}/`,
       changeFrequency: 'weekly',
       priority: 1.0,
     },


### PR DESCRIPTION
## 변경 사항
- `robots.ts` / `sitemap.ts`: 하드코딩 URL → `NEXT_PUBLIC_APP_URL` 환경변수로 교체
- `sitemap.ts`: `/home` → `/` (PR #86 라우트 이동 미반영 수정)
- `.env.example`: `NEXT_PUBLIC_APP_URL` 항목 추가

## 배포 전 필수
Vercel 환경변수에 `NEXT_PUBLIC_APP_URL=https://rocommend.com` 추가 필요