### PR TITLE
feat: 컵노트 조합 닉네임 자동 생성

### DIFF
--- a/prisma/migrations/20260430060000_add_user_nickname/migration.sql
+++ b/prisma/migrations/20260430060000_add_user_nickname/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN "nickname" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_nickname_key" ON "User"("nickname");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,6 +10,7 @@ model User {
   id                   String           @id @default(cuid())
   email                String?          @unique
   name                 String?
+  nickname             String?  @unique
   image                String?
   createdAt            DateTime         @default(now())
   preferences          Json?

--- a/src/components/rating/RatingListItem.tsx
+++ b/src/components/rating/RatingListItem.tsx
@@ -40,7 +40,7 @@ interface RatingListItemProps {
 export function RatingListItem({ item, isLoggedIn }: RatingListItemProps) {
   const [reportOpen, setReportOpen] = useState(false)
 
-  const displayName = item.user.name ?? '익명'
+  const displayName = item.user.nickname ?? '익명'
   const date = new Intl.DateTimeFormat('ko-KR', {
     year: 'numeric',
     month: 'short',

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -2,6 +2,7 @@ import NextAuth from 'next-auth'
 import { PrismaAdapter } from '@auth/prisma-adapter'
 import { prisma } from '@/lib/prisma'
 import { authConfig } from '@/lib/auth.config'
+import { generateUniqueNickname } from '@/lib/nickname'
 import '@/types/auth'
 
 // Node.js 전용 (Server Components, API Routes, Server Actions)
@@ -28,6 +29,18 @@ export const { handlers, auth, signIn, signOut, unstable_update } = NextAuth({
         const existingProvider = existing.accounts[0].provider
         if (existingProvider !== account.provider) {
           return `/login?error=OAuthAccountNotLinked&provider=${existingProvider}`
+        }
+      }
+
+      // 닉네임 미배정 유저에게 자동 배정
+      if (user.id) {
+        const dbUser = await prisma.user.findUnique({
+          where: { id: user.id },
+          select: { nickname: true },
+        })
+        if (dbUser && !dbUser.nickname) {
+          const nickname = await generateUniqueNickname()
+          await prisma.user.update({ where: { id: user.id }, data: { nickname } })
         }
       }
 

--- a/src/lib/nickname.ts
+++ b/src/lib/nickname.ts
@@ -1,0 +1,71 @@
+import { prisma } from '@/lib/prisma'
+
+const FRONT_WORDS = [
+  '블루베리',
+  '레몬',
+  '초콜릿',
+  '캐러멜',
+  '복숭아',
+  '딸기',
+  '바닐라',
+  '자두',
+  '오렌지',
+  '망고',
+  '체리',
+  '크랜베리',
+  '패션후르츠',
+  '사과',
+  '자몽',
+  '라임',
+  '파인애플',
+  '살구',
+  '장미',
+  '라벤더',
+  '히비스커스',
+  '아몬드',
+  '시나몬',
+  '헤이즐넛',
+  '메이플',
+]
+
+const BACK_WORDS = [
+  '재스민',
+  '허니',
+  '다크초콜릿',
+  '버터스카치',
+  '흑당',
+  '마카다미아',
+  '피칸',
+  '코코넛',
+  '리치',
+  '수박',
+  '멜론',
+  '카모마일',
+  '얼그레이',
+  '민트',
+  '토피',
+  '마멀레이드',
+  '브라운슈가',
+  '진저',
+  '유자',
+  '로즈힙',
+  '흑설탕',
+  '계피',
+  '생강',
+  '대추',
+  '매실',
+]
+
+function pick<T>(arr: T[]): T {
+  return arr[Math.floor(Math.random() * arr.length)]
+}
+
+export async function generateUniqueNickname(): Promise<string> {
+  for (let i = 0; i < 10; i++) {
+    const candidate = pick(FRONT_WORDS) + pick(BACK_WORDS)
+    const exists = await prisma.user.findUnique({ where: { nickname: candidate } })
+    if (!exists) return candidate
+  }
+  // 10회 실패 시 타임스탬프 접미사로 보장
+  return pick(FRONT_WORDS) + pick(BACK_WORDS) + Date.now().toString().slice(-4)
+}

--- a/src/lib/queries/rating.ts
+++ b/src/lib/queries/rating.ts
@@ -31,7 +31,7 @@ export async function getRoasteryRatings(input: {
       score: true,
       comment: true,
       updatedAt: true,
-      user: { select: { name: true, image: true } },
+      user: { select: { nickname: true, image: true } },
       reports: {
         where: { userId: currentUserId ?? '' },
         select: { id: true },

--- a/src/types/rating.ts
+++ b/src/types/rating.ts
@@ -5,7 +5,7 @@ export interface RatingListItem {
   score: number
   comment: string
   updatedAt: Date
-  user: { name: string | null; image: string | null }
+  user: { nickname: string | null; image: string | null }
   isOwnRating: boolean
   hasReported: boolean
 }


### PR DESCRIPTION
## 변경 사항
- 회원가입(첫 로그인) 시 컵노트 2단어 조합 닉네임 자동 배정
- 앞 단어 풀 25개 / 뒤 단어 풀 25개 분리 → 625가지 조합
- DB 중복 체크 + 재시도(최대 10회) 방식으로 고유성 보장
- 한줄평에 실명(name) 대신 nickname 표시

## 테스트 방법
- [ ] 로그인 후 DB에서 User.nickname이 배정됐는지 확인
- [ ] 한줄평 목록에서 닉네임이 표시되는지 확인 (예: `블루베리허니`)
- [ ] 기존 유저 재로그인 시 닉네임이 새로 배정되는지 확인