### PR TITLE
feat: 비로그인 데스크탑 드롭다운에 법적 고지 링크 추가

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -136,12 +136,12 @@ export function Header({ className }: { className?: string }) {
                     <FeedbackButton onOpenModal={() => setFeedbackOpen(true)} />
                   </div>
                   <DropdownMenuSeparator />
-                  <DropdownMenuItem asChild>
+                  <DropdownMenuItem>
                     <Link href="/legal/privacy" className="w-full">
                       개인정보처리방침
                     </Link>
                   </DropdownMenuItem>
-                  <DropdownMenuItem asChild>
+                  <DropdownMenuItem>
                     <Link href="/legal/terms" className="w-full">
                       이용약관
                     </Link>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -135,6 +135,17 @@ export function Header({ className }: { className?: string }) {
                   <div className="px-2 py-0.5">
                     <FeedbackButton onOpenModal={() => setFeedbackOpen(true)} />
                   </div>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem asChild>
+                    <Link href="/legal/privacy" className="w-full">
+                      개인정보처리방침
+                    </Link>
+                  </DropdownMenuItem>
+                  <DropdownMenuItem asChild>
+                    <Link href="/legal/terms" className="w-full">
+                      이용약관
+                    </Link>
+                  </DropdownMenuItem>
                 </DropdownMenuContent>
               </DropdownMenu>
               <Link


### PR DESCRIPTION
## 변경 사항
- 데스크탑 Header 비로그인 ⋮ 메뉴에 개인정보처리방침/이용약관 링크 추가
- 기존 테마·피드백 항목 아래 구분선 후 배치

## 테스트 방법
- [ ] 비로그인 상태로 데스크탑에서 우측 상단 ⋮ 클릭
- [ ] 드롭다운에 개인정보처리방침, 이용약관 항목 확인
- [ ] 각 링크 클릭 시 해당 페이지로 이동 확인