### PR TITLE
fix: 로스터리 검색 input 한글 IME 입력 오작동 수정

### DIFF
--- a/src/components/roastery/FilterPanel.tsx
+++ b/src/components/roastery/FilterPanel.tsx
@@ -26,13 +26,14 @@ export function FilterPanel({ filter, sort, isLoggedIn }: FilterPanelProps) {
   const [openPill, setOpenPill] = useState<PillId | null>(null)
   const [inputValue, setInputValue] = useState(filter.q)
   const searchId = useId()
+  const isComposingRef = useRef(false)
 
   useEffect(() => {
     setInputValue(filter.q)
   }, [filter.q])
 
   useEffect(() => {
-    if (inputValue.trim() === filter.q) return
+    if (inputValue.trim() === filter.q || isComposingRef.current) return
     const t = setTimeout(() => navigate({ q: inputValue.trim() }), 400)
     return () => clearTimeout(t)
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -112,8 +113,14 @@ export function FilterPanel({ filter, sort, isLoggedIn }: FilterPanelProps) {
           placeholder="로스터리 이름 검색..."
           value={inputValue}
           onChange={(e) => setInputValue(e.target.value)}
+          onCompositionStart={() => {
+            isComposingRef.current = true
+          }}
+          onCompositionEnd={() => {
+            isComposingRef.current = false
+          }}
           onKeyDown={(e) => {
-            if (e.key === 'Enter') navigate({ q: inputValue.trim() })
+            if (e.key === 'Enter' && !e.nativeEvent.isComposing) navigate({ q: inputValue.trim() })
           }}
           className="min-w-0 flex-1 rounded-md border border-border bg-background px-3 py-1.5 text-[16px] leading-snug text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
           aria-label="로스터리 이름 검색"
@@ -167,8 +174,14 @@ export function FilterPanel({ filter, sort, isLoggedIn }: FilterPanelProps) {
           placeholder="로스터리 이름 검색..."
           value={inputValue}
           onChange={(e) => setInputValue(e.target.value)}
+          onCompositionStart={() => {
+            isComposingRef.current = true
+          }}
+          onCompositionEnd={() => {
+            isComposingRef.current = false
+          }}
           onKeyDown={(e) => {
-            if (e.key === 'Enter') navigate({ q: inputValue.trim() })
+            if (e.key === 'Enter' && !e.nativeEvent.isComposing) navigate({ q: inputValue.trim() })
           }}
           className="w-56 rounded-full border border-border bg-background px-4 py-1.5 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
           aria-label="로스터리 이름 검색"


### PR DESCRIPTION
## 변경 사항
- `FilterPanel.tsx` 검색 input에 `isComposingRef` 추가
- IME 조합 중(`compositionstart` ~ `compositionend`)에는 400ms 디바운스 navigate를 차단해 한글 입력이 중간에 초기화되는 현상 수정
- `onKeyDown` Enter 처리 시 `e.nativeEvent.isComposing` 체크 추가 (조합 확정 Enter가 검색으로 잘못 처리되는 문제 방지)
- 모바일/데스크탑 input 모두 동일하게 적용

## 원인
한글 입력 중 `onChange`가 발생 → 400ms 디바운스로 `router.replace()` 호출 → `filter.q` 변경 → `setInputValue(filter.q)` 동기화 effect가 실행되어 조합 중인 한글 초기화

## 테스트 방법
- [x] 로스터리 페이지(`/roasteries`) 검색 input에서 한글 입력 시 글자가 정상적으로 완성되는지 확인
- [x] 영문 입력도 정상 동작하는지 확인
- [x] Enter 키로 검색이 정상 동작하는지 확인