### PR TITLE
fix: 홈 피드 섹션 구분선을 제목 하단으로 이동 및 여백 안으로 제한

### DIFF
--- a/src/components/home/FeedSkeleton.tsx
+++ b/src/components/home/FeedSkeleton.tsx
@@ -12,17 +12,17 @@ function CardSkeleton() {
 
 export function FeedSkeleton() {
   return (
-    <div className="flex flex-col divide-y divide-border">
-      <div className="flex flex-col gap-4 py-6">
-        <Skeleton className="h-5 w-32" />
+    <div className="flex flex-col gap-8">
+      <div className="flex flex-col gap-4">
+        <Skeleton className="h-5 w-32 border-b border-border pb-2" />
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {Array.from({ length: 3 }).map((_, i) => (
             <CardSkeleton key={i} />
           ))}
         </div>
       </div>
-      <div className="flex flex-col gap-4 py-6">
-        <Skeleton className="h-5 w-40" />
+      <div className="flex flex-col gap-4">
+        <Skeleton className="h-5 w-40 border-b border-border pb-2" />
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {Array.from({ length: 3 }).map((_, i) => (
             <CardSkeleton key={i} />

--- a/src/components/home/HomeFeedClient.tsx
+++ b/src/components/home/HomeFeedClient.tsx
@@ -59,9 +59,9 @@ export function HomeFeedClient({
   const showDecafToggle = hasCFSections && result.source === 'cf' && isLoggedIn
 
   return (
-    <div className="flex flex-col divide-y divide-border">
+    <div className="flex flex-col gap-8">
       {showDecafToggle && (
-        <div className="page-wrapper flex items-center pb-4">
+        <div className="page-wrapper flex items-center">
           <DecafToggle decafOn={decafOn} onToggle={() => setDecafOn((v) => !v)} />
         </div>
       )}

--- a/src/components/home/LoginCTASection.tsx
+++ b/src/components/home/LoginCTASection.tsx
@@ -7,8 +7,10 @@ interface LoginCTASectionProps {
 
 export function LoginCTASection({ title }: LoginCTASectionProps) {
   return (
-    <section className="flex flex-col gap-3 py-6">
-      <h2 className="page-wrapper text-base font-semibold">{title}</h2>
+    <section className="flex flex-col gap-3">
+      <div className="page-wrapper">
+        <h2 className="border-b border-border pb-2 text-base font-semibold">{title}</h2>
+      </div>
       <div className="relative overflow-hidden">
         {/* 블러 배경 — 스켈레톤 카드 3개 */}
         <div className="flex gap-3 px-4 md:px-6 select-none pointer-events-none blur-sm">

--- a/src/components/home/PopularSection.tsx
+++ b/src/components/home/PopularSection.tsx
@@ -16,8 +16,10 @@ export function PopularSection({
   if (items.length === 0) return null
 
   return (
-    <section className="flex flex-col gap-3 py-6">
-      <h2 className="page-wrapper text-base font-semibold">{title}</h2>
+    <section className="flex flex-col gap-3">
+      <div className="page-wrapper">
+        <h2 className="border-b border-border pb-2 text-base font-semibold">{title}</h2>
+      </div>
       <ScrollRow>
         {items.map((roastery, i) => (
           <ScrollItem key={roastery.id}>

--- a/src/components/home/RecommendSection.tsx
+++ b/src/components/home/RecommendSection.tsx
@@ -12,8 +12,10 @@ export function RecommendSection({ title, items, onCardClick }: RecommendSection
   if (items.length === 0) return null
 
   return (
-    <section className="flex flex-col gap-3 py-6">
-      <h2 className="page-wrapper text-base font-semibold">{title}</h2>
+    <section className="flex flex-col gap-3">
+      <div className="page-wrapper">
+        <h2 className="border-b border-border pb-2 text-base font-semibold">{title}</h2>
+      </div>
       <ScrollRow>
         {items.map((item, i) => (
           <ScrollItem key={item.roastery.id}>


### PR DESCRIPTION
## 변경 사항
- `divide-y`(섹션 간 전체 폭 구분선) 제거 → 섹션 간 `gap-8` 복원
- 각 섹션 h2를 `page-wrapper` div로 감싸고 h2에 `border-b border-border pb-2` 추가 → 제목 아래 구분선이 padding 영역 안에서만 표시

## 테스트 방법
- [x] 각 섹션 제목 아래에 구분선이 표시되는지 확인
- [x] 구분선이 화면 가장자리까지 늘어나지 않고 여백 안에서 끝나는지 확인
- [x] 로그인/비로그인 상태 모두 동일하게 적용되는지 확인