### PR TITLE
fix: release-please target-branch main으로 수정

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,3 +19,4 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          target-branch: main


### PR DESCRIPTION
## 변경 사항
- `release-please.yml`에 `target-branch: main` 명시
- 기존에는 워크플로우 트리거 브랜치(develop)가 타겟으로 사용되어 PR #98이 develop을 타겟으로 잘못 생성됨