### PR TITLE
feat: 로스터리/원두 소프트 삭제·숨기기·폐업 기능

### DIFF
--- a/prisma/migrations/20260429120740_add_roastery_bean_status_fields/migration.sql
+++ b/prisma/migrations/20260429120740_add_roastery_bean_status_fields/migration.sql
@@ -1,0 +1,14 @@
+-- AlterTable
+ALTER TABLE "Bean" ADD COLUMN     "deletedAt" TIMESTAMP(3),
+ADD COLUMN     "hidden" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "Roastery" ADD COLUMN     "closedAt" TIMESTAMP(3),
+ADD COLUMN     "deletedAt" TIMESTAMP(3),
+ADD COLUMN     "hidden" BOOLEAN NOT NULL DEFAULT false;
+
+-- CreateIndex
+CREATE INDEX "Bean_deletedAt_idx" ON "Bean"("deletedAt");
+
+-- CreateIndex
+CREATE INDEX "Roastery_deletedAt_idx" ON "Roastery"("deletedAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -53,6 +53,9 @@ model Roastery {
   createdAt             DateTime                  @default(now())
   isOnboardingCandidate Boolean                   @default(false)
   address               String?
+  closedAt              DateTime?
+  hidden                Boolean                   @default(false)
+  deletedAt             DateTime?
   beans                 Bean[]
   bookmarks             Bookmark[]
   featuredIn            FeaturedSectionRoastery[]
@@ -64,6 +67,7 @@ model Roastery {
   @@index([priceRange])
   @@index([decaf])
   @@index([name])
+  @@index([deletedAt])
 }
 
 model Tag {
@@ -97,10 +101,13 @@ model Bean {
   cupNotes      String[]
   imageUrl      String?
   createdAt     DateTime           @default(now())
+  hidden        Boolean            @default(false)
+  deletedAt     DateTime?
   roastery      Roastery           @relation(fields: [roasteryId], references: [id], onDelete: Cascade)
   channelPrices BeanChannelPrice[]
 
   @@index([roasteryId])
+  @@index([deletedAt])
 }
 
 model ChannelDefinition {

--- a/src/actions/admin.ts
+++ b/src/actions/admin.ts
@@ -292,6 +292,121 @@ export async function updateBean(
   }
 }
 
+// ── 로스터리 상태 변경 ───────────────────────────────────
+
+export async function softDeleteRoastery(id: string): Promise<ActionResult<void>> {
+  const check = await requireAdmin()
+  if ('error' in check) return { success: false, error: check.error, code: check.code }
+  try {
+    await prisma.roastery.update({
+      where: { id },
+      data: { deletedAt: new Date(), isOnboardingCandidate: false },
+    })
+    revalidatePath('/admin/roasteries')
+    return { success: true, data: undefined }
+  } catch {
+    return { success: false, error: '삭제 중 오류가 발생했습니다', code: 'DB_ERROR' }
+  }
+}
+
+export async function restoreRoastery(id: string): Promise<ActionResult<void>> {
+  const check = await requireAdmin()
+  if ('error' in check) return { success: false, error: check.error, code: check.code }
+  try {
+    await prisma.roastery.update({ where: { id }, data: { deletedAt: null } })
+    revalidatePath('/admin/roasteries')
+    return { success: true, data: undefined }
+  } catch {
+    return { success: false, error: '복원 중 오류가 발생했습니다', code: 'DB_ERROR' }
+  }
+}
+
+export async function toggleHideRoastery(id: string): Promise<ActionResult<void>> {
+  const check = await requireAdmin()
+  if ('error' in check) return { success: false, error: check.error, code: check.code }
+  try {
+    const current = await prisma.roastery.findUnique({ where: { id }, select: { hidden: true } })
+    if (!current)
+      return { success: false, error: '존재하지 않는 로스터리입니다', code: 'VALIDATION' }
+    const hide = !current.hidden
+    await prisma.roastery.update({
+      where: { id },
+      data: { hidden: hide, ...(hide && { isOnboardingCandidate: false }) },
+    })
+    revalidatePath('/admin/roasteries')
+    return { success: true, data: undefined }
+  } catch {
+    return { success: false, error: '저장 중 오류가 발생했습니다', code: 'DB_ERROR' }
+  }
+}
+
+export async function closeRoastery(id: string): Promise<ActionResult<void>> {
+  const check = await requireAdmin()
+  if ('error' in check) return { success: false, error: check.error, code: check.code }
+  try {
+    await prisma.roastery.update({
+      where: { id },
+      data: { closedAt: new Date(), isOnboardingCandidate: false },
+    })
+    revalidatePath('/admin/roasteries')
+    return { success: true, data: undefined }
+  } catch {
+    return { success: false, error: '저장 중 오류가 발생했습니다', code: 'DB_ERROR' }
+  }
+}
+
+export async function reopenRoastery(id: string): Promise<ActionResult<void>> {
+  const check = await requireAdmin()
+  if ('error' in check) return { success: false, error: check.error, code: check.code }
+  try {
+    await prisma.roastery.update({ where: { id }, data: { closedAt: null } })
+    revalidatePath('/admin/roasteries')
+    return { success: true, data: undefined }
+  } catch {
+    return { success: false, error: '저장 중 오류가 발생했습니다', code: 'DB_ERROR' }
+  }
+}
+
+// ── 원두 상태 변경 ───────────────────────────────────────
+
+export async function softDeleteBean(id: string): Promise<ActionResult<void>> {
+  const check = await requireAdmin()
+  if ('error' in check) return { success: false, error: check.error, code: check.code }
+  try {
+    await prisma.bean.update({ where: { id }, data: { deletedAt: new Date() } })
+    revalidatePath('/admin/roasteries')
+    return { success: true, data: undefined }
+  } catch {
+    return { success: false, error: '삭제 중 오류가 발생했습니다', code: 'DB_ERROR' }
+  }
+}
+
+export async function restoreBean(id: string): Promise<ActionResult<void>> {
+  const check = await requireAdmin()
+  if ('error' in check) return { success: false, error: check.error, code: check.code }
+  try {
+    await prisma.bean.update({ where: { id }, data: { deletedAt: null } })
+    revalidatePath('/admin/roasteries')
+    return { success: true, data: undefined }
+  } catch {
+    return { success: false, error: '복원 중 오류가 발생했습니다', code: 'DB_ERROR' }
+  }
+}
+
+export async function toggleHideBean(id: string): Promise<ActionResult<void>> {
+  const check = await requireAdmin()
+  if ('error' in check) return { success: false, error: check.error, code: check.code }
+  try {
+    const current = await prisma.bean.findUnique({ where: { id }, select: { hidden: true } })
+    if (!current) return { success: false, error: '존재하지 않는 원두입니다', code: 'VALIDATION' }
+    await prisma.bean.update({ where: { id }, data: { hidden: !current.hidden } })
+    revalidatePath('/admin/roasteries')
+    return { success: true, data: undefined }
+  } catch {
+    return { success: false, error: '저장 중 오류가 발생했습니다', code: 'DB_ERROR' }
+  }
+}
+
 // ── 로스터리 단건 조회 (admin 전용) ─────────────────────
 export async function getAdminRoastery(id: string) {
   const check = await requireAdmin()
@@ -311,6 +426,9 @@ export async function getAdminRoastery(id: string) {
       decaf: true,
       imageUrl: true,
       isOnboardingCandidate: true,
+      closedAt: true,
+      hidden: true,
+      deletedAt: true,
       channels: {
         select: { id: true, channelKey: true, url: true },
         orderBy: { createdAt: 'asc' },
@@ -360,6 +478,9 @@ export async function getAdminRoasteries() {
       decaf: true,
       isOnboardingCandidate: true,
       createdAt: true,
+      closedAt: true,
+      hidden: true,
+      deletedAt: true,
       _count: { select: { beans: true } },
     },
     orderBy: { createdAt: 'desc' },
@@ -380,6 +501,8 @@ export async function getAdminBeans() {
       decaf: true,
       origins: true,
       createdAt: true,
+      hidden: true,
+      deletedAt: true,
       roastery: { select: { id: true, name: true } },
     },
     orderBy: { createdAt: 'desc' },
@@ -400,6 +523,8 @@ export async function getAdminRoasteryBeans(roasteryId: string) {
       decaf: true,
       origins: true,
       createdAt: true,
+      hidden: true,
+      deletedAt: true,
     },
     orderBy: { createdAt: 'desc' },
   })

--- a/src/app/(auth)/onboarding/page.tsx
+++ b/src/app/(auth)/onboarding/page.tsx
@@ -13,7 +13,7 @@ export default async function OnboardingPage() {
   if (existing) redirect('/')
 
   const roasteries = await prisma.roastery.findMany({
-    where: { isOnboardingCandidate: true },
+    where: { isOnboardingCandidate: true, deletedAt: null, hidden: false, closedAt: null },
     select: {
       id: true,
       name: true,

--- a/src/app/admin/roasteries/[id]/page.tsx
+++ b/src/app/admin/roasteries/[id]/page.tsx
@@ -2,6 +2,8 @@ import Link from 'next/link'
 import { notFound, redirect } from 'next/navigation'
 import { auth } from '@/lib/auth'
 import { getAdminRoastery, getAdminRoasteryBeans } from '@/actions/admin'
+import { RoasteryStatusButtons } from '@/components/admin/RoasteryStatusButtons'
+import { BeanStatusButton } from '@/components/admin/BeanStatusButton'
 
 const PRICE_RANGE_LABEL: Record<string, string> = {
   LOW: '2만원 미만',
@@ -29,27 +31,49 @@ export default async function RoasteryDetailPage({ params }: Props) {
   if (!roastery) notFound()
 
   const primaryRegion = roastery.tags.find((t) => t.category === 'REGION')?.name ?? '—'
+  const isDeleted = roastery.deletedAt !== null
+  const isClosed = roastery.closedAt !== null
+  const isHidden = roastery.hidden
 
   return (
     <div className="flex flex-col gap-8">
       {/* 헤더 */}
-      <div className="flex items-center gap-3">
+      <div className="flex items-center gap-3 flex-wrap">
         <Link href="/admin/roasteries" className="text-sm text-text-sub hover:text-text">
           ← 목록
         </Link>
         <h1 className="text-2xl font-bold text-text">{roastery.name}</h1>
+        {isDeleted && (
+          <span className="rounded px-2 py-0.5 text-xs bg-red-100 text-red-700">삭제됨</span>
+        )}
+        {!isDeleted && isClosed && (
+          <span className="rounded px-2 py-0.5 text-xs bg-amber-100 text-amber-700">폐업</span>
+        )}
+        {!isDeleted && !isClosed && isHidden && (
+          <span className="rounded px-2 py-0.5 text-xs bg-gray-100 text-gray-600">숨김</span>
+        )}
       </div>
 
       {/* 로스터리 정보 카드 */}
       <div className="rounded-xl border border-border bg-surface p-6">
-        <div className="mb-4 flex items-center justify-between">
+        <div className="mb-4 flex items-center justify-between flex-wrap gap-2">
           <h2 className="text-base font-semibold text-text">로스터리 정보</h2>
-          <Link
-            href={`/admin/roasteries/${id}/edit`}
-            className="rounded-lg border border-border px-3 py-1.5 text-xs text-text-sub hover:text-text transition-colors"
-          >
-            수정
-          </Link>
+          <div className="flex items-center gap-3">
+            {!isDeleted && (
+              <Link
+                href={`/admin/roasteries/${id}/edit`}
+                className="rounded-lg border border-border px-3 py-1.5 text-xs text-text-sub hover:text-text transition-colors"
+              >
+                수정
+              </Link>
+            )}
+            <RoasteryStatusButtons
+              roasteryId={id}
+              deletedAt={roastery.deletedAt}
+              hidden={roastery.hidden}
+              closedAt={roastery.closedAt}
+            />
+          </div>
         </div>
         <dl className="grid gap-2 text-sm sm:grid-cols-2">
           <div className="flex gap-2">
@@ -81,12 +105,14 @@ export default async function RoasteryDetailPage({ params }: Props) {
       <div>
         <div className="mb-4 flex items-center justify-between">
           <h2 className="text-lg font-semibold text-text">원두 목록 ({beans.length})</h2>
-          <Link
-            href={`/admin/roasteries/${id}/beans/new`}
-            className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90 transition-opacity"
-          >
-            + 새 원두
-          </Link>
+          {!isDeleted && (
+            <Link
+              href={`/admin/roasteries/${id}/beans/new`}
+              className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90 transition-opacity"
+            >
+              + 새 원두
+            </Link>
+          )}
         </div>
 
         {beans.length === 0 ? (
@@ -100,28 +126,58 @@ export default async function RoasteryDetailPage({ params }: Props) {
                   <th className="px-4 py-3 text-left font-medium text-text-sub">로스팅</th>
                   <th className="px-4 py-3 text-left font-medium text-text-sub">원산지</th>
                   <th className="px-4 py-3 text-left font-medium text-text-sub">디카페인</th>
+                  <th className="px-4 py-3 text-left font-medium text-text-sub">상태</th>
                   <th className="px-4 py-3 text-left font-medium text-text-sub"></th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-border bg-surface">
-                {beans.map((b) => (
-                  <tr key={b.id} className="hover:bg-surface-sub transition-colors">
-                    <td className="px-4 py-3 font-medium text-text">{b.name}</td>
-                    <td className="px-4 py-3 text-text-sub">
-                      {ROASTING_LEVEL_LABEL[b.roastingLevel] ?? b.roastingLevel}
-                    </td>
-                    <td className="px-4 py-3 text-text-sub">{b.origins.join(', ') || '—'}</td>
-                    <td className="px-4 py-3 text-text-sub">{b.decaf ? 'O' : '—'}</td>
-                    <td className="px-4 py-3">
-                      <Link
-                        href={`/admin/roasteries/${id}/beans/${b.id}/edit`}
-                        className="text-xs text-text-sub hover:text-text transition-colors"
-                      >
-                        수정
-                      </Link>
-                    </td>
-                  </tr>
-                ))}
+                {beans.map((b) => {
+                  const beanDeleted = b.deletedAt !== null
+                  const beanHidden = b.hidden
+                  return (
+                    <tr
+                      key={b.id}
+                      className={`transition-colors ${beanDeleted ? 'opacity-50' : 'hover:bg-surface-sub'}`}
+                    >
+                      <td className="px-4 py-3 font-medium text-text">{b.name}</td>
+                      <td className="px-4 py-3 text-text-sub">
+                        {ROASTING_LEVEL_LABEL[b.roastingLevel] ?? b.roastingLevel}
+                      </td>
+                      <td className="px-4 py-3 text-text-sub">{b.origins.join(', ') || '—'}</td>
+                      <td className="px-4 py-3 text-text-sub">{b.decaf ? 'O' : '—'}</td>
+                      <td className="px-4 py-3">
+                        {beanDeleted ? (
+                          <span className="rounded px-1.5 py-0.5 text-xs bg-red-100 text-red-700">
+                            삭제됨
+                          </span>
+                        ) : beanHidden ? (
+                          <span className="rounded px-1.5 py-0.5 text-xs bg-gray-100 text-gray-600">
+                            숨김
+                          </span>
+                        ) : (
+                          <span className="text-xs text-text-sub">활성</span>
+                        )}
+                      </td>
+                      <td className="px-4 py-3">
+                        <div className="flex items-center gap-2">
+                          {!beanDeleted && (
+                            <Link
+                              href={`/admin/roasteries/${id}/beans/${b.id}/edit`}
+                              className="text-xs text-text-sub hover:text-text transition-colors"
+                            >
+                              수정
+                            </Link>
+                          )}
+                          <BeanStatusButton
+                            beanId={b.id}
+                            deletedAt={b.deletedAt}
+                            hidden={b.hidden}
+                          />
+                        </div>
+                      </td>
+                    </tr>
+                  )
+                })}
               </tbody>
             </table>
           </div>

--- a/src/app/admin/roasteries/page.tsx
+++ b/src/app/admin/roasteries/page.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 import { getAdminRoasteries } from '@/actions/admin'
+import { RoasteryStatusButtons } from '@/components/admin/RoasteryStatusButtons'
 
 const PRICE_RANGE_LABEL: Record<string, string> = {
   LOW: '2만원 미만',
@@ -35,37 +36,79 @@ export default async function AdminRoasteriesPage() {
                 <th className="px-4 py-3 text-left font-medium text-text-sub">디카페인</th>
                 <th className="px-4 py-3 text-left font-medium text-text-sub">원두 수</th>
                 <th className="px-4 py-3 text-left font-medium text-text-sub">Q5 노출</th>
+                <th className="px-4 py-3 text-left font-medium text-text-sub">상태</th>
                 <th className="px-4 py-3 text-left font-medium text-text-sub"></th>
               </tr>
             </thead>
             <tbody className="divide-y divide-border bg-surface">
-              {roasteries.map((r) => (
-                <tr key={r.id} className="hover:bg-surface-sub transition-colors">
-                  <td className="px-4 py-3 font-medium text-text">
-                    <Link
-                      href={`/admin/roasteries/${r.id}`}
-                      className="hover:text-primary transition-colors"
-                    >
-                      {r.name}
-                    </Link>
-                  </td>
-                  <td className="px-4 py-3 text-text-sub">
-                    {r.tags.find((t) => t.category === 'REGION')?.name ?? '—'}
-                  </td>
-                  <td className="px-4 py-3 text-text-sub">{PRICE_RANGE_LABEL[r.priceRange]}</td>
-                  <td className="px-4 py-3 text-text-sub">{r.decaf ? 'O' : '—'}</td>
-                  <td className="px-4 py-3 text-text-sub">{r._count.beans}</td>
-                  <td className="px-4 py-3 text-text-sub">{r.isOnboardingCandidate ? 'O' : '—'}</td>
-                  <td className="px-4 py-3">
-                    <Link
-                      href={`/admin/roasteries/${r.id}/edit`}
-                      className="text-xs text-text-sub hover:text-text transition-colors"
-                    >
-                      수정
-                    </Link>
-                  </td>
-                </tr>
-              ))}
+              {roasteries.map((r) => {
+                const isDeleted = r.deletedAt !== null
+                const isClosed = r.closedAt !== null
+                const isHidden = r.hidden
+
+                return (
+                  <tr
+                    key={r.id}
+                    className={`transition-colors ${isDeleted ? 'opacity-50' : 'hover:bg-surface-sub'}`}
+                  >
+                    <td className="px-4 py-3 font-medium text-text">
+                      <Link
+                        href={`/admin/roasteries/${r.id}`}
+                        className="hover:text-primary transition-colors"
+                      >
+                        {r.name}
+                      </Link>
+                    </td>
+                    <td className="px-4 py-3 text-text-sub">
+                      {r.tags.find((t) => t.category === 'REGION')?.name ?? '—'}
+                    </td>
+                    <td className="px-4 py-3 text-text-sub">{PRICE_RANGE_LABEL[r.priceRange]}</td>
+                    <td className="px-4 py-3 text-text-sub">{r.decaf ? 'O' : '—'}</td>
+                    <td className="px-4 py-3 text-text-sub">{r._count.beans}</td>
+                    <td className="px-4 py-3 text-text-sub">
+                      {r.isOnboardingCandidate ? 'O' : '—'}
+                    </td>
+                    <td className="px-4 py-3">
+                      {isDeleted && (
+                        <span className="rounded px-1.5 py-0.5 text-xs bg-red-100 text-red-700">
+                          삭제됨
+                        </span>
+                      )}
+                      {!isDeleted && isClosed && (
+                        <span className="rounded px-1.5 py-0.5 text-xs bg-amber-100 text-amber-700">
+                          폐업
+                        </span>
+                      )}
+                      {!isDeleted && !isClosed && isHidden && (
+                        <span className="rounded px-1.5 py-0.5 text-xs bg-gray-100 text-gray-600">
+                          숨김
+                        </span>
+                      )}
+                      {!isDeleted && !isClosed && !isHidden && (
+                        <span className="text-xs text-text-sub">활성</span>
+                      )}
+                    </td>
+                    <td className="px-4 py-3">
+                      <div className="flex items-center gap-3">
+                        {!isDeleted && (
+                          <Link
+                            href={`/admin/roasteries/${r.id}/edit`}
+                            className="text-xs text-text-sub hover:text-text transition-colors"
+                          >
+                            수정
+                          </Link>
+                        )}
+                        <RoasteryStatusButtons
+                          roasteryId={r.id}
+                          deletedAt={r.deletedAt}
+                          hidden={r.hidden}
+                          closedAt={r.closedAt}
+                        />
+                      </div>
+                    </td>
+                  </tr>
+                )
+              })}
             </tbody>
           </table>
         </div>

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -5,6 +5,7 @@ const BASE_URL = process.env.NEXT_PUBLIC_APP_URL ?? 'https://rocommend.com'
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const roasteries = await prisma.roastery.findMany({
+    where: { deletedAt: null, hidden: false },
     select: { id: true },
   })
 

--- a/src/components/admin/BeanStatusButton.tsx
+++ b/src/components/admin/BeanStatusButton.tsx
@@ -1,0 +1,57 @@
+'use client'
+
+import { useTransition } from 'react'
+import { softDeleteBean, restoreBean, toggleHideBean } from '@/actions/admin'
+
+interface Props {
+  beanId: string
+  deletedAt: Date | null
+  hidden: boolean
+}
+
+export function BeanStatusButton({ beanId, deletedAt, hidden }: Props) {
+  const [isPending, startTransition] = useTransition()
+
+  const run = (action: () => Promise<unknown>) => {
+    startTransition(async () => {
+      await action()
+    })
+  }
+
+  if (deletedAt) {
+    return (
+      <button
+        type="button"
+        disabled={isPending}
+        onClick={() => run(() => restoreBean(beanId))}
+        className="text-xs text-blue-600 hover:underline disabled:opacity-50 cursor-pointer"
+      >
+        복원
+      </button>
+    )
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <button
+        type="button"
+        disabled={isPending}
+        onClick={() => run(() => toggleHideBean(beanId))}
+        className="text-xs text-text-sub hover:text-text disabled:opacity-50 cursor-pointer transition-colors"
+      >
+        {hidden ? '숨기기 해제' : '숨기기'}
+      </button>
+      <button
+        type="button"
+        disabled={isPending}
+        onClick={() => {
+          if (!confirm('이 원두를 삭제하시겠습니까?')) return
+          run(() => softDeleteBean(beanId))
+        }}
+        className="text-xs text-destructive hover:underline disabled:opacity-50 cursor-pointer"
+      >
+        삭제
+      </button>
+    </div>
+  )
+}

--- a/src/components/admin/RoasteryStatusButtons.tsx
+++ b/src/components/admin/RoasteryStatusButtons.tsx
@@ -1,0 +1,84 @@
+'use client'
+
+import { useTransition } from 'react'
+import {
+  softDeleteRoastery,
+  restoreRoastery,
+  toggleHideRoastery,
+  closeRoastery,
+  reopenRoastery,
+} from '@/actions/admin'
+
+interface Props {
+  roasteryId: string
+  deletedAt: Date | null
+  hidden: boolean
+  closedAt: Date | null
+}
+
+export function RoasteryStatusButtons({ roasteryId, deletedAt, hidden, closedAt }: Props) {
+  const [isPending, startTransition] = useTransition()
+
+  const run = (action: () => Promise<unknown>) => {
+    startTransition(async () => {
+      await action()
+    })
+  }
+
+  if (deletedAt) {
+    return (
+      <button
+        type="button"
+        disabled={isPending}
+        onClick={() => run(() => restoreRoastery(roasteryId))}
+        className="text-xs text-blue-600 hover:underline disabled:opacity-50 cursor-pointer"
+      >
+        복원
+      </button>
+    )
+  }
+
+  return (
+    <div className="flex items-center gap-3">
+      <button
+        type="button"
+        disabled={isPending}
+        onClick={() => run(() => toggleHideRoastery(roasteryId))}
+        className="text-xs text-text-sub hover:text-text disabled:opacity-50 cursor-pointer transition-colors"
+      >
+        {hidden ? '숨기기 해제' : '숨기기'}
+      </button>
+      {closedAt ? (
+        <button
+          type="button"
+          disabled={isPending}
+          onClick={() => run(() => reopenRoastery(roasteryId))}
+          className="text-xs text-text-sub hover:text-text disabled:opacity-50 cursor-pointer transition-colors"
+        >
+          재개업
+        </button>
+      ) : (
+        <button
+          type="button"
+          disabled={isPending}
+          onClick={() => run(() => closeRoastery(roasteryId))}
+          className="text-xs text-amber-600 hover:underline disabled:opacity-50 cursor-pointer"
+        >
+          폐업
+        </button>
+      )}
+      <button
+        type="button"
+        disabled={isPending}
+        onClick={() => {
+          if (!confirm('소프트 삭제하면 일반 사용자에게 완전히 숨겨집니다. 계속하시겠습니까?'))
+            return
+          run(() => softDeleteRoastery(roasteryId))
+        }}
+        className="text-xs text-destructive hover:underline disabled:opacity-50 cursor-pointer"
+      >
+        삭제
+      </button>
+    </div>
+  )
+}

--- a/src/components/bookmark/BookmarkList.tsx
+++ b/src/components/bookmark/BookmarkList.tsx
@@ -51,34 +51,60 @@ export function BookmarkList({ bookmarks, initialSort }: BookmarkListProps) {
       {/* 목록 */}
       <ul className="flex flex-col divide-y divide-border">
         {sorted.map((item) => (
-          <li key={item.id} className="flex items-center gap-4 py-4">
-            <Link
-              href={`/roasteries/${item.roasteryId}`}
-              className="flex flex-1 flex-col gap-1 min-w-0"
-            >
-              <span className="font-medium truncate">{item.roastery.name}</span>
-              <span className="text-sm text-muted-foreground">
-                <RegionDisplay regions={getRegions(item.roastery.tags)} />
-              </span>
-              <div className="flex items-center gap-2 flex-wrap">
-                <Badge variant="outline" className="text-xs">
-                  {PRICE_RANGE_LABELS[item.roastery.priceRange]}
-                </Badge>
-                {item.roastery.decaf && (
-                  <Badge variant="secondary" className="text-xs">
-                    디카페인
-                  </Badge>
-                )}
+          <li
+            key={item.id}
+            className={`flex items-center gap-4 py-4 ${item.isUnavailable ? 'opacity-50' : ''}`}
+          >
+            {item.isUnavailable ? (
+              <div className="flex flex-1 flex-col gap-1 min-w-0">
+                <span className="font-medium truncate text-muted-foreground">
+                  {item.roastery.name}
+                </span>
+                <span className="text-xs text-muted-foreground">
+                  더 이상 이용할 수 없는 로스터리입니다
+                </span>
               </div>
-            </Link>
+            ) : (
+              <Link
+                href={`/roasteries/${item.roasteryId}`}
+                className="flex flex-1 flex-col gap-1 min-w-0"
+              >
+                <div className="flex items-center gap-2">
+                  <span className="font-medium truncate">{item.roastery.name}</span>
+                  {item.isClosed && (
+                    <Badge
+                      variant="outline"
+                      className="text-xs shrink-0 text-amber-700 border-amber-300 bg-amber-50"
+                    >
+                      폐업
+                    </Badge>
+                  )}
+                </div>
+                <span className="text-sm text-muted-foreground">
+                  <RegionDisplay regions={getRegions(item.roastery.tags)} />
+                </span>
+                <div className="flex items-center gap-2 flex-wrap">
+                  <Badge variant="outline" className="text-xs">
+                    {PRICE_RANGE_LABELS[item.roastery.priceRange]}
+                  </Badge>
+                  {item.roastery.decaf && (
+                    <Badge variant="secondary" className="text-xs">
+                      디카페인
+                    </Badge>
+                  )}
+                </div>
+              </Link>
+            )}
 
             <div className="flex items-center gap-3 shrink-0">
-              <div className="text-sm flex items-center gap-1">
-                <RatingDisplay
-                  avgRating={item.roastery.avgRating}
-                  ratingCount={item.roastery.ratingCount}
-                />
-              </div>
+              {!item.isUnavailable && (
+                <div className="text-sm flex items-center gap-1">
+                  <RatingDisplay
+                    avgRating={item.roastery.avgRating}
+                    ratingCount={item.roastery.ratingCount}
+                  />
+                </div>
+              )}
               {item.myRating !== null && (
                 <span className="text-xs text-muted-foreground">내 평가 {item.myRating}점</span>
               )}

--- a/src/components/roastery/RoasteryDetail.tsx
+++ b/src/components/roastery/RoasteryDetail.tsx
@@ -47,7 +47,17 @@ export function RoasteryDetail({
           </div>
           <div className="flex flex-col gap-1.5 flex-1 min-w-0">
             <div className="flex items-start justify-between gap-2">
-              <h1 className="text-2xl font-semibold leading-tight">{roastery.name}</h1>
+              <div className="flex items-center gap-2 flex-wrap">
+                <h1 className="text-2xl font-semibold leading-tight">{roastery.name}</h1>
+                {roastery.closedAt && (
+                  <Badge
+                    variant="outline"
+                    className="text-xs text-amber-700 border-amber-300 bg-amber-50"
+                  >
+                    폐업
+                  </Badge>
+                )}
+              </div>
               {isLoggedIn && (
                 <BookmarkButton roasteryId={roastery.id} initialIsBookmarked={isBookmarked} />
               )}

--- a/src/lib/queries/bookmark.ts
+++ b/src/lib/queries/bookmark.ts
@@ -35,6 +35,9 @@ export async function getBookmarks(
             decaf: true,
             imageUrl: true,
             website: true,
+            closedAt: true,
+            deletedAt: true,
+            hidden: true,
             _count: { select: { ratings: true } },
           },
         },
@@ -64,6 +67,8 @@ export async function getBookmarks(
       avgRating: avgMap.get(b.roasteryId) ?? null,
     },
     myRating: myRatingMap.get(b.roasteryId) ?? null,
+    isClosed: b.roastery.closedAt !== null,
+    isUnavailable: b.roastery.deletedAt !== null || b.roastery.hidden,
   }))
 
   if (sort === 'myRating') {

--- a/src/lib/queries/recommendation.ts
+++ b/src/lib/queries/recommendation.ts
@@ -22,6 +22,9 @@ export async function getPopularRoasteries(
   preferredPriceRanges?: PriceRange[]
 ): Promise<RoasteryWithStats[]> {
   const where = {
+    deletedAt: null,
+    hidden: false,
+    closedAt: null,
     ...(userId && { ratings: { none: { userId } } }),
     ...(preferredPriceRanges?.length && { priceRange: { in: preferredPriceRanges } }),
   }
@@ -85,6 +88,7 @@ export async function getFeaturedSections(): Promise<FeaturedSectionData[]> {
         title: true,
         type: true,
         roasteries: {
+          where: { roastery: { deletedAt: null, hidden: false, closedAt: null } },
           orderBy: { order: 'asc' },
           select: {
             roastery: {
@@ -137,7 +141,7 @@ export interface StoredRecommendation {
 export async function getStoredRecommendations(userId: string): Promise<StoredRecommendation[]> {
   const [recs, avgRatings, userRatings] = await Promise.all([
     prisma.recommendation.findMany({
-      where: { userId },
+      where: { userId, roastery: { deletedAt: null, hidden: false, closedAt: null } },
       include: {
         roastery: {
           select: {

--- a/src/lib/queries/roastery.ts
+++ b/src/lib/queries/roastery.ts
@@ -44,6 +44,9 @@ export async function getRoasteries(
   }
 
   const where: Prisma.RoasteryWhereInput = {
+    deletedAt: null,
+    hidden: false,
+    closedAt: null,
     ...(filter.price.length > 0 && { priceRange: { in: filter.price } }),
     ...(filter.decaf && { decaf: true }),
     ...(filter.q && { name: { contains: filter.q, mode: 'insensitive' as const } }),
@@ -127,12 +130,13 @@ function flattenChannels(
 export async function getRoasteryById(id: string): Promise<RoasteryDetail | null> {
   const [roastery, avgRating] = await Promise.all([
     prisma.roastery.findUnique({
-      where: { id },
+      where: { id, deletedAt: null, hidden: false },
       select: {
         id: true,
         name: true,
         description: true,
         address: true,
+        closedAt: true,
         tags: TAG_SELECT,
         priceRange: true,
         decaf: true,
@@ -142,6 +146,7 @@ export async function getRoasteryById(id: string): Promise<RoasteryDetail | null
           ...CHANNEL_SELECT,
         },
         beans: {
+          where: { deletedAt: null, hidden: false },
           select: {
             id: true,
             name: true,
@@ -202,6 +207,7 @@ export async function getRoasteryById(id: string): Promise<RoasteryDetail | null
 
   return {
     ...roastery,
+    closedAt: roastery.closedAt,
     tags: flattenTags(roastery.tags),
     ratingCount: roastery._count.ratings,
     avgRating: avgRating._avg.score ?? null,

--- a/src/types/bookmark.ts
+++ b/src/types/bookmark.ts
@@ -5,6 +5,8 @@ export interface BookmarkWithRoastery {
   roasteryId: string
   roastery: RoasteryWithStats
   myRating: number | null
+  isClosed: boolean
+  isUnavailable: boolean
 }
 
 export type BookmarkSort = 'name' | 'myRating'

--- a/src/types/roastery.ts
+++ b/src/types/roastery.ts
@@ -71,6 +71,7 @@ export interface BeanWithDetails {
 
 export interface RoasteryDetail extends RoasteryWithStats {
   address: string | null
+  closedAt: Date | null
   beans: BeanWithDetails[]
   channels: ChannelWithPrice[] // 원두 미선택 시 또는 가격 없는 로스터리의 기본 채널 목록
 }


### PR DESCRIPTION
## 변경 사항

### DB 스키마
- `Roastery`: `closedAt`(폐업), `hidden`(숨기기), `deletedAt`(소프트 삭제) 필드 추가
- `Bean`: `hidden`, `deletedAt` 필드 추가

### 사용자 데이터 처리 설계
- **폐업(closedAt)**: 상세 페이지 접근 가능, 목록/검색/추천 제외, 별점 데이터 유지
- **숨기기(hidden)**: 모든 public 페이지에서 완전 숨김
- **소프트 삭제(deletedAt)**: 모든 public 페이지에서 완전 숨김, admin에서 복원 가능

### Admin
- 로스터리: 목록/상세에 상태 배지(활성/폐업/숨김/삭제됨) + 액션 버튼
- 원두: 테이블에 상태 배지 + 액션 버튼
- 폐업/숨기기/삭제 시 `isOnboardingCandidate` 자동 false 처리
- 소프트 삭제 시 confirm 다이얼로그, 복원 버튼 제공

### 사용자 화면
- 로스터리 상세: 폐업 시 이름 옆 "폐업" amber 배지
- 즐겨찾기 목록: 폐업 로스터리 "폐업" 배지, 삭제/숨김 로스터리 "더 이상 이용할 수 없는 로스터리" 안내

### Public 쿼리 필터
- 목록/검색/추천/인기/피처드 섹션/온보딩에서 삭제·숨김·폐업 로스터리 제외
- 로스터리 상세 페이지: 삭제·숨김만 404, 폐업은 접근 가능
- 원두: 상세 페이지에서 삭제·숨김 원두 제외
- Sitemap: 삭제·숨김 제외(폐업은 URL 유지)

## 테스트 방법
- [ ] admin > 로스터리 목록에서 폐업/숨기기/삭제/복원 버튼 동작 확인
- [ ] admin > 원두 상세에서 숨기기/삭제/복원 버튼 동작 확인
- [ ] 폐업 처리 후 로스터리 목록에서 제외되는지 확인
- [ ] 폐업 처리 후 상세 페이지 접근 시 "폐업" 배지 표시 확인
- [ ] 폐업 로스터리 북마크 시 즐겨찾기에 "폐업" 배지 표시 확인
- [ ] 삭제 처리 후 즐겨찾기에 "더 이상 이용할 수 없는 로스터리" 표시 확인