### PR TITLE
feat: 온보딩 Q0 프로필 사진 + 닉네임 기본값 보장

### DIFF
--- a/src/app/(auth)/onboarding/page.tsx
+++ b/src/app/(auth)/onboarding/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from 'next/navigation'
 import { auth } from '@/lib/auth'
 import { prisma } from '@/lib/prisma'
+import { generateUniqueNickname } from '@/lib/nickname'
 import { flattenTags } from '@/types/roastery'
 import { OnboardingWizard } from '@/components/onboarding/OnboardingWizard'
 
@@ -13,10 +14,17 @@ export default async function OnboardingPage() {
     }),
     prisma.user.findUnique({
       where: { id: session!.user.id },
-      select: { nickname: true },
+      select: { nickname: true, image: true, name: true },
     }),
   ])
   if (existing) redirect('/')
+
+  // signIn 콜백 미실행 등으로 닉네임이 없는 경우 여기서 보완
+  let nickname = user?.nickname ?? null
+  if (!nickname) {
+    nickname = await generateUniqueNickname()
+    await prisma.user.update({ where: { id: session!.user.id }, data: { nickname } })
+  }
 
   const roasteries = await prisma.roastery.findMany({
     where: { isOnboardingCandidate: true, deletedAt: null, hidden: false, closedAt: null },
@@ -39,7 +47,9 @@ export default async function OnboardingPage() {
         </p>
       </div>
       <OnboardingWizard
-        initialNickname={user?.nickname ?? ''}
+        initialNickname={nickname}
+        currentImage={user?.image ?? null}
+        name={user?.name ?? null}
         roasteries={roasteries.map((r) => ({ ...r, tags: flattenTags(r.tags) }))}
       />
     </div>

--- a/src/components/onboarding/OnboardingWizard.test.tsx
+++ b/src/components/onboarding/OnboardingWizard.test.tsx
@@ -17,6 +17,9 @@ vi.mock('@/actions/user', () => ({
   updateNickname: mockUpdateNickname,
 }))
 vi.mock('sonner', () => ({ toast: mockToast }))
+vi.mock('next-auth/react', () => ({ useSession: () => ({ update: vi.fn() }), signOut: vi.fn() }))
+vi.mock('next/navigation', () => ({ useRouter: () => ({ refresh: vi.fn() }) }))
+vi.mock('@/actions/upload', () => ({ uploadAvatar: vi.fn() }))
 
 const roasteries = [
   {
@@ -52,14 +55,28 @@ describe('OnboardingWizard', () => {
 
   // C-20: 초기 렌더 → Q0(닉네임) 표시
   it('C-20: 초기 렌더 시 닉네임 설정 화면이 표시된다', () => {
-    render(<OnboardingWizard initialNickname={INITIAL_NICKNAME} roasteries={roasteries} />)
-    expect(screen.getByText(/닉네임을 정해볼까요/i)).toBeInTheDocument()
+    render(
+      <OnboardingWizard
+        initialNickname={INITIAL_NICKNAME}
+        currentImage={null}
+        name={null}
+        roasteries={roasteries}
+      />
+    )
+    expect(screen.getByText(/프로필을 설정해볼까요/i)).toBeInTheDocument()
     expect(screen.getByText('1 / 6')).toBeInTheDocument()
   })
 
   // C-20b: Q0 다음 → Q1 표시
   it('C-20b: Q0에서 다음을 누르면 Q1 브루잉 방법 질문이 표시된다', async () => {
-    render(<OnboardingWizard initialNickname={INITIAL_NICKNAME} roasteries={roasteries} />)
+    render(
+      <OnboardingWizard
+        initialNickname={INITIAL_NICKNAME}
+        currentImage={null}
+        name={null}
+        roasteries={roasteries}
+      />
+    )
     await passQ0()
     expect(screen.getByText(/어떤 방법으로 커피를 즐기시나요/i)).toBeInTheDocument()
     expect(screen.getByText('2 / 6')).toBeInTheDocument()
@@ -67,7 +84,14 @@ describe('OnboardingWizard', () => {
 
   // C-21: Q1 선택 → 다음 버튼 활성화
   it('C-21: Q1에서 항목을 선택하면 다음 버튼이 활성화된다', async () => {
-    render(<OnboardingWizard initialNickname={INITIAL_NICKNAME} roasteries={roasteries} />)
+    render(
+      <OnboardingWizard
+        initialNickname={INITIAL_NICKNAME}
+        currentImage={null}
+        name={null}
+        roasteries={roasteries}
+      />
+    )
     await passQ0()
     const nextButton = screen.getByRole('button', { name: '다음' })
     expect(nextButton).toBeDisabled()
@@ -78,7 +102,14 @@ describe('OnboardingWizard', () => {
 
   // C-22: Q4=FIRST_TIME → Q5 스킵, 진행바 "5/5"
   it('C-22: Q4에서 FIRST_TIME을 선택하면 총 5단계가 되고 "완료 및 제출" 버튼이 표시된다', async () => {
-    render(<OnboardingWizard initialNickname={INITIAL_NICKNAME} roasteries={roasteries} />)
+    render(
+      <OnboardingWizard
+        initialNickname={INITIAL_NICKNAME}
+        currentImage={null}
+        name={null}
+        roasteries={roasteries}
+      />
+    )
 
     await passQ0()
 
@@ -103,7 +134,14 @@ describe('OnboardingWizard', () => {
 
   // C-23: Q4≠FIRST_TIME → Q5 표시, 진행바 "6/6"
   it('C-23: Q4에서 FIRST_TIME 외를 선택하고 다음으로 넘어가면 Q5가 표시된다', async () => {
-    render(<OnboardingWizard initialNickname={INITIAL_NICKNAME} roasteries={roasteries} />)
+    render(
+      <OnboardingWizard
+        initialNickname={INITIAL_NICKNAME}
+        currentImage={null}
+        name={null}
+        roasteries={roasteries}
+      />
+    )
 
     await passQ0()
 
@@ -122,7 +160,14 @@ describe('OnboardingWizard', () => {
 
   // C-24: Q5 3개 미만 → 제출 버튼 비활성
   it('C-24: Q5에서 3개 미만 선택 시 제출 버튼이 비활성 상태다', async () => {
-    render(<OnboardingWizard initialNickname={INITIAL_NICKNAME} roasteries={roasteries} />)
+    render(
+      <OnboardingWizard
+        initialNickname={INITIAL_NICKNAME}
+        currentImage={null}
+        name={null}
+        roasteries={roasteries}
+      />
+    )
 
     await passQ0()
 

--- a/src/components/onboarding/OnboardingWizard.tsx
+++ b/src/components/onboarding/OnboardingWizard.tsx
@@ -29,10 +29,17 @@ interface Roastery {
 
 interface OnboardingWizardProps {
   initialNickname: string
+  currentImage: string | null
+  name: string | null
   roasteries: Roastery[]
 }
 
-export function OnboardingWizard({ initialNickname, roasteries }: OnboardingWizardProps) {
+export function OnboardingWizard({
+  initialNickname,
+  currentImage,
+  name,
+  roasteries,
+}: OnboardingWizardProps) {
   const [step, setStep] = useState<Step>('Q0')
   const [q1, setQ1] = useState<BrewingMethod[]>([])
   const [q2, setQ2] = useState<PurchaseStyle | null>(null)
@@ -65,7 +72,12 @@ export function OnboardingWizard({ initialNickname, roasteries }: OnboardingWiza
     return (
       <div className="space-y-6">
         <ProgressBar current={currentStep} total={totalSteps} />
-        <Q0Nickname initialNickname={initialNickname} onNext={() => setStep('Q1')} />
+        <Q0Nickname
+          initialNickname={initialNickname}
+          currentImage={currentImage}
+          name={name}
+          onNext={() => setStep('Q1')}
+        />
       </div>
     )
   }

--- a/src/components/onboarding/steps/Q0Nickname.tsx
+++ b/src/components/onboarding/steps/Q0Nickname.tsx
@@ -3,14 +3,17 @@
 import { useState, useRef } from 'react'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
+import { AvatarUpload } from '@/components/account/AvatarUpload'
 import { checkNicknameAvailable, updateNickname } from '@/actions/user'
 
 interface Q0NicknameProps {
   initialNickname: string
+  currentImage: string | null
+  name: string | null
   onNext: () => void
 }
 
-export function Q0Nickname({ initialNickname, onNext }: Q0NicknameProps) {
+export function Q0Nickname({ initialNickname, currentImage, name, onNext }: Q0NicknameProps) {
   const [nickname, setNickname] = useState(initialNickname)
   const [checking, setChecking] = useState(false)
   const [available, setAvailable] = useState(true)
@@ -63,13 +66,17 @@ export function Q0Nickname({ initialNickname, onNext }: Q0NicknameProps) {
   return (
     <div className="space-y-6">
       <div>
-        <h2 className="text-xl font-semibold text-text-primary">닉네임을 정해볼까요?</h2>
+        <h2 className="text-xl font-semibold text-text-primary">프로필을 설정해볼까요?</h2>
         <p className="mt-1 text-sm text-text-secondary">
-          커피 향미에서 영감을 받은 닉네임이에요. 원하시면 바꿀 수 있어요.
+          나중에 계정 설정에서 언제든 바꿀 수 있어요.
         </p>
       </div>
 
+      <AvatarUpload currentImage={currentImage} name={name} />
+
       <div className="flex flex-col gap-2">
+        <label className="text-sm font-medium text-text-primary">닉네임</label>
+        <p className="text-xs text-text-secondary">커피 향미에서 영감을 받은 닉네임이에요.</p>
         <Input
           value={nickname}
           onChange={(e) => handleChange(e.target.value)}


### PR DESCRIPTION
## 변경 사항
- 온보딩 Q0 화면: 상단 프로필 사진 변경, 하단 닉네임 입력 (자동 생성 기본값)
- 기존 로그인 상태 유저도 닉네임 null이면 온보딩 페이지에서 직접 생성·저장

## 테스트 방법
- [ ] 온보딩 진입 시 프로필 사진 변경 UI + 자동 생성 닉네임 기본값 표시 확인
- [ ] 닉네임 수정 후 다음 진행 확인