### PR TITLE
fix: 다크 모드에서 버튼 텍스트 가시성 수정

### DIFF
--- a/src/app/admin/sections/_components/SectionList.tsx
+++ b/src/app/admin/sections/_components/SectionList.tsx
@@ -151,7 +151,7 @@ export function SectionList({ initialSections }: { initialSections: SectionItem[
         <button
           onClick={handleSaveOrder}
           disabled={isPending}
-          className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-white hover:bg-primary/90 disabled:opacity-50"
+          className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
         >
           {isPending ? '저장 중...' : '순서 저장'}
         </button>

--- a/src/app/admin/sections/page.tsx
+++ b/src/app/admin/sections/page.tsx
@@ -11,7 +11,7 @@ export default async function SectionsPage() {
         <h1 className="text-2xl font-bold text-text">추천 섹션 관리</h1>
         <Link
           href="/admin/sections/new"
-          className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-white hover:bg-primary/90"
+          className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
         >
           + 새 섹션
         </Link>

--- a/src/components/admin/SectionForm.tsx
+++ b/src/components/admin/SectionForm.tsx
@@ -210,7 +210,7 @@ export function SectionForm({
         <button
           type="submit"
           disabled={isPending}
-          className="rounded-lg bg-primary px-5 py-2 text-sm font-medium text-white hover:bg-primary/90 disabled:opacity-50"
+          className="rounded-lg bg-primary px-5 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
         >
           {isPending ? '저장 중...' : isEdit ? '수정' : '생성'}
         </button>

--- a/src/components/home/LoginCTASection.tsx
+++ b/src/components/home/LoginCTASection.tsx
@@ -28,7 +28,7 @@ export function LoginCTASection({ title }: LoginCTASectionProps) {
           </p>
           <Link
             href="/login"
-            className="rounded-lg bg-primary px-5 py-2 text-sm font-medium text-white hover:bg-primary/90"
+            className="rounded-lg bg-primary px-5 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
           >
             로그인하기
           </Link>


### PR DESCRIPTION
## 변경 사항
- `bg-primary text-white` 조합을 `bg-primary text-primary-foreground`로 교체
- 다크 모드에서 `--primary`가 밝은 색상(`oklch(0.87)`)이므로 `text-white`가 흰색 배경에 흰색 텍스트가 되는 문제 해결
- `Button` 컴포넌트의 `default` variant는 이미 `text-primary-foreground`를 사용 중이나, 직접 클래스를 적용한 4개 파일이 누락된 상태였음

**영향 파일:**
- `src/components/home/LoginCTASection.tsx` — 홈 로그인 유도 버튼
- `src/app/admin/sections/page.tsx` — 어드민 섹션 목록 "+ 새 섹션" 링크
- `src/components/admin/SectionForm.tsx` — 섹션 폼 저장 버튼
- `src/app/admin/sections/_components/SectionList.tsx` — 섹션 순서 저장 버튼

## 테스트 방법
- [ ] 다크 모드 전환 후 홈 화면 로그인 유도 배너의 "로그인하기" 버튼 텍스트 확인
- [ ] 다크 모드 전환 후 어드민 섹션 관리 페이지 버튼들 텍스트 확인