### PR TITLE
style: 홈 피드 추천 섹션 간 구분선 추가

### DIFF
--- a/src/components/home/FeedSkeleton.tsx
+++ b/src/components/home/FeedSkeleton.tsx
@@ -12,8 +12,8 @@ function CardSkeleton() {
 
 export function FeedSkeleton() {
   return (
-    <div className="flex flex-col gap-8">
-      <div className="flex flex-col gap-4">
+    <div className="flex flex-col divide-y divide-border">
+      <div className="flex flex-col gap-4 py-6">
         <Skeleton className="h-5 w-32" />
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {Array.from({ length: 3 }).map((_, i) => (
@@ -21,7 +21,7 @@ export function FeedSkeleton() {
           ))}
         </div>
       </div>
-      <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-4 py-6">
         <Skeleton className="h-5 w-40" />
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {Array.from({ length: 3 }).map((_, i) => (

--- a/src/components/home/HomeFeedClient.tsx
+++ b/src/components/home/HomeFeedClient.tsx
@@ -59,9 +59,9 @@ export function HomeFeedClient({
   const showDecafToggle = hasCFSections && result.source === 'cf' && isLoggedIn
 
   return (
-    <div className="flex flex-col gap-8">
+    <div className="flex flex-col divide-y divide-border">
       {showDecafToggle && (
-        <div className="page-wrapper flex items-center">
+        <div className="page-wrapper flex items-center pb-4">
           <DecafToggle decafOn={decafOn} onToggle={() => setDecafOn((v) => !v)} />
         </div>
       )}

--- a/src/components/home/LoginCTASection.tsx
+++ b/src/components/home/LoginCTASection.tsx
@@ -7,7 +7,7 @@ interface LoginCTASectionProps {
 
 export function LoginCTASection({ title }: LoginCTASectionProps) {
   return (
-    <section className="flex flex-col gap-3">
+    <section className="flex flex-col gap-3 py-6">
       <h2 className="page-wrapper text-base font-semibold">{title}</h2>
       <div className="relative overflow-hidden">
         {/* 블러 배경 — 스켈레톤 카드 3개 */}

--- a/src/components/home/PopularSection.tsx
+++ b/src/components/home/PopularSection.tsx
@@ -16,7 +16,7 @@ export function PopularSection({
   if (items.length === 0) return null
 
   return (
-    <section className="flex flex-col gap-3">
+    <section className="flex flex-col gap-3 py-6">
       <h2 className="page-wrapper text-base font-semibold">{title}</h2>
       <ScrollRow>
         {items.map((roastery, i) => (

--- a/src/components/home/RecommendSection.tsx
+++ b/src/components/home/RecommendSection.tsx
@@ -12,7 +12,7 @@ export function RecommendSection({ title, items, onCardClick }: RecommendSection
   if (items.length === 0) return null
 
   return (
-    <section className="flex flex-col gap-3">
+    <section className="flex flex-col gap-3 py-6">
       <h2 className="page-wrapper text-base font-semibold">{title}</h2>
       <ScrollRow>
         {items.map((item, i) => (


### PR DESCRIPTION
## 변경 사항
- HomeFeedClient, FeedSkeleton 외부 래퍼를 `gap-8` → `divide-y divide-border`로 변경
- 각 섹션(RecommendSection, PopularSection, LoginCTASection)에 `py-6` 추가해 구분선 위아래 여백 확보
- DecafToggle 래퍼에 `pb-4` 추가해 첫 구분선과의 간격 조정

## 테스트 방법
- [x] 홈 피드에서 추천 섹션 간 구분선이 표시되는지 확인
- [x] 로그인/비로그인 상태 모두에서 섹션 구분이 잘 보이는지 확인
- [x] 디카페인 토글이 있을 때 토글-첫 섹션 사이 구분선이 자연스러운지 확인
- [x] 로딩 스켈레톤도 동일하게 구분선이 표시되는지 확인