### PR TITLE
fix: 검색 input 한글 IME 조합 끊김 및 글자 재등장 버그 수정

### DIFF
--- a/src/components/roastery/FilterPanel.tsx
+++ b/src/components/roastery/FilterPanel.tsx
@@ -27,9 +27,10 @@ export function FilterPanel({ filter, sort, isLoggedIn }: FilterPanelProps) {
   const [inputValue, setInputValue] = useState(filter.q)
   const searchId = useId()
   const isComposingRef = useRef(false)
+  const isFocusedRef = useRef(false)
 
   useEffect(() => {
-    setInputValue(filter.q)
+    if (!isFocusedRef.current) setInputValue(filter.q)
   }, [filter.q])
 
   useEffect(() => {
@@ -113,6 +114,12 @@ export function FilterPanel({ filter, sort, isLoggedIn }: FilterPanelProps) {
           placeholder="로스터리 이름 검색..."
           value={inputValue}
           onChange={(e) => setInputValue(e.target.value)}
+          onFocus={() => {
+            isFocusedRef.current = true
+          }}
+          onBlur={() => {
+            isFocusedRef.current = false
+          }}
           onCompositionStart={() => {
             isComposingRef.current = true
           }}
@@ -174,6 +181,12 @@ export function FilterPanel({ filter, sort, isLoggedIn }: FilterPanelProps) {
           placeholder="로스터리 이름 검색..."
           value={inputValue}
           onChange={(e) => setInputValue(e.target.value)}
+          onFocus={() => {
+            isFocusedRef.current = true
+          }}
+          onBlur={() => {
+            isFocusedRef.current = false
+          }}
           onCompositionStart={() => {
             isComposingRef.current = true
           }}

--- a/src/components/roastery/FilterPanel.tsx
+++ b/src/components/roastery/FilterPanel.tsx
@@ -25,6 +25,7 @@ export function FilterPanel({ filter, sort, isLoggedIn }: FilterPanelProps) {
   const [isPending, startTransition] = useTransition()
   const [openPill, setOpenPill] = useState<PillId | null>(null)
   const [inputValue, setInputValue] = useState(filter.q)
+  const [compositionKey, setCompositionKey] = useState(0)
   const searchId = useId()
   const isComposingRef = useRef(false)
   const isFocusedRef = useRef(false)
@@ -38,7 +39,7 @@ export function FilterPanel({ filter, sort, isLoggedIn }: FilterPanelProps) {
     const t = setTimeout(() => navigate({ q: inputValue.trim() }), 400)
     return () => clearTimeout(t)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [inputValue])
+  }, [inputValue, compositionKey])
 
   function buildParams(updates: Partial<FilterParams>): string {
     const params = new URLSearchParams(searchParams.toString())
@@ -125,6 +126,7 @@ export function FilterPanel({ filter, sort, isLoggedIn }: FilterPanelProps) {
           }}
           onCompositionEnd={() => {
             isComposingRef.current = false
+            setCompositionKey((k) => k + 1)
           }}
           onKeyDown={(e) => {
             if (e.key === 'Enter' && !e.nativeEvent.isComposing) navigate({ q: inputValue.trim() })
@@ -192,6 +194,7 @@ export function FilterPanel({ filter, sort, isLoggedIn }: FilterPanelProps) {
           }}
           onCompositionEnd={() => {
             isComposingRef.current = false
+            setCompositionKey((k) => k + 1)
           }}
           onKeyDown={(e) => {
             if (e.key === 'Enter' && !e.nativeEvent.isComposing) navigate({ q: inputValue.trim() })


### PR DESCRIPTION
## 변경 사항

- `isFocusedRef` 추가 — input 포커스 중 `filter.q → inputValue` 싱크 차단
- URL 업데이트(400ms 디바운스 결과)가 조합 중인 한글을 덮어쓰던 문제 해결
- 타이핑 후 빠르게 지웠을 때 지운 글자가 다시 나타나던 문제 해결
- 모바일·데스크탑 input 양쪽 모두 `onFocus` / `onBlur` 핸들러 추가

### 근본 원인

기존 코드에 `useEffect([filter.q]) → setInputValue(filter.q)` 싱크가 있었는데, 디바운스(400ms)가 URL을 업데이트하면 이 effect가 즉시 실행되면서 사용자가 이미 수정한 input 값을 덮어쓰는 구조였습니다. 한글 IME 조합 중에도 같은 문제가 발생했습니다.

## 테스트 방법

- [x] 로스터리 목록 페이지에서 검색창에 한글 입력 시 한 글자씩 즉시 반영되는지 확인
- [x] 한글 입력 후 빠르게 Backspace로 지웠을 때 지운 글자가 다시 나타나지 않는지 확인
- [x] 검색어 입력 후 400ms 뒤 실제 필터링이 정상 동작하는지 확인
- [x] 데스크탑/모바일 양쪽 모두 테스트