### PR TITLE
feat: 내 평가·즐겨찾기 탭 정렬 기능 + 디자인 개편

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,16 @@ pnpm prisma db seed        # 시드 재실행
 > **전제 조건**: 릴리즈할 모든 feat/fix 브랜치가 develop에 merge된 상태여야 한다.
 
 1. **미merge 브랜치 확인** — develop에 반영 안 된 작업이 있으면 먼저 PR 생성 후 merge 요청.
-2. **Release PR 확인** — `gh pr list --base main` 으로 release-please가 만든 Release PR이 있는지 확인.
-   - 없으면: GitHub Actions > Release Please > `workflow_dispatch` 로 수동 트리거
-3. **Release PR 머지** — PR 내용(버전 bump, CHANGELOG) 확인 후 **Merge commit** 으로 main에 머지 → GitHub Release 자동 생성 + Vercel 자동 배포
-4. **develop 백머지** — `git switch develop && git merge main && git push`
+2. **develop → main PR 생성 및 머지** — develop의 커밋을 main에 반영한다.
+   ```bash
+   gh pr create --base main --head develop --title "chore: merge develop into main for release" --body ""
+   gh pr merge {PR번호} --merge --delete-branch=false
+   ```
+   > release-please는 `push to main`을 감지해야 Release PR을 생성한다. 이 단계가 없으면 `workflow_dispatch`를 눌러도 `commits: 0`으로 PR이 생성되지 않는다.
+3. **Release PR 확인** — release-please가 자동으로 Release PR을 생성할 때까지 대기.
+   ```bash
+   gh pr list --base main
+   ```
+   자동 생성이 안 되면: `gh workflow run release-please.yml`
+4. **Release PR 머지** — PR 내용(버전 bump, CHANGELOG) 확인 후 **Merge commit** 으로 main에 머지 → GitHub Release 자동 생성 + Vercel 자동 배포
+5. **develop 백머지** — `git switch develop && git fetch origin main && git merge origin/main && git push`

--- a/src/actions/rating.ts
+++ b/src/actions/rating.ts
@@ -8,7 +8,7 @@ import { upsertRatingSchema, deleteRatingSchema, reportRatingSchema } from '@/li
 import { computeAndSaveCF } from '@/lib/recommender'
 import { getRoasteryRatings } from '@/lib/queries/rating'
 import type { ActionResult } from '@/types/action'
-import type { RatingSortOption, RatingsPage } from '@/types/rating'
+import type { RatingSortOption, RatingsPage, MyRatingSort } from '@/types/rating'
 
 export async function upsertRating(input: {
   roasteryId: string
@@ -107,14 +107,17 @@ export async function fetchRoasteryRatings(input: {
   })
 }
 
-export async function fetchUserRatings(cursor: string): Promise<{
+export async function fetchUserRatings(
+  sort: MyRatingSort,
+  cursor: string
+): Promise<{
   items: import('@/types/rating').MyRatingItem[]
   nextCursor: string | null
 }> {
   const session = await auth()
   if (!session?.user?.id) return { items: [], nextCursor: null }
   const { getUserRatings } = await import('@/lib/queries/rating')
-  return getUserRatings(session.user.id, cursor || undefined)
+  return getUserRatings(session.user.id, sort, cursor || undefined)
 }
 
 export async function reportRating(input: {

--- a/src/components/activity/ActivityTabs.tsx
+++ b/src/components/activity/ActivityTabs.tsx
@@ -46,15 +46,11 @@ export function ActivityTabs({ ratings, bookmarks }: ActivityTabsProps) {
       </div>
 
       {activeTab === 'ratings' ? (
-        <div className="rounded-xl bg-surface px-4 overflow-hidden">
-          <MyRatingList initialItems={ratings.items} initialNextCursor={ratings.nextCursor} />
-        </div>
+        <MyRatingList initialItems={ratings.items} initialNextCursor={ratings.nextCursor} />
       ) : bookmarks.length === 0 ? (
         <EmptyBookmark />
       ) : (
-        <div className="rounded-xl bg-surface px-4 overflow-hidden">
-          <BookmarkList bookmarks={bookmarks} initialSort="name" />
-        </div>
+        <BookmarkList bookmarks={bookmarks} initialSort="name" />
       )}
     </div>
   )

--- a/src/components/activity/ActivityTabs.tsx
+++ b/src/components/activity/ActivityTabs.tsx
@@ -52,7 +52,9 @@ export function ActivityTabs({ ratings, bookmarks }: ActivityTabsProps) {
       ) : bookmarks.length === 0 ? (
         <EmptyBookmark />
       ) : (
-        <BookmarkList bookmarks={bookmarks} initialSort="name" />
+        <div className="rounded-xl bg-surface px-4 overflow-hidden">
+          <BookmarkList bookmarks={bookmarks} initialSort="name" />
+        </div>
       )}
     </div>
   )

--- a/src/components/bookmark/BookmarkList.tsx
+++ b/src/components/bookmark/BookmarkList.tsx
@@ -62,7 +62,7 @@ export function BookmarkList({ bookmarks, initialSort }: BookmarkListProps) {
                 </button>
               </div>
             ) : (
-              <div className="flex items-center gap-3 py-4 hover:bg-[var(--color-bg)] -mx-4 px-4 transition-colors">
+              <div className="flex items-center gap-3 py-4 hover:bg-[var(--color-surface)] transition-colors">
                 <Link
                   href={`/roasteries/${item.roasteryId}`}
                   className="flex flex-1 items-center gap-2 min-w-0"

--- a/src/components/bookmark/BookmarkList.tsx
+++ b/src/components/bookmark/BookmarkList.tsx
@@ -4,12 +4,14 @@ import { useState } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { Badge } from '@/components/ui/badge'
-import { RatingDisplay } from '@/components/roastery/RatingDisplay'
-import { RegionDisplay } from '@/components/roastery/RegionDisplay'
+import { SortDropdown } from '@/components/ui/sort-dropdown'
 import { RemoveBookmarkDialog } from './RemoveBookmarkDialog'
-import { PRICE_RANGE_LABELS, getRegions } from '@/types/roastery'
 import type { BookmarkWithRoastery, BookmarkSort } from '@/types/bookmark'
-import { cn } from '@/lib/utils'
+
+const SORT_OPTIONS: { value: BookmarkSort; label: string }[] = [
+  { value: 'name', label: '이름순' },
+  { value: 'myRating', label: '내 별점순' },
+]
 
 interface BookmarkListProps {
   bookmarks: BookmarkWithRoastery[]
@@ -31,38 +33,19 @@ export function BookmarkList({ bookmarks, initialSort }: BookmarkListProps) {
 
   return (
     <>
-      {/* 정렬 */}
-      <div className="flex gap-3 border-b border-[var(--color-border)] py-3">
-        {(['name', 'myRating'] as BookmarkSort[]).map((s) => (
-          <button
-            key={s}
-            type="button"
-            onClick={() => setSort(s)}
-            className={cn(
-              'text-sm font-medium transition-colors cursor-pointer',
-              sort === s
-                ? 'text-[var(--color-text-primary)]'
-                : 'text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)]'
-            )}
-          >
-            {s === 'name' ? '이름순' : '내 별점순'}
-          </button>
-        ))}
+      <div className="flex justify-end py-3 border-b border-[var(--color-border)]">
+        <SortDropdown value={sort} options={SORT_OPTIONS} onChange={setSort} />
       </div>
 
-      {/* 목록 */}
       <ul className="flex flex-col">
         {sorted.map((item) => (
           <li
             key={item.id}
-            className={cn(
-              'border-b border-[var(--color-border)] last-of-type:border-b-0',
-              item.isUnavailable ? 'opacity-50' : ''
-            )}
+            className={`border-b border-[var(--color-border)] last-of-type:border-b-0 ${item.isUnavailable ? 'opacity-50' : ''}`}
           >
             {item.isUnavailable ? (
-              <div className="flex items-start gap-3 py-4">
-                <div className="flex flex-1 flex-col gap-1 min-w-0">
+              <div className="flex items-center gap-3 py-4">
+                <div className="flex flex-1 flex-col gap-0.5 min-w-0">
                   <span className="text-sm font-medium text-muted-foreground truncate">
                     {item.roastery.name}
                   </span>
@@ -79,57 +62,36 @@ export function BookmarkList({ bookmarks, initialSort }: BookmarkListProps) {
                 </button>
               </div>
             ) : (
-              <div className="flex items-start gap-3 py-4 hover:bg-[var(--color-bg)] -mx-4 px-4 transition-colors">
+              <div className="flex items-center gap-3 py-4 hover:bg-[var(--color-bg)] -mx-4 px-4 transition-colors">
                 <Link
                   href={`/roasteries/${item.roasteryId}`}
-                  className="flex flex-1 flex-col gap-1 min-w-0"
+                  className="flex flex-1 items-center gap-2 min-w-0"
                 >
-                  <div className="flex items-center gap-2">
-                    <span className="text-sm font-medium text-[var(--color-text-primary)] truncate">
-                      {item.roastery.name}
-                    </span>
-                    {item.isClosed && (
-                      <Badge
-                        variant="outline"
-                        className="text-xs shrink-0 text-amber-700 border-amber-300 bg-amber-50"
-                      >
-                        폐업
-                      </Badge>
-                    )}
-                  </div>
-                  <span className="text-xs text-[var(--color-text-secondary)]">
-                    <RegionDisplay regions={getRegions(item.roastery.tags)} />
+                  <span className="text-sm font-medium text-[var(--color-text-primary)] truncate">
+                    {item.roastery.name}
                   </span>
-                  <div className="flex items-center gap-2 flex-wrap">
-                    <Badge variant="outline" className="text-xs">
-                      {PRICE_RANGE_LABELS[item.roastery.priceRange]}
+                  {item.isClosed && (
+                    <Badge
+                      variant="outline"
+                      className="text-xs shrink-0 text-amber-700 border-amber-300 bg-amber-50"
+                    >
+                      폐업
                     </Badge>
-                    {item.roastery.decaf && (
-                      <Badge variant="secondary" className="text-xs">
-                        디카페인
-                      </Badge>
-                    )}
-                  </div>
-                </Link>
-
-                <div className="flex flex-col items-end gap-1.5 shrink-0">
-                  <RatingDisplay
-                    avgRating={item.roastery.avgRating}
-                    ratingCount={item.roastery.ratingCount}
-                  />
+                  )}
                   {item.myRating !== null && (
-                    <span className="text-xs text-[var(--color-text-secondary)]">
-                      내 평가 {item.myRating}점
+                    <span className="text-xs text-[var(--color-accent)] shrink-0 ml-auto">
+                      {'★'.repeat(item.myRating)}
+                      {'☆'.repeat(5 - item.myRating)}
                     </span>
                   )}
-                  <button
-                    type="button"
-                    onClick={() => setRemoveTarget(item)}
-                    className="text-xs text-destructive hover:underline cursor-pointer"
-                  >
-                    해제
-                  </button>
-                </div>
+                </Link>
+                <button
+                  type="button"
+                  onClick={() => setRemoveTarget(item)}
+                  className="text-xs text-destructive hover:underline cursor-pointer shrink-0"
+                >
+                  해제
+                </button>
               </div>
             )}
           </li>

--- a/src/components/bookmark/BookmarkList.tsx
+++ b/src/components/bookmark/BookmarkList.tsx
@@ -31,8 +31,8 @@ export function BookmarkList({ bookmarks, initialSort }: BookmarkListProps) {
 
   return (
     <>
-      {/* 정렬 탭 */}
-      <div className="flex gap-3 border-b border-border pb-3">
+      {/* 정렬 */}
+      <div className="flex gap-3 border-b border-[var(--color-border)] py-3">
         {(['name', 'myRating'] as BookmarkSort[]).map((s) => (
           <button
             key={s}
@@ -40,7 +40,9 @@ export function BookmarkList({ bookmarks, initialSort }: BookmarkListProps) {
             onClick={() => setSort(s)}
             className={cn(
               'text-sm font-medium transition-colors cursor-pointer',
-              sort === s ? 'text-text-primary' : 'text-text-secondary hover:text-text-primary'
+              sort === s
+                ? 'text-[var(--color-text-primary)]'
+                : 'text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)]'
             )}
           >
             {s === 'name' ? '이름순' : '내 별점순'}
@@ -49,15 +51,18 @@ export function BookmarkList({ bookmarks, initialSort }: BookmarkListProps) {
       </div>
 
       {/* 목록 */}
-      <ul className="flex flex-col divide-y divide-border">
+      <ul className="flex flex-col">
         {sorted.map((item) => (
           <li
             key={item.id}
-            className={`flex items-center gap-4 py-4 ${item.isUnavailable ? 'opacity-50' : ''}`}
+            className={cn(
+              'border-b border-[var(--color-border)] last-of-type:border-b-0',
+              item.isUnavailable ? 'opacity-50' : ''
+            )}
           >
             {item.isUnavailable ? (
-              <div className="flex flex-1 flex-col gap-1 min-w-0">
-                <span className="font-medium truncate text-muted-foreground">
+              <div className="flex flex-col gap-1 py-4">
+                <span className="text-sm font-medium text-muted-foreground truncate">
                   {item.roastery.name}
                 </span>
                 <span className="text-xs text-muted-foreground">
@@ -65,57 +70,59 @@ export function BookmarkList({ bookmarks, initialSort }: BookmarkListProps) {
                 </span>
               </div>
             ) : (
-              <Link
-                href={`/roasteries/${item.roasteryId}`}
-                className="flex flex-1 flex-col gap-1 min-w-0"
-              >
-                <div className="flex items-center gap-2">
-                  <span className="font-medium truncate">{item.roastery.name}</span>
-                  {item.isClosed && (
-                    <Badge
-                      variant="outline"
-                      className="text-xs shrink-0 text-amber-700 border-amber-300 bg-amber-50"
-                    >
-                      폐업
+              <div className="flex items-start gap-3 py-4 hover:bg-[var(--color-bg)] -mx-4 px-4 transition-colors">
+                <Link
+                  href={`/roasteries/${item.roasteryId}`}
+                  className="flex flex-1 flex-col gap-1 min-w-0"
+                >
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-medium text-[var(--color-text-primary)] truncate">
+                      {item.roastery.name}
+                    </span>
+                    {item.isClosed && (
+                      <Badge
+                        variant="outline"
+                        className="text-xs shrink-0 text-amber-700 border-amber-300 bg-amber-50"
+                      >
+                        폐업
+                      </Badge>
+                    )}
+                  </div>
+                  <span className="text-xs text-[var(--color-text-secondary)]">
+                    <RegionDisplay regions={getRegions(item.roastery.tags)} />
+                  </span>
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <Badge variant="outline" className="text-xs">
+                      {PRICE_RANGE_LABELS[item.roastery.priceRange]}
                     </Badge>
-                  )}
-                </div>
-                <span className="text-sm text-muted-foreground">
-                  <RegionDisplay regions={getRegions(item.roastery.tags)} />
-                </span>
-                <div className="flex items-center gap-2 flex-wrap">
-                  <Badge variant="outline" className="text-xs">
-                    {PRICE_RANGE_LABELS[item.roastery.priceRange]}
-                  </Badge>
-                  {item.roastery.decaf && (
-                    <Badge variant="secondary" className="text-xs">
-                      디카페인
-                    </Badge>
-                  )}
-                </div>
-              </Link>
-            )}
+                    {item.roastery.decaf && (
+                      <Badge variant="secondary" className="text-xs">
+                        디카페인
+                      </Badge>
+                    )}
+                  </div>
+                </Link>
 
-            <div className="flex items-center gap-3 shrink-0">
-              {!item.isUnavailable && (
-                <div className="text-sm flex items-center gap-1">
+                <div className="flex flex-col items-end gap-1.5 shrink-0">
                   <RatingDisplay
                     avgRating={item.roastery.avgRating}
                     ratingCount={item.roastery.ratingCount}
                   />
+                  {item.myRating !== null && (
+                    <span className="text-xs text-[var(--color-text-secondary)]">
+                      내 평가 {item.myRating}점
+                    </span>
+                  )}
+                  <button
+                    type="button"
+                    onClick={() => setRemoveTarget(item)}
+                    className="text-xs text-destructive hover:underline cursor-pointer"
+                  >
+                    해제
+                  </button>
                 </div>
-              )}
-              {item.myRating !== null && (
-                <span className="text-xs text-muted-foreground">내 평가 {item.myRating}점</span>
-              )}
-              <button
-                type="button"
-                onClick={() => setRemoveTarget(item)}
-                className="text-xs text-destructive hover:underline cursor-pointer"
-              >
-                해제
-              </button>
-            </div>
+              </div>
+            )}
           </li>
         ))}
       </ul>

--- a/src/components/bookmark/BookmarkList.tsx
+++ b/src/components/bookmark/BookmarkList.tsx
@@ -61,13 +61,22 @@ export function BookmarkList({ bookmarks, initialSort }: BookmarkListProps) {
             )}
           >
             {item.isUnavailable ? (
-              <div className="flex flex-col gap-1 py-4">
-                <span className="text-sm font-medium text-muted-foreground truncate">
-                  {item.roastery.name}
-                </span>
-                <span className="text-xs text-muted-foreground">
-                  더 이상 이용할 수 없는 로스터리입니다
-                </span>
+              <div className="flex items-start gap-3 py-4">
+                <div className="flex flex-1 flex-col gap-1 min-w-0">
+                  <span className="text-sm font-medium text-muted-foreground truncate">
+                    {item.roastery.name}
+                  </span>
+                  <span className="text-xs text-muted-foreground">
+                    더 이상 이용할 수 없는 로스터리입니다
+                  </span>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => setRemoveTarget(item)}
+                  className="text-xs text-destructive hover:underline cursor-pointer shrink-0"
+                >
+                  해제
+                </button>
               </div>
             ) : (
               <div className="flex items-start gap-3 py-4 hover:bg-[var(--color-bg)] -mx-4 px-4 transition-colors">

--- a/src/components/profile/MyRatingList.tsx
+++ b/src/components/profile/MyRatingList.tsx
@@ -34,19 +34,18 @@ export function MyRatingList({ initialItems, initialNextCursor }: MyRatingListPr
   const [nextCursor, setNextCursor] = useState<string | null>(initialNextCursor)
   const [isPending, startTransition] = useTransition()
   const sentinelRef = useRef<HTMLDivElement>(null)
-  const isFirstRender = useRef(true)
 
-  useEffect(() => {
-    if (isFirstRender.current) {
-      isFirstRender.current = false
-      return
-    }
+  // 버튼 클릭 핸들러에서 sort 변경 + 상태 즉시 초기화: effect 내 setState 금지 규칙 회피 + stale cursor race 방지
+  function handleSortChange(newSort: MyRatingSort) {
+    setSort(newSort)
+    setItems([])
+    setNextCursor(null)
     startTransition(async () => {
-      const page = await fetchUserRatings(sort, '')
+      const page = await fetchUserRatings(newSort, '')
       setItems(page.items)
       setNextCursor(page.nextCursor)
     })
-  }, [sort])
+  }
 
   useEffect(() => {
     if (!nextCursor || !sentinelRef.current) return
@@ -71,7 +70,7 @@ export function MyRatingList({ initialItems, initialNextCursor }: MyRatingListPr
   if (!isPending && items.length === 0) {
     return (
       <>
-        <SortBar sort={sort} onChange={setSort} />
+        <SortBar sort={sort} onChange={handleSortChange} />
         <p className="text-sm text-[var(--color-text-secondary)] py-4 text-center">
           아직 작성한 한줄평이 없습니다.
         </p>
@@ -81,7 +80,7 @@ export function MyRatingList({ initialItems, initialNextCursor }: MyRatingListPr
 
   return (
     <div className="flex flex-col">
-      <SortBar sort={sort} onChange={setSort} />
+      <SortBar sort={sort} onChange={handleSortChange} />
       {isPending && items.length === 0 ? (
         <p className="text-sm text-[var(--color-text-secondary)] py-4 text-center">
           불러오는 중...

--- a/src/components/profile/MyRatingList.tsx
+++ b/src/components/profile/MyRatingList.tsx
@@ -3,20 +3,18 @@
 import { useState, useEffect, useRef, useTransition } from 'react'
 import Link from 'next/link'
 import { fetchUserRatings } from '@/actions/rating'
-import { cn } from '@/lib/utils'
+import { SortDropdown } from '@/components/ui/sort-dropdown'
 import type { MyRatingItem, MyRatingSort } from '@/types/rating'
 
 const SORT_OPTIONS: { value: MyRatingSort; label: string }[] = [
   { value: 'date_desc', label: '최신순' },
   { value: 'score_desc', label: '별점 높은순' },
   { value: 'score_asc', label: '별점 낮은순' },
-  { value: 'name_asc', label: '이름순' },
-  { value: 'name_desc', label: '이름 역순' },
 ]
 
 function StarRow({ score }: { score: number }) {
   return (
-    <span className="text-xs text-[var(--color-accent)]">
+    <span className="text-xs text-[var(--color-accent)] shrink-0">
       {'★'.repeat(score)}
       {'☆'.repeat(5 - score)}
     </span>
@@ -35,7 +33,6 @@ export function MyRatingList({ initialItems, initialNextCursor }: MyRatingListPr
   const [isPending, startTransition] = useTransition()
   const sentinelRef = useRef<HTMLDivElement>(null)
 
-  // 버튼 클릭 핸들러에서 sort 변경 + 상태 즉시 초기화: effect 내 setState 금지 규칙 회피 + stale cursor race 방지
   function handleSortChange(newSort: MyRatingSort) {
     setSort(newSort)
     setItems([])
@@ -67,23 +64,19 @@ export function MyRatingList({ initialItems, initialNextCursor }: MyRatingListPr
     return () => observer.disconnect()
   }, [nextCursor, isPending, sort])
 
-  if (!isPending && items.length === 0) {
-    return (
-      <>
-        <SortBar sort={sort} onChange={handleSortChange} />
-        <p className="text-sm text-[var(--color-text-secondary)] py-4 text-center">
-          아직 작성한 한줄평이 없습니다.
-        </p>
-      </>
-    )
-  }
-
   return (
     <div className="flex flex-col">
-      <SortBar sort={sort} onChange={handleSortChange} />
+      <div className="flex justify-end py-3 border-b border-[var(--color-border)]">
+        <SortDropdown value={sort} options={SORT_OPTIONS} onChange={handleSortChange} />
+      </div>
+
       {isPending && items.length === 0 ? (
         <p className="text-sm text-[var(--color-text-secondary)] py-4 text-center">
           불러오는 중...
+        </p>
+      ) : !isPending && items.length === 0 ? (
+        <p className="text-sm text-[var(--color-text-secondary)] py-4 text-center">
+          아직 작성한 한줄평이 없습니다.
         </p>
       ) : (
         <>
@@ -102,35 +95,7 @@ export function MyRatingList({ initialItems, initialNextCursor }: MyRatingListPr
   )
 }
 
-function SortBar({ sort, onChange }: { sort: MyRatingSort; onChange: (s: MyRatingSort) => void }) {
-  return (
-    <div className="flex gap-3 border-b border-[var(--color-border)] py-3 overflow-x-auto">
-      {SORT_OPTIONS.map(({ value, label }) => (
-        <button
-          key={value}
-          type="button"
-          onClick={() => onChange(value)}
-          className={cn(
-            'text-sm font-medium transition-colors cursor-pointer shrink-0',
-            sort === value
-              ? 'text-[var(--color-text-primary)]'
-              : 'text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)]'
-          )}
-        >
-          {label}
-        </button>
-      ))}
-    </div>
-  )
-}
-
 function MyRatingRow({ item }: { item: MyRatingItem }) {
-  const date = new Intl.DateTimeFormat('ko-KR', {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-  }).format(new Date(item.updatedAt))
-
   return (
     <Link
       href={`/roasteries/${item.roastery.id}`}
@@ -140,10 +105,7 @@ function MyRatingRow({ item }: { item: MyRatingItem }) {
         <span className="text-sm font-medium text-[var(--color-text-primary)] truncate">
           {item.roastery.name}
         </span>
-        <div className="flex items-center gap-2 flex-shrink-0">
-          <StarRow score={item.score} />
-          <span className="text-xs text-[var(--color-text-disabled)]">{date}</span>
-        </div>
+        <StarRow score={item.score} />
       </div>
       {item.comment && (
         <p className="text-sm text-[var(--color-text-secondary)] line-clamp-2">{item.comment}</p>

--- a/src/components/profile/MyRatingList.tsx
+++ b/src/components/profile/MyRatingList.tsx
@@ -3,7 +3,16 @@
 import { useState, useEffect, useRef, useTransition } from 'react'
 import Link from 'next/link'
 import { fetchUserRatings } from '@/actions/rating'
-import type { MyRatingItem } from '@/types/rating'
+import { cn } from '@/lib/utils'
+import type { MyRatingItem, MyRatingSort } from '@/types/rating'
+
+const SORT_OPTIONS: { value: MyRatingSort; label: string }[] = [
+  { value: 'date_desc', label: '최신순' },
+  { value: 'score_desc', label: '별점 높은순' },
+  { value: 'score_asc', label: '별점 낮은순' },
+  { value: 'name_asc', label: '이름순' },
+  { value: 'name_desc', label: '이름 역순' },
+]
 
 function StarRow({ score }: { score: number }) {
   return (
@@ -20,10 +29,24 @@ interface MyRatingListProps {
 }
 
 export function MyRatingList({ initialItems, initialNextCursor }: MyRatingListProps) {
+  const [sort, setSort] = useState<MyRatingSort>('date_desc')
   const [items, setItems] = useState<MyRatingItem[]>(initialItems)
   const [nextCursor, setNextCursor] = useState<string | null>(initialNextCursor)
   const [isPending, startTransition] = useTransition()
   const sentinelRef = useRef<HTMLDivElement>(null)
+  const isFirstRender = useRef(true)
+
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false
+      return
+    }
+    startTransition(async () => {
+      const page = await fetchUserRatings(sort, '')
+      setItems(page.items)
+      setNextCursor(page.nextCursor)
+    })
+  }, [sort])
 
   useEffect(() => {
     if (!nextCursor || !sentinelRef.current) return
@@ -32,7 +55,7 @@ export function MyRatingList({ initialItems, initialNextCursor }: MyRatingListPr
       (entries) => {
         if (entries[0].isIntersecting && !isPending && nextCursor) {
           startTransition(async () => {
-            const page = await fetchUserRatings(nextCursor)
+            const page = await fetchUserRatings(sort, nextCursor)
             setItems((prev) => [...prev, ...page.items])
             setNextCursor(page.nextCursor)
           })
@@ -43,27 +66,61 @@ export function MyRatingList({ initialItems, initialNextCursor }: MyRatingListPr
 
     observer.observe(sentinelRef.current)
     return () => observer.disconnect()
-  }, [nextCursor, isPending])
+  }, [nextCursor, isPending, sort])
 
-  if (items.length === 0) {
+  if (!isPending && items.length === 0) {
     return (
-      <p className="text-sm text-[var(--color-text-secondary)] py-4 text-center">
-        아직 작성한 한줄평이 없습니다.
-      </p>
+      <>
+        <SortBar sort={sort} onChange={setSort} />
+        <p className="text-sm text-[var(--color-text-secondary)] py-4 text-center">
+          아직 작성한 한줄평이 없습니다.
+        </p>
+      </>
     )
   }
 
   return (
     <div className="flex flex-col">
-      {items.map((item) => (
-        <MyRatingRow key={item.id} item={item} />
-      ))}
-      <div ref={sentinelRef} className="h-1" />
-      {isPending && (
+      <SortBar sort={sort} onChange={setSort} />
+      {isPending && items.length === 0 ? (
         <p className="text-sm text-[var(--color-text-secondary)] py-4 text-center">
           불러오는 중...
         </p>
+      ) : (
+        <>
+          {items.map((item) => (
+            <MyRatingRow key={item.id} item={item} />
+          ))}
+          <div ref={sentinelRef} className="h-1" />
+          {isPending && (
+            <p className="text-sm text-[var(--color-text-secondary)] py-4 text-center">
+              불러오는 중...
+            </p>
+          )}
+        </>
       )}
+    </div>
+  )
+}
+
+function SortBar({ sort, onChange }: { sort: MyRatingSort; onChange: (s: MyRatingSort) => void }) {
+  return (
+    <div className="flex gap-3 border-b border-[var(--color-border)] py-3 overflow-x-auto">
+      {SORT_OPTIONS.map(({ value, label }) => (
+        <button
+          key={value}
+          type="button"
+          onClick={() => onChange(value)}
+          className={cn(
+            'text-sm font-medium transition-colors cursor-pointer shrink-0',
+            sort === value
+              ? 'text-[var(--color-text-primary)]'
+              : 'text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)]'
+          )}
+        >
+          {label}
+        </button>
+      ))}
     </div>
   )
 }

--- a/src/components/profile/MyRatingList.tsx
+++ b/src/components/profile/MyRatingList.tsx
@@ -99,7 +99,7 @@ function MyRatingRow({ item }: { item: MyRatingItem }) {
   return (
     <Link
       href={`/roasteries/${item.roastery.id}`}
-      className="flex flex-col gap-1 py-4 border-b border-[var(--color-border)] last-of-type:border-b-0 hover:bg-[var(--color-bg)] -mx-4 px-4 transition-colors"
+      className="flex flex-col gap-1 py-4 border-b border-[var(--color-border)] last-of-type:border-b-0 hover:bg-[var(--color-surface)] transition-colors"
     >
       <div className="flex items-center justify-between gap-2">
         <span className="text-sm font-medium text-[var(--color-text-primary)] truncate">

--- a/src/components/ui/sort-dropdown.tsx
+++ b/src/components/ui/sort-dropdown.tsx
@@ -1,0 +1,62 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { ChevronDown } from 'lucide-react'
+
+interface SortDropdownProps<T extends string> {
+  value: T
+  options: { value: T; label: string }[]
+  onChange: (value: T) => void
+}
+
+export function SortDropdown<T extends string>({ value, options, onChange }: SortDropdownProps<T>) {
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    function handleClickOutside(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false)
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [open])
+
+  const currentLabel = options.find((o) => o.value === value)?.label ?? options[0].label
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-label="정렬 기준"
+        className="inline-flex shrink-0 cursor-pointer items-center gap-1.5 whitespace-nowrap rounded-md border border-border bg-background px-3 py-1.5 text-sm text-foreground transition-colors hover:bg-accent/10"
+      >
+        {currentLabel}
+        <ChevronDown
+          className={`h-3.5 w-3.5 transition-transform duration-150 ${open ? 'rotate-180' : ''}`}
+        />
+      </button>
+
+      {open && (
+        <div className="absolute left-0 top-full z-50 mt-1 min-w-[8rem] rounded-xl border border-border bg-background py-1 shadow-lg">
+          {options.map((opt) => (
+            <button
+              key={opt.value}
+              type="button"
+              onClick={() => {
+                onChange(opt.value)
+                setOpen(false)
+              }}
+              className={`w-full cursor-pointer px-4 py-2 text-left text-sm transition-colors hover:bg-accent/10 ${
+                opt.value === value ? 'font-medium text-foreground' : 'text-muted-foreground'
+              }`}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/lib/queries/rating.ts
+++ b/src/lib/queries/rating.ts
@@ -1,6 +1,6 @@
 import { prisma } from '@/lib/prisma'
 import { cosineSimilarity } from '@/lib/recommender/item-cf'
-import type { RatingSortOption, RatingListItem, MyRatingItem } from '@/types/rating'
+import type { RatingSortOption, RatingListItem, MyRatingItem, MyRatingSort } from '@/types/rating'
 
 const PAGE_SIZE = 10
 
@@ -93,8 +93,17 @@ export async function getRoasteryRatings(input: {
 
 export async function getUserRatings(
   userId: string,
+  sort: MyRatingSort = 'date_desc',
   cursor?: string
 ): Promise<{ items: MyRatingItem[]; nextCursor: string | null }> {
+  const orderBy = {
+    date_desc: [{ updatedAt: 'desc' as const }],
+    score_desc: [{ score: 'desc' as const }, { updatedAt: 'desc' as const }],
+    score_asc: [{ score: 'asc' as const }, { updatedAt: 'desc' as const }],
+    name_asc: [{ roastery: { name: 'asc' as const } }],
+    name_desc: [{ roastery: { name: 'desc' as const } }],
+  }[sort]
+
   const rawRatings = await prisma.rating.findMany({
     where: { userId },
     select: {
@@ -104,7 +113,7 @@ export async function getUserRatings(
       updatedAt: true,
       roastery: { select: { id: true, name: true, imageUrl: true } },
     },
-    orderBy: { updatedAt: 'desc' },
+    orderBy,
     take: PAGE_SIZE + 1,
     ...(cursor && { cursor: { id: cursor }, skip: 1 }),
   })

--- a/src/lib/queries/rating.ts
+++ b/src/lib/queries/rating.ts
@@ -100,8 +100,6 @@ export async function getUserRatings(
     date_desc: [{ updatedAt: 'desc' as const }],
     score_desc: [{ score: 'desc' as const }, { updatedAt: 'desc' as const }],
     score_asc: [{ score: 'asc' as const }, { updatedAt: 'desc' as const }],
-    name_asc: [{ roastery: { name: 'asc' as const } }],
-    name_desc: [{ roastery: { name: 'desc' as const } }],
   }[sort]
 
   const rawRatings = await prisma.rating.findMany({

--- a/src/types/rating.ts
+++ b/src/types/rating.ts
@@ -1,5 +1,7 @@
 export type RatingSortOption = 'SIMILAR' | 'HIGH' | 'LOW'
 
+export type MyRatingSort = 'date_desc' | 'score_desc' | 'score_asc' | 'name_asc' | 'name_desc'
+
 export interface RatingListItem {
   id: string
   score: number

--- a/src/types/rating.ts
+++ b/src/types/rating.ts
@@ -1,6 +1,6 @@
 export type RatingSortOption = 'SIMILAR' | 'HIGH' | 'LOW'
 
-export type MyRatingSort = 'date_desc' | 'score_desc' | 'score_asc' | 'name_asc' | 'name_desc'
+export type MyRatingSort = 'date_desc' | 'score_desc' | 'score_asc'
 
 export interface RatingListItem {
   id: string

--- a/src/types/roastery.ts
+++ b/src/types/roastery.ts
@@ -87,6 +87,7 @@ export const PRICE_OPTIONS = Object.keys(PRICE_RANGE_LABELS) as PriceRange[]
 
 export const ROASTING_LEVEL_LABELS: Record<string, string> = {
   LIGHT: '라이트',
+  LIGHT_MEDIUM: '라이트 미디엄',
   MEDIUM: '미디엄',
   MEDIUM_DARK: '미디엄 다크',
   DARK: '다크',


### PR DESCRIPTION
## 변경 사항

### 내 평가 탭 정렬 기능
- 최신순(기본) / 별점 높은순 / 별점 낮은순 드롭다운 정렬
- 로스터리 페이지 SortSelector와 동일한 드롭다운 패턴 (`SortDropdown` 공용 컴포넌트)
- sort 변경 시 목록 즉시 초기화 후 서버 재fetch, infinite scroll 유지

### 내 평가·즐겨찾기 디자인 개편
- **내 평가**: 이름 + 별점 + 한줄평만 표시 (날짜·지역·가격대 제거)
- **즐겨찾기**: 이름 + 내 별점(있을 때만) + 해제 버튼 (지역·가격·뱃지·평균평점 제거)
- 두 탭 모두 `rounded-xl bg-surface px-4` 래퍼로 통일
- 정렬 UI를 로스터리 페이지와 동일한 드롭다운으로 통일

## 테스트 방법
- [x] `/activity?tab=ratings`에서 정렬 드롭다운 동작 확인
- [x] 별점순 전환 시 목록 즉시 초기화 후 재정렬 확인
- [x] `/activity?tab=bookmarks`에서 내 평가 탭과 동일한 스타일 확인
- [x] 이용 불가 즐겨찾기 항목의 해제 버튼 동작 확인