### PR TITLE
fix: 데스크탑 헤더 내비게이션 및 활동 탭 UI 수정

### DIFF
--- a/src/components/activity/ActivityTabs.tsx
+++ b/src/components/activity/ActivityTabs.tsx
@@ -27,7 +27,7 @@ export function ActivityTabs({ ratings, bookmarks }: ActivityTabsProps) {
 
   return (
     <div className="flex flex-col gap-4">
-      <div className="flex gap-6 border-b border-border">
+      <div className="flex gap-6">
         {TABS.map(({ key, label }) => (
           <button
             key={key}
@@ -36,7 +36,7 @@ export function ActivityTabs({ ratings, bookmarks }: ActivityTabsProps) {
             className={cn(
               'pb-3 text-sm font-medium transition-colors cursor-pointer',
               activeTab === key
-                ? 'text-text-primary border-b-2 border-text-primary -mb-px'
+                ? 'text-text-primary border-b-2 border-text-primary'
                 : 'text-text-secondary hover:text-text-primary'
             )}
           >

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -22,7 +22,7 @@ import { cn } from '@/lib/utils'
 const authNavLinks = [
   { href: '/', label: '홈' },
   { href: '/roasteries', label: '로스터리' },
-  { href: '/bookmarks', label: '즐겨찾기' },
+  { href: '/activity', label: '내 활동' },
 ]
 
 const guestNavLinks = [

--- a/src/components/profile/MyRatingList.tsx
+++ b/src/components/profile/MyRatingList.tsx
@@ -78,7 +78,7 @@ function MyRatingRow({ item }: { item: MyRatingItem }) {
   return (
     <Link
       href={`/roasteries/${item.roastery.id}`}
-      className="flex flex-col gap-1 py-4 border-b border-[var(--color-border)] last:border-b-0 hover:bg-[var(--color-bg)] -mx-4 px-4 transition-colors"
+      className="flex flex-col gap-1 py-4 border-b border-[var(--color-border)] last-of-type:border-b-0 hover:bg-[var(--color-bg)] -mx-4 px-4 transition-colors"
     >
       <div className="flex items-center justify-between gap-2">
         <span className="text-sm font-medium text-[var(--color-text-primary)] truncate">


### PR DESCRIPTION
## 변경 사항
- 데스크탑 헤더 authNavLinks: `/bookmarks 즐겨찾기` → `/activity 내 활동`으로 모바일 BottomTab과 통일
- ActivityTabs 탭 바 하단 경계선(`border-b border-border`) 제거
- 활성 탭 active indicator의 불필요한 `-mb-px` 오프셋 제거 (container border 제거로 인해 불필요)
- 내 평가 리스트 마지막 항목 하단 경계선 제거: `last:border-b-0` → `last-of-type:border-b-0` (sentinelRef div가 마지막 자식이라 last가 미적용되던 문제 수정)

## 테스트 방법
- [x] 데스크탑 화면에서 로그인 후 헤더 내비게이션에 "내 활동" 링크가 표시되는지 확인
- [x] "내 활동" 링크 클릭 시 `/activity` 페이지로 이동하는지 확인
- [x] `/activity` 페이지에서 탭 바("내 평가" / "즐겨찾기") 하단 경계선이 없는지 확인
- [x] `/activity` 내 평가 탭에서 마지막 평가 항목 하단 경계선이 없는지 확인