### PR TITLE
feat: 온보딩 Q1에 '아직 기구가 없어요' 옵션 추가

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -48,7 +48,7 @@ const securityHeaders = [
       // 웹폰트는 동일 출처만
       "font-src 'self'",
       // Sentry 에러 전송, Axiom 로그 전송 허용
-      "connect-src 'self' https://*.ingest.sentry.io https://api.axiom.co https://*.google-analytics.com https://analytics.google.com https://www.googletagmanager.com",
+      "connect-src 'self' https://*.ingest.sentry.io https://*.ingest.us.sentry.io https://api.axiom.co https://*.google-analytics.com https://analytics.google.com https://www.googletagmanager.com https://vitals.vercel-insights.com",
       // iframe으로 이 페이지를 삽입하는 것 자체를 차단 (X-Frame-Options 보완)
       "frame-ancestors 'none'",
       // <base> 태그 출처 제한 (base href 하이재킹 방지)

--- a/src/components/onboarding/steps/Q1BrewingMethod.tsx
+++ b/src/components/onboarding/steps/Q1BrewingMethod.tsx
@@ -2,6 +2,8 @@ import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import { BREWING_METHODS, BREWING_METHOD_LABELS, type BrewingMethod } from '@/types/onboarding'
 
+const EQUIPMENT_METHODS = BREWING_METHODS.filter((m) => m !== 'NONE')
+
 interface Q1BrewingMethodProps {
   selected: BrewingMethod[]
   onChange: (value: BrewingMethod[]) => void
@@ -10,10 +12,15 @@ interface Q1BrewingMethodProps {
 
 export function Q1BrewingMethod({ selected, onChange, onNext }: Q1BrewingMethodProps) {
   function toggle(method: BrewingMethod) {
-    if (selected.includes(method)) {
-      onChange(selected.filter((m) => m !== method))
+    if (method === 'NONE') {
+      onChange(selected.includes('NONE') ? [] : ['NONE'])
+      return
+    }
+    const withoutNone = selected.filter((m) => m !== 'NONE')
+    if (withoutNone.includes(method)) {
+      onChange(withoutNone.filter((m) => m !== method))
     } else {
-      onChange([...selected, method])
+      onChange([...withoutNone, method])
     }
   }
 
@@ -26,22 +33,37 @@ export function Q1BrewingMethod({ selected, onChange, onNext }: Q1BrewingMethodP
         <p className="mt-1 text-sm text-text-secondary">해당하는 것을 모두 선택해주세요</p>
       </div>
 
-      <div className="grid grid-cols-2 gap-3">
-        {BREWING_METHODS.map((method) => (
-          <button
-            key={method}
-            type="button"
-            onClick={() => toggle(method)}
-            className={cn(
-              'rounded-xl border px-4 py-3 text-left text-sm font-medium transition-colors',
-              selected.includes(method)
-                ? 'border-primary bg-primary/10 text-primary'
-                : 'border-border bg-card text-text-primary hover:border-primary/50'
-            )}
-          >
-            {BREWING_METHOD_LABELS[method]}
-          </button>
-        ))}
+      <div className="space-y-3">
+        <div className="grid grid-cols-2 gap-3">
+          {EQUIPMENT_METHODS.map((method) => (
+            <button
+              key={method}
+              type="button"
+              onClick={() => toggle(method)}
+              className={cn(
+                'rounded-xl border px-4 py-3 text-left text-sm font-medium transition-colors',
+                selected.includes(method)
+                  ? 'border-primary bg-primary/10 text-primary'
+                  : 'border-border bg-card text-text-primary hover:border-primary/50'
+              )}
+            >
+              {BREWING_METHOD_LABELS[method]}
+            </button>
+          ))}
+        </div>
+
+        <button
+          type="button"
+          onClick={() => toggle('NONE')}
+          className={cn(
+            'w-full rounded-xl border px-4 py-3 text-left text-sm font-medium transition-colors',
+            selected.includes('NONE')
+              ? 'border-primary bg-primary/10 text-primary'
+              : 'border-border bg-card text-text-primary hover:border-primary/50'
+          )}
+        >
+          {BREWING_METHOD_LABELS['NONE']}
+        </button>
       </div>
 
       <Button className="w-full" size="lg" onClick={onNext} disabled={selected.length === 0}>

--- a/src/lib/schemas/onboarding.ts
+++ b/src/lib/schemas/onboarding.ts
@@ -10,6 +10,14 @@ export const onboardingSchema = z
     q5: z.array(z.string()).optional(),
   })
   .superRefine((data, ctx) => {
+    if (data.q1.includes('NONE') && data.q1.length > 1) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['q1'],
+        message: '"아직 기구가 없어요"는 단독으로만 선택할 수 있습니다',
+      })
+    }
+
     if (data.q3.includes('NO_PREFERENCE') && data.q3.length > 1) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,

--- a/src/types/onboarding.ts
+++ b/src/types/onboarding.ts
@@ -5,6 +5,7 @@ export const BREWING_METHODS = [
   'COLD_BREW',
   'AEROPRESS',
   'MOKA_POT',
+  'NONE',
 ] as const
 
 export const PURCHASE_STYLES = ['ONLINE', 'OFFLINE', 'BOTH'] as const
@@ -39,6 +40,7 @@ export const BREWING_METHOD_LABELS: Record<BrewingMethod, string> = {
   COLD_BREW: '콜드브루',
   AEROPRESS: '에어로프레스',
   MOKA_POT: '모카포트',
+  NONE: '아직 기구가 없어요',
 }
 
 export const PURCHASE_STYLE_LABELS: Record<PurchaseStyle, string> = {


### PR DESCRIPTION
## 변경 사항
- `BREWING_METHODS`에 `NONE` 타입 및 레이블(아직 기구가 없어요) 추가
- Q1 컴포넌트: `NONE` 선택 시 다른 옵션 해제, 다른 옵션 선택 시 `NONE` 해제 (상호 배제)
- `NONE`은 기구 옵션 2열 그리드 아래 전체 폭 버튼으로 분리 배치
- `onboarding` 스키마에 `NONE` 단독 선택 검증 추가

## 테스트 방법
- [x] 온보딩 Q1에서 "아직 기구가 없어요" 버튼이 하단에 전체 폭으로 표시된다
- [x] "아직 기구가 없어요" 선택 시 다른 기구 옵션이 모두 해제된다
- [x] 다른 기구 옵션 선택 시 "아직 기구가 없어요"가 해제된다
- [x] "아직 기구가 없어요"만 선택한 상태로 다음 단계 진행이 가능하다