### PR TITLE
feat: 원두 그람 수 및 채널별 직접 구매 링크 지원

### DIFF
--- a/src/actions/admin.ts
+++ b/src/actions/admin.ts
@@ -126,6 +126,8 @@ export async function createRoastery(
 export interface BeanPriceInput {
   channelId: string
   price: number | null
+  sizeGrams?: number | null
+  sourceUrl?: string | null
 }
 
 export interface CreateBeanInput {
@@ -169,7 +171,12 @@ export async function createBean(input: CreateBeanInput): Promise<ActionResult<{
         cupNotes: input.cupNotes.map((n) => n.trim()).filter(Boolean),
         imageUrl: input.imageUrl.trim() || null,
         channelPrices: {
-          create: validPrices.map((p) => ({ channelId: p.channelId, price: p.price as number })),
+          create: validPrices.map((p) => ({
+            channelId: p.channelId,
+            price: p.price as number,
+            sizeGrams: p.sizeGrams ?? null,
+            sourceUrl: p.sourceUrl?.trim() || null,
+          })),
         },
       },
       select: { id: true },
@@ -281,7 +288,12 @@ export async function updateBean(
         imageUrl: input.imageUrl.trim() || null,
         channelPrices: {
           deleteMany: {},
-          create: validPrices.map((p) => ({ channelId: p.channelId, price: p.price as number })),
+          create: validPrices.map((p) => ({
+            channelId: p.channelId,
+            price: p.price as number,
+            sizeGrams: p.sizeGrams ?? null,
+            sourceUrl: p.sourceUrl?.trim() || null,
+          })),
         },
       },
       select: { id: true },
@@ -456,7 +468,7 @@ export async function getAdminBean(id: string) {
       cupNotes: true,
       imageUrl: true,
       channelPrices: {
-        select: { channelId: true, price: true },
+        select: { channelId: true, price: true, sizeGrams: true, sourceUrl: true },
       },
     },
   })

--- a/src/components/admin/BeanForm.tsx
+++ b/src/components/admin/BeanForm.tsx
@@ -32,7 +32,12 @@ interface BeanFormProps {
     decaf: boolean
     cupNotes: string[]
     imageUrl: string
-    prices?: { channelId: string; price: number }[]
+    prices?: {
+      channelId: string
+      price: number
+      sizeGrams?: number | null
+      sourceUrl?: string | null
+    }[]
   }
 }
 
@@ -75,10 +80,38 @@ export function BeanForm({
     return map
   })
 
+  // 채널별 그람 수: channelId → sizeGrams string
+  const [sizeGrams, setSizeGrams] = useState<Record<string, string>>(() => {
+    const map: Record<string, string> = {}
+    for (const ch of channels) {
+      const existing = initialData?.prices?.find((p) => p.channelId === ch.id)
+      map[ch.id] = existing?.sizeGrams != null ? String(existing.sizeGrams) : ''
+    }
+    return map
+  })
+
+  // 채널별 구매 링크: channelId → sourceUrl string
+  const [sourceUrls, setSourceUrls] = useState<Record<string, string>>(() => {
+    const map: Record<string, string> = {}
+    for (const ch of channels) {
+      const existing = initialData?.prices?.find((p) => p.channelId === ch.id)
+      map[ch.id] = existing?.sourceUrl ?? ''
+    }
+    return map
+  })
+
   const isEdit = !!beanId
 
   function handlePriceChange(channelId: string, value: string) {
     setPrices((prev) => ({ ...prev, [channelId]: value }))
+  }
+
+  function handleSizeGramsChange(channelId: string, value: string) {
+    setSizeGrams((prev) => ({ ...prev, [channelId]: value }))
+  }
+
+  function handleSourceUrlChange(channelId: string, value: string) {
+    setSourceUrls((prev) => ({ ...prev, [channelId]: value }))
   }
 
   function handleSubmit(e: React.FormEvent) {
@@ -88,6 +121,8 @@ export function BeanForm({
     const priceList = channels.map((ch) => ({
       channelId: ch.id,
       price: prices[ch.id] !== '' ? Number(prices[ch.id]) : null,
+      sizeGrams: sizeGrams[ch.id] !== '' ? Number(sizeGrams[ch.id]) : null,
+      sourceUrl: sourceUrls[ch.id]?.trim() || null,
     }))
 
     const input = {
@@ -190,22 +225,41 @@ export function BeanForm({
 
       {/* 채널별 가격 */}
       {channels.length > 0 && (
-        <div className="flex flex-col gap-2">
-          <label className="text-sm font-medium text-text">채널별 가격 (200g 기준, 원)</label>
-          <ul className="flex flex-col gap-2">
+        <div className="flex flex-col gap-3">
+          <label className="text-sm font-medium text-text">채널별 가격 및 구매 링크</label>
+          <ul className="flex flex-col gap-4">
             {channels.map((ch) => {
               const def = CHANNEL_DEFS.find((d) => d.key === ch.channelKey)
               const label = def?.label ?? ch.channelKey
               return (
-                <li key={ch.id} className="flex items-center gap-2">
-                  <span className="w-36 shrink-0 text-sm text-text-sub">{label}</span>
+                <li key={ch.id} className="flex flex-col gap-2 rounded-lg border border-border p-3">
+                  <span className="text-sm font-medium text-text">{label}</span>
+                  <div className="flex items-center gap-2">
+                    <input
+                      type="number"
+                      min={0}
+                      value={prices[ch.id] ?? ''}
+                      onChange={(e) => handlePriceChange(ch.id, e.target.value)}
+                      className="w-32 rounded-lg border border-border bg-surface px-3 py-2 text-sm text-text outline-none focus:ring-2 focus:ring-primary/30"
+                      placeholder="가격 (원)"
+                    />
+                    <span className="text-sm text-text-sub">/</span>
+                    <input
+                      type="number"
+                      min={1}
+                      value={sizeGrams[ch.id] ?? ''}
+                      onChange={(e) => handleSizeGramsChange(ch.id, e.target.value)}
+                      className="w-24 rounded-lg border border-border bg-surface px-3 py-2 text-sm text-text outline-none focus:ring-2 focus:ring-primary/30"
+                      placeholder="그람 (g)"
+                    />
+                    <span className="text-sm text-text-sub">g</span>
+                  </div>
                   <input
-                    type="number"
-                    min={0}
-                    value={prices[ch.id] ?? ''}
-                    onChange={(e) => handlePriceChange(ch.id, e.target.value)}
-                    className="w-36 rounded-lg border border-border bg-surface px-3 py-2 text-sm text-text outline-none focus:ring-2 focus:ring-primary/30"
-                    placeholder="예: 18000"
+                    type="url"
+                    value={sourceUrls[ch.id] ?? ''}
+                    onChange={(e) => handleSourceUrlChange(ch.id, e.target.value)}
+                    className="rounded-lg border border-border bg-surface px-3 py-2 text-sm text-text outline-none focus:ring-2 focus:ring-primary/30"
+                    placeholder="원두 직접 구매 링크 (선택)"
                   />
                 </li>
               )

--- a/src/components/roastery/BeanList.tsx
+++ b/src/components/roastery/BeanList.tsx
@@ -12,8 +12,9 @@ interface BeanListProps {
   roasteryId: string
 }
 
-function formatPrice(price: number): string {
-  return price.toLocaleString('ko-KR') + '원'
+function formatPrice(price: number, sizeGrams?: number | null): string {
+  const priceStr = price.toLocaleString('ko-KR') + '원'
+  return sizeGrams ? `${priceStr} / ${sizeGrams}g` : priceStr
 }
 
 export function BeanList({ beans, roasteryId }: BeanListProps) {
@@ -78,7 +79,7 @@ export function BeanList({ beans, roasteryId }: BeanListProps) {
                   </div>
                   {hasPurchase && primary.price !== null && (
                     <span className="text-sm font-medium shrink-0 tabular-nums">
-                      {formatPrice(primary.price)}
+                      {formatPrice(primary.price, primary.sizeGrams)}
                     </span>
                   )}
                 </div>
@@ -135,7 +136,7 @@ export function BeanList({ beans, roasteryId }: BeanListProps) {
                           <span className="text-foreground">{ch.label}</span>
                           {ch.price !== null ? (
                             <span className="text-muted-foreground text-xs tabular-nums">
-                              {formatPrice(ch.price)}
+                              {formatPrice(ch.price, ch.sizeGrams)}
                             </span>
                           ) : (
                             <span className="text-muted-foreground text-xs">→</span>

--- a/src/lib/queries/roastery.ts
+++ b/src/lib/queries/roastery.ts
@@ -158,6 +158,8 @@ export async function getRoasteryById(id: string): Promise<RoasteryDetail | null
             channelPrices: {
               select: {
                 price: true,
+                sizeGrams: true,
+                sourceUrl: true,
                 channel: CHANNEL_SELECT,
               },
             },
@@ -192,7 +194,21 @@ export async function getRoasteryById(id: string): Promise<RoasteryDetail | null
 
   // 원두별 채널 가격
   const beans: RoasteryDetail['beans'] = roastery.beans.map((bean) => {
-    const priceByChannelId = new Map(bean.channelPrices.map((bp) => [bp.channel.id, bp.price]))
+    const bpMap = new Map(bean.channelPrices.map((bp) => [bp.channel.id, bp]))
+    const channelPrices = roastery.channels
+      .filter((ch) => bpMap.has(ch.id))
+      .map((ch) => {
+        const bp = bpMap.get(ch.id)!
+        return {
+          channelId: ch.id,
+          channelKey: ch.channelKey,
+          label: ch.definition.label,
+          url: bp.sourceUrl ?? ch.url,
+          price: bp.price,
+          order: ch.definition.order,
+          sizeGrams: bp.sizeGrams ?? null,
+        }
+      })
     return {
       id: bean.id,
       name: bean.name,
@@ -201,7 +217,7 @@ export async function getRoasteryById(id: string): Promise<RoasteryDetail | null
       decaf: bean.decaf,
       cupNotes: bean.cupNotes,
       imageUrl: bean.imageUrl,
-      channelPrices: flattenChannels(roastery.channels, priceByChannelId),
+      channelPrices,
     }
   })
 

--- a/src/types/roastery.ts
+++ b/src/types/roastery.ts
@@ -49,6 +49,7 @@ export interface ChannelWithPrice {
   url: string
   price: number | null // null = 가격 없이 링크만 (언스페셜티 등)
   order: number
+  sizeGrams?: number | null
 }
 
 /** 채널 정렬: 가격 있는 것 오름차순 → 가격 없는 것 order 기준 */


### PR DESCRIPTION
## 변경 사항
- 어드민 원두 폼에 채널별 **그람 수(g)** 및 **원두 직접 구매 링크** 입력 필드 추가
- 원두 등록/수정 시 `sizeGrams`, `sourceUrl` 저장 (스키마에 이미 존재하는 필드 활용)
- 원두 상세 조회 시 `sourceUrl`이 있으면 채널 기본 URL 대신 원두별 URL 사용
- 사용자 화면(BeanList) 가격 옆에 그람 수 표시 (예: `18,000원 / 200g`)

## 테스트 방법
- [ ] 어드민에서 원두 수정 → 채널별 그람 수, 구매 링크 입력 후 저장
- [ ] 로스터리 상세 페이지에서 원두 카드 클릭 시 `sourceUrl`로 이동 확인
- [ ] 가격 표시에 그람 수 병기 확인 (sizeGrams 미입력 시 기존 형식 그대로)