### PR TITLE
fix: 정렬 드롭다운 오른쪽 화면 밖으로 넘치는 문제 수정

### DIFF
--- a/src/components/ui/sort-dropdown.tsx
+++ b/src/components/ui/sort-dropdown.tsx
@@ -39,7 +39,7 @@ export function SortDropdown<T extends string>({ value, options, onChange }: Sor
       </button>
 
       {open && (
-        <div className="absolute left-0 top-full z-50 mt-1 min-w-[8rem] rounded-xl border border-border bg-background py-1 shadow-lg">
+        <div className="absolute right-0 top-full z-50 mt-1 min-w-[8rem] rounded-xl border border-border bg-background py-1 shadow-lg">
           {options.map((opt) => (
             <button
               key={opt.value}


### PR DESCRIPTION
## 변경 사항
- `SortDropdown` 컴포넌트의 드롭다운 메뉴 위치를 `left-0`에서 `right-0`으로 변경
- 화면 오른쪽에 버튼이 위치할 때 드롭다운이 viewport 밖으로 잘리던 문제 수정

## 테스트 방법
- [x] 내 활동 페이지 → 정렬 드롭다운 클릭 → 메뉴가 화면 안에 표시되는지 확인
- [x] 즐겨찾기 탭도 동일하게 확인