### PR TITLE
feat: 프로필 카드 클릭 시 계정 관리 페이지로 이동

### DIFF
--- a/src/app/(main)/profile/page.tsx
+++ b/src/app/(main)/profile/page.tsx
@@ -91,13 +91,6 @@ export default async function ProfilePage() {
         </div>
       </section>
 
-      <Link
-        href="/account"
-        className="w-full cursor-pointer rounded-lg border border-border bg-surface px-4 py-3 text-center text-sm font-medium text-text-primary transition-colors hover:bg-bg"
-      >
-        계정 관리
-      </Link>
-
       <LogoutButton />
     </div>
   )

--- a/src/components/profile/ProfileCard.tsx
+++ b/src/components/profile/ProfileCard.tsx
@@ -1,3 +1,5 @@
+import Link from 'next/link'
+
 interface ProfileCardProps {
   name: string | null
   email: string | null
@@ -6,7 +8,10 @@ interface ProfileCardProps {
 
 export function ProfileCard({ name, email, image }: ProfileCardProps) {
   return (
-    <div className="flex items-center gap-4 rounded-xl bg-surface px-5 py-6">
+    <Link
+      href="/account"
+      className="flex items-center gap-4 rounded-xl bg-surface px-5 py-6 transition-colors hover:bg-bg"
+    >
       <div className="flex size-16 flex-shrink-0 items-center justify-center overflow-hidden rounded-full bg-border">
         {image ? (
           // eslint-disable-next-line @next/next/no-img-element
@@ -15,10 +20,25 @@ export function ProfileCard({ name, email, image }: ProfileCardProps) {
           <span className="text-xl font-medium text-text-secondary">{name?.[0] ?? '?'}</span>
         )}
       </div>
-      <div className="min-w-0">
+      <div className="min-w-0 flex-1">
         <p className="truncate text-base font-semibold text-text-primary">{name ?? '이름 없음'}</p>
         {email && <p className="truncate text-sm text-text-secondary">{email}</p>}
       </div>
-    </div>
+      <svg
+        width="16"
+        height="16"
+        viewBox="0 0 16 16"
+        fill="none"
+        className="flex-shrink-0 text-text-secondary"
+      >
+        <path
+          d="M6 4l4 4-4 4"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+    </Link>
   )
 }


### PR DESCRIPTION
## 변경 사항
- ProfileCard를 /account 링크로 변환
- hover 배경색 + 우측 chevron 아이콘 추가하여 클릭 가능함 시각화

## 테스트 방법
- [ ] 로그인 후 프로필 탭 → 상단 프로필 카드 클릭 → 계정 관리 페이지 이동 확인
- [ ] hover 시 배경색 변화 및 chevron 표시 확인