### PR TITLE
feat: 닉네임 온보딩 단계 및 계정 페이지 변경 기능 추가

### DIFF
--- a/src/actions/user.ts
+++ b/src/actions/user.ts
@@ -67,7 +67,7 @@ export async function updateNickname(input: { nickname: string }): Promise<Actio
 
   const available = await checkNicknameAvailable(parsed.data.nickname)
   if (!available) {
-    return { success: false, error: '이미 사용 중인 닉네임입니다', code: 'CONFLICT' }
+    return { success: false, error: '이미 사용 중인 닉네임입니다', code: 'DUPLICATE' }
   }
 
   try {

--- a/src/actions/user.ts
+++ b/src/actions/user.ts
@@ -11,6 +11,14 @@ const nameSchema = z.object({
   name: z.string().min(1, '이름을 입력해주세요').max(20, '20자 이내로 입력해주세요').trim(),
 })
 
+const nicknameSchema = z.object({
+  nickname: z
+    .string()
+    .min(2, '닉네임은 2자 이상이어야 합니다')
+    .max(20, '20자 이내로 입력해주세요')
+    .trim(),
+})
+
 export async function updateName(input: { name: string }): Promise<ActionResult> {
   const session = await auth()
   if (!session?.user?.id) {
@@ -26,6 +34,46 @@ export async function updateName(input: { name: string }): Promise<ActionResult>
     await prisma.user.update({
       where: { id: session.user.id },
       data: { name: parsed.data.name },
+    })
+  } catch {
+    return { success: false, error: '저장 중 오류가 발생했습니다.', code: 'DB_ERROR' }
+  }
+
+  revalidatePath('/account')
+  return { success: true }
+}
+
+export async function checkNicknameAvailable(nickname: string): Promise<boolean> {
+  const session = await auth()
+  if (!session?.user?.id) return false
+
+  const existing = await prisma.user.findUnique({
+    where: { nickname: nickname.trim() },
+    select: { id: true },
+  })
+  return !existing || existing.id === session.user.id
+}
+
+export async function updateNickname(input: { nickname: string }): Promise<ActionResult> {
+  const session = await auth()
+  if (!session?.user?.id) {
+    return { success: false, error: '로그인이 필요합니다', code: 'UNAUTHORIZED' }
+  }
+
+  const parsed = nicknameSchema.safeParse(input)
+  if (!parsed.success) {
+    return { success: false, error: parsed.error.issues[0].message, code: 'VALIDATION' }
+  }
+
+  const available = await checkNicknameAvailable(parsed.data.nickname)
+  if (!available) {
+    return { success: false, error: '이미 사용 중인 닉네임입니다', code: 'CONFLICT' }
+  }
+
+  try {
+    await prisma.user.update({
+      where: { id: session.user.id },
+      data: { nickname: parsed.data.nickname },
     })
   } catch {
     return { success: false, error: '저장 중 오류가 발생했습니다.', code: 'DB_ERROR' }

--- a/src/app/(auth)/onboarding/page.tsx
+++ b/src/app/(auth)/onboarding/page.tsx
@@ -6,10 +6,16 @@ import { OnboardingWizard } from '@/components/onboarding/OnboardingWizard'
 
 export default async function OnboardingPage() {
   const session = await auth()
-  const existing = await prisma.onboarding.findUnique({
-    where: { userId: session!.user.id },
-    select: { id: true },
-  })
+  const [existing, user] = await Promise.all([
+    prisma.onboarding.findUnique({
+      where: { userId: session!.user.id },
+      select: { id: true },
+    }),
+    prisma.user.findUnique({
+      where: { id: session!.user.id },
+      select: { nickname: true },
+    }),
+  ])
   if (existing) redirect('/')
 
   const roasteries = await prisma.roastery.findMany({
@@ -32,7 +38,10 @@ export default async function OnboardingPage() {
           맞춤 로스터리 추천을 위해 취향을 알려주세요
         </p>
       </div>
-      <OnboardingWizard roasteries={roasteries.map((r) => ({ ...r, tags: flattenTags(r.tags) }))} />
+      <OnboardingWizard
+        initialNickname={user?.nickname ?? ''}
+        roasteries={roasteries.map((r) => ({ ...r, tags: flattenTags(r.tags) }))}
+      />
     </div>
   )
 }

--- a/src/app/(main)/account/page.tsx
+++ b/src/app/(main)/account/page.tsx
@@ -2,6 +2,7 @@ import { redirect } from 'next/navigation'
 import { auth } from '@/lib/auth'
 import { prisma } from '@/lib/prisma'
 import { NameEditForm } from '@/components/account/NameEditForm'
+import { NicknameEditForm } from '@/components/account/NicknameEditForm'
 import { AvatarUpload } from '@/components/account/AvatarUpload'
 import { DeleteAccountDialog } from '@/components/profile/DeleteAccountDialog'
 
@@ -11,7 +12,7 @@ export default async function AccountPage() {
 
   const user = await prisma.user.findUnique({
     where: { id: session.user.id },
-    select: { name: true, image: true },
+    select: { name: true, nickname: true, image: true },
   })
 
   return (
@@ -22,6 +23,7 @@ export default async function AccountPage() {
         <h2 className="text-sm font-semibold text-text-primary">프로필 정보</h2>
         <AvatarUpload currentImage={user?.image ?? null} name={user?.name ?? null} />
         <NameEditForm currentName={user?.name ?? null} />
+        <NicknameEditForm currentNickname={user?.nickname ?? null} />
       </section>
 
       <section className="flex flex-col gap-4 rounded-xl bg-surface px-5 py-6">

--- a/src/components/account/NicknameEditForm.tsx
+++ b/src/components/account/NicknameEditForm.tsx
@@ -1,0 +1,93 @@
+'use client'
+
+import { useState, useRef, useTransition } from 'react'
+import { useRouter } from 'next/navigation'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { checkNicknameAvailable, updateNickname } from '@/actions/user'
+
+interface NicknameEditFormProps {
+  currentNickname: string | null
+}
+
+export function NicknameEditForm({ currentNickname }: NicknameEditFormProps) {
+  const [nickname, setNickname] = useState(currentNickname ?? '')
+  const [checking, setChecking] = useState(false)
+  const [available, setAvailable] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [saved, setSaved] = useState(false)
+  const [isPending, startTransition] = useTransition()
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const router = useRouter()
+
+  const isDirty = nickname.trim() !== (currentNickname ?? '')
+
+  function handleChange(val: string) {
+    setNickname(val)
+    setSaved(false)
+    setError(null)
+
+    const trimmed = val.trim()
+    if (trimmed === (currentNickname ?? '') || trimmed.length < 2) {
+      setAvailable(true)
+      setChecking(false)
+      if (debounceRef.current) clearTimeout(debounceRef.current)
+      return
+    }
+
+    setChecking(true)
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    debounceRef.current = setTimeout(async () => {
+      const ok = await checkNicknameAvailable(trimmed)
+      setAvailable(ok)
+      setChecking(false)
+    }, 400)
+  }
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+    setSaved(false)
+    startTransition(async () => {
+      const result = await updateNickname({ nickname })
+      if (result.success) {
+        setSaved(true)
+        router.refresh()
+      } else {
+        setError(result.error)
+      }
+    })
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-3">
+      <label className="text-sm font-medium text-text-primary">닉네임</label>
+      <div className="flex gap-2">
+        <Input
+          value={nickname}
+          onChange={(e) => handleChange(e.target.value)}
+          placeholder="닉네임을 입력하세요"
+          maxLength={20}
+          className="flex-1"
+        />
+        <Button
+          type="submit"
+          disabled={isPending || !isDirty || checking || !available || nickname.trim().length < 2}
+          className="shrink-0"
+        >
+          {isPending ? '저장 중...' : '저장'}
+        </Button>
+      </div>
+      <p className="text-xs h-4">
+        {checking && <span className="text-text-secondary">확인 중...</span>}
+        {!checking && isDirty && nickname.trim().length >= 2 && (
+          <span className={available ? 'text-success' : 'text-error'}>
+            {available ? '사용할 수 있는 닉네임이에요' : '이미 사용 중인 닉네임이에요'}
+          </span>
+        )}
+        {error && <span className="text-error">{error}</span>}
+        {saved && <span className="text-success">저장됐습니다.</span>}
+      </p>
+    </form>
+  )
+}

--- a/src/components/onboarding/OnboardingWizard.test.tsx
+++ b/src/components/onboarding/OnboardingWizard.test.tsx
@@ -4,12 +4,18 @@ import userEvent from '@testing-library/user-event'
 import { OnboardingWizard } from './OnboardingWizard'
 
 const mockSubmitOnboarding = vi.hoisted(() => vi.fn())
+const mockCheckNicknameAvailable = vi.hoisted(() => vi.fn())
+const mockUpdateNickname = vi.hoisted(() => vi.fn())
 const mockToast = vi.hoisted(() => ({
   success: vi.fn(),
   error: vi.fn(),
 }))
 
 vi.mock('@/actions/onboarding', () => ({ submitOnboarding: mockSubmitOnboarding }))
+vi.mock('@/actions/user', () => ({
+  checkNicknameAvailable: mockCheckNicknameAvailable,
+  updateNickname: mockUpdateNickname,
+}))
 vi.mock('sonner', () => ({ toast: mockToast }))
 
 const roasteries = [
@@ -30,23 +36,39 @@ const roasteries = [
   },
 ]
 
+const INITIAL_NICKNAME = '블루베리허니'
+
+async function passQ0() {
+  await userEvent.click(screen.getByRole('button', { name: '다음' }))
+}
+
 describe('OnboardingWizard', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    // submitOnboarding은 성공 시 redirect를 호출하므로 never return을 모방
     mockSubmitOnboarding.mockResolvedValue(undefined)
+    mockUpdateNickname.mockResolvedValue({ success: true })
+    mockCheckNicknameAvailable.mockResolvedValue(true)
   })
 
-  // C-20: 초기 렌더 → Q1 표시
-  it('C-20: 초기 렌더 시 Q1 브루잉 방법 질문이 표시된다', () => {
-    render(<OnboardingWizard roasteries={roasteries} />)
+  // C-20: 초기 렌더 → Q0(닉네임) 표시
+  it('C-20: 초기 렌더 시 닉네임 설정 화면이 표시된다', () => {
+    render(<OnboardingWizard initialNickname={INITIAL_NICKNAME} roasteries={roasteries} />)
+    expect(screen.getByText(/닉네임을 정해볼까요/i)).toBeInTheDocument()
+    expect(screen.getByText('1 / 6')).toBeInTheDocument()
+  })
+
+  // C-20b: Q0 다음 → Q1 표시
+  it('C-20b: Q0에서 다음을 누르면 Q1 브루잉 방법 질문이 표시된다', async () => {
+    render(<OnboardingWizard initialNickname={INITIAL_NICKNAME} roasteries={roasteries} />)
+    await passQ0()
     expect(screen.getByText(/어떤 방법으로 커피를 즐기시나요/i)).toBeInTheDocument()
-    expect(screen.getByText('1 / 5')).toBeInTheDocument()
+    expect(screen.getByText('2 / 6')).toBeInTheDocument()
   })
 
   // C-21: Q1 선택 → 다음 버튼 활성화
   it('C-21: Q1에서 항목을 선택하면 다음 버튼이 활성화된다', async () => {
-    render(<OnboardingWizard roasteries={roasteries} />)
+    render(<OnboardingWizard initialNickname={INITIAL_NICKNAME} roasteries={roasteries} />)
+    await passQ0()
     const nextButton = screen.getByRole('button', { name: '다음' })
     expect(nextButton).toBeDisabled()
 
@@ -54,9 +76,11 @@ describe('OnboardingWizard', () => {
     expect(nextButton).toBeEnabled()
   })
 
-  // C-22: Q4=FIRST_TIME → Q5 스킵, 진행바 "4/4"
-  it('C-22: Q4에서 FIRST_TIME을 선택하면 총 4단계가 되고 "완료 및 제출" 버튼이 표시된다', async () => {
-    render(<OnboardingWizard roasteries={roasteries} />)
+  // C-22: Q4=FIRST_TIME → Q5 스킵, 진행바 "5/5"
+  it('C-22: Q4에서 FIRST_TIME을 선택하면 총 5단계가 되고 "완료 및 제출" 버튼이 표시된다', async () => {
+    render(<OnboardingWizard initialNickname={INITIAL_NICKNAME} roasteries={roasteries} />)
+
+    await passQ0()
 
     // Q1
     await userEvent.click(screen.getByRole('button', { name: '에스프레소 머신' }))
@@ -73,39 +97,35 @@ describe('OnboardingWizard', () => {
     // Q4 - FIRST_TIME 선택
     await userEvent.click(screen.getByRole('button', { name: '처음 구매해보려고요' }))
 
-    // 진행바 "4/4"
-    expect(screen.getByText('4 / 4')).toBeInTheDocument()
-    // "완료 및 제출" 버튼
+    expect(screen.getByText('5 / 5')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: '완료 및 제출' })).toBeInTheDocument()
   })
 
-  // C-23: Q4≠FIRST_TIME → Q5 표시, 진행바 "5/5"
+  // C-23: Q4≠FIRST_TIME → Q5 표시, 진행바 "6/6"
   it('C-23: Q4에서 FIRST_TIME 외를 선택하고 다음으로 넘어가면 Q5가 표시된다', async () => {
-    render(<OnboardingWizard roasteries={roasteries} />)
+    render(<OnboardingWizard initialNickname={INITIAL_NICKNAME} roasteries={roasteries} />)
 
-    // Q1
+    await passQ0()
+
     await userEvent.click(screen.getByRole('button', { name: '에스프레소 머신' }))
     await userEvent.click(screen.getByRole('button', { name: '다음' }))
-    // Q2
     await userEvent.click(screen.getByRole('button', { name: '주로 온라인' }))
     await userEvent.click(screen.getByRole('button', { name: '다음' }))
-    // Q3
     await userEvent.click(screen.getByRole('button', { name: '크게 신경 안 써요' }))
     await userEvent.click(screen.getByRole('button', { name: '다음' }))
-    // Q4 - MONTHLY
     await userEvent.click(screen.getByRole('button', { name: '한 달에 한 번' }))
     await userEvent.click(screen.getByRole('button', { name: '다음' }))
 
-    // Q5
-    expect(screen.getByText('5 / 5')).toBeInTheDocument()
+    expect(screen.getByText('6 / 6')).toBeInTheDocument()
     expect(screen.getByText(/좋아하는 로스터리/i)).toBeInTheDocument()
   })
 
   // C-24: Q5 3개 미만 → 제출 버튼 비활성
   it('C-24: Q5에서 3개 미만 선택 시 제출 버튼이 비활성 상태다', async () => {
-    render(<OnboardingWizard roasteries={roasteries} />)
+    render(<OnboardingWizard initialNickname={INITIAL_NICKNAME} roasteries={roasteries} />)
 
-    // Q1~Q4 통과
+    await passQ0()
+
     await userEvent.click(screen.getByRole('button', { name: '에스프레소 머신' }))
     await userEvent.click(screen.getByRole('button', { name: '다음' }))
     await userEvent.click(screen.getByRole('button', { name: '주로 온라인' }))
@@ -118,12 +138,10 @@ describe('OnboardingWizard', () => {
     const submitButton = screen.getByRole('button', { name: '완료 및 제출' })
     expect(submitButton).toBeDisabled()
 
-    // 2개 선택
     await userEvent.click(screen.getByText('블루보틀'))
     await userEvent.click(screen.getByText('프리츠'))
     expect(submitButton).toBeDisabled()
 
-    // 3개 선택 → 활성화
     await userEvent.click(screen.getByText('센터커피'))
     await waitFor(() => expect(submitButton).toBeEnabled())
   })

--- a/src/components/onboarding/OnboardingWizard.tsx
+++ b/src/components/onboarding/OnboardingWizard.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import { signOut } from 'next-auth/react'
 import { toast } from 'sonner'
 import { ProgressBar } from './ProgressBar'
+import { Q0Nickname } from './steps/Q0Nickname'
 import { Q1BrewingMethod } from './steps/Q1BrewingMethod'
 import { Q2PurchaseStyle } from './steps/Q2PurchaseStyle'
 import { Q3PriceRange } from './steps/Q3PriceRange'
@@ -18,7 +19,7 @@ import type {
   OnboardingAnswers,
 } from '@/types/onboarding'
 
-type Step = 'Q1' | 'Q2' | 'Q3' | 'Q4' | 'Q5'
+type Step = 'Q0' | 'Q1' | 'Q2' | 'Q3' | 'Q4' | 'Q5'
 
 interface Roastery {
   id: string
@@ -27,11 +28,12 @@ interface Roastery {
 }
 
 interface OnboardingWizardProps {
+  initialNickname: string
   roasteries: Roastery[]
 }
 
-export function OnboardingWizard({ roasteries }: OnboardingWizardProps) {
-  const [step, setStep] = useState<Step>('Q1')
+export function OnboardingWizard({ initialNickname, roasteries }: OnboardingWizardProps) {
+  const [step, setStep] = useState<Step>('Q0')
   const [q1, setQ1] = useState<BrewingMethod[]>([])
   const [q2, setQ2] = useState<PurchaseStyle | null>(null)
   const [q3, setQ3] = useState<OnboardingPriceRange[]>([])
@@ -40,8 +42,8 @@ export function OnboardingWizard({ roasteries }: OnboardingWizardProps) {
   const [isLoading, setIsLoading] = useState(false)
 
   const isFirstTime = q4 === 'FIRST_TIME'
-  const totalSteps = isFirstTime ? 4 : 5
-  const currentStep = ['Q1', 'Q2', 'Q3', 'Q4', 'Q5'].indexOf(step) + 1
+  const totalSteps = isFirstTime ? 5 : 6
+  const currentStep = ['Q0', 'Q1', 'Q2', 'Q3', 'Q4', 'Q5'].indexOf(step) + 1
 
   async function handleSubmit(answers: OnboardingAnswers) {
     setIsLoading(true)
@@ -57,6 +59,15 @@ export function OnboardingWizard({ roasteries }: OnboardingWizardProps) {
       }
       setIsLoading(false)
     }
+  }
+
+  if (step === 'Q0') {
+    return (
+      <div className="space-y-6">
+        <ProgressBar current={currentStep} total={totalSteps} />
+        <Q0Nickname initialNickname={initialNickname} onNext={() => setStep('Q1')} />
+      </div>
+    )
   }
 
   if (step === 'Q1') {

--- a/src/components/onboarding/steps/Q0Nickname.tsx
+++ b/src/components/onboarding/steps/Q0Nickname.tsx
@@ -1,0 +1,96 @@
+'use client'
+
+import { useState, useRef } from 'react'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { checkNicknameAvailable, updateNickname } from '@/actions/user'
+
+interface Q0NicknameProps {
+  initialNickname: string
+  onNext: () => void
+}
+
+export function Q0Nickname({ initialNickname, onNext }: Q0NicknameProps) {
+  const [nickname, setNickname] = useState(initialNickname)
+  const [checking, setChecking] = useState(false)
+  const [available, setAvailable] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [isSaving, setIsSaving] = useState(false)
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  function handleChange(val: string) {
+    setNickname(val)
+    setError(null)
+
+    const trimmed = val.trim()
+    if (trimmed === initialNickname || trimmed.length < 2) {
+      setAvailable(true)
+      setChecking(false)
+      if (debounceRef.current) clearTimeout(debounceRef.current)
+      return
+    }
+
+    setChecking(true)
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    debounceRef.current = setTimeout(async () => {
+      const ok = await checkNicknameAvailable(trimmed)
+      setAvailable(ok)
+      setChecking(false)
+    }, 400)
+  }
+
+  async function handleNext() {
+    const trimmed = nickname.trim()
+    if (!trimmed || !available) return
+
+    setError(null)
+    setIsSaving(true)
+
+    if (trimmed !== initialNickname) {
+      const result = await updateNickname({ nickname: trimmed })
+      if (!result.success) {
+        setError(result.error)
+        setIsSaving(false)
+        return
+      }
+    }
+
+    onNext()
+  }
+
+  const isDisabled = isSaving || checking || !available || nickname.trim().length < 2
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-xl font-semibold text-text-primary">닉네임을 정해볼까요?</h2>
+        <p className="mt-1 text-sm text-text-secondary">
+          커피 향미에서 영감을 받은 닉네임이에요. 원하시면 바꿀 수 있어요.
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <Input
+          value={nickname}
+          onChange={(e) => handleChange(e.target.value)}
+          placeholder="닉네임을 입력하세요"
+          maxLength={20}
+          className="text-base"
+        />
+        <p className="text-xs h-4">
+          {checking && <span className="text-text-secondary">확인 중...</span>}
+          {!checking && nickname.trim().length >= 2 && nickname.trim() !== initialNickname && (
+            <span className={available ? 'text-success' : 'text-error'}>
+              {available ? '사용할 수 있는 닉네임이에요' : '이미 사용 중인 닉네임이에요'}
+            </span>
+          )}
+          {error && <span className="text-error">{error}</span>}
+        </p>
+      </div>
+
+      <Button className="w-full" size="lg" onClick={handleNext} disabled={isDisabled}>
+        {isSaving ? '저장 중...' : '다음'}
+      </Button>
+    </div>
+  )
+}


### PR DESCRIPTION
## 변경 사항
- 온보딩 첫 단계(Q0)에 닉네임 설정 화면 추가 (자동 생성값 기본, 실시간 중복 확인)
- 계정 페이지에 닉네임 변경 폼 추가
- checkNicknameAvailable, updateNickname Server Action 추가

## 테스트 방법
- [ ] 신규 가입 → 온보딩 첫 화면에서 닉네임 확인/변경 가능한지 확인
- [ ] 이미 사용 중인 닉네임 입력 시 에러 메시지 표시 확인
- [ ] 계정 관리 페이지에서 닉네임 변경 가능한지 확인