### PR TITLE
feat: 원두 로스팅 포인트에 미디움 라이트 옵션 추가

### DIFF
--- a/src/actions/admin.ts
+++ b/src/actions/admin.ts
@@ -141,7 +141,7 @@ export interface CreateBeanInput {
   prices: BeanPriceInput[]
 }
 
-const ROASTING_LEVELS = ['LIGHT', 'MEDIUM', 'MEDIUM_DARK', 'DARK']
+const ROASTING_LEVELS = ['LIGHT', 'MEDIUM_LIGHT', 'MEDIUM', 'MEDIUM_DARK', 'DARK']
 
 export async function createBean(input: CreateBeanInput): Promise<ActionResult<{ id: string }>> {
   const check = await requireAdmin()

--- a/src/app/admin/roasteries/[id]/edit/page.tsx
+++ b/src/app/admin/roasteries/[id]/edit/page.tsx
@@ -7,6 +7,7 @@ import type { PriceRange } from '@prisma/client'
 
 const ROASTING_LEVEL_LABEL: Record<string, string> = {
   LIGHT: '라이트',
+  MEDIUM_LIGHT: '미디움 라이트',
   MEDIUM: '미디엄',
   MEDIUM_DARK: '미디엄 다크',
   DARK: '다크',

--- a/src/app/admin/roasteries/[id]/page.tsx
+++ b/src/app/admin/roasteries/[id]/page.tsx
@@ -13,6 +13,7 @@ const PRICE_RANGE_LABEL: Record<string, string> = {
 
 const ROASTING_LEVEL_LABEL: Record<string, string> = {
   LIGHT: '라이트',
+  MEDIUM_LIGHT: '미디움 라이트',
   MEDIUM: '미디엄',
   MEDIUM_DARK: '미디엄 다크',
   DARK: '다크',

--- a/src/components/admin/BeanForm.tsx
+++ b/src/components/admin/BeanForm.tsx
@@ -43,6 +43,7 @@ interface BeanFormProps {
 
 const ROASTING_LEVELS = [
   { value: 'LIGHT', label: '라이트' },
+  { value: 'MEDIUM_LIGHT', label: '미디움 라이트' },
   { value: 'MEDIUM', label: '미디엄' },
   { value: 'MEDIUM_DARK', label: '미디엄 다크' },
   { value: 'DARK', label: '다크' },

--- a/src/components/roastery/FilterPanel.tsx
+++ b/src/components/roastery/FilterPanel.tsx
@@ -25,6 +25,7 @@ export function FilterPanel({ filter, sort, isLoggedIn }: FilterPanelProps) {
   const [isPending, startTransition] = useTransition()
   const [openPill, setOpenPill] = useState<PillId | null>(null)
   const [inputValue, setInputValue] = useState(filter.q)
+  const [compositionKey, setCompositionKey] = useState(0)
   const searchId = useId()
   const isComposingRef = useRef(false)
 
@@ -37,7 +38,7 @@ export function FilterPanel({ filter, sort, isLoggedIn }: FilterPanelProps) {
     const t = setTimeout(() => navigate({ q: inputValue.trim() }), 400)
     return () => clearTimeout(t)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [inputValue])
+  }, [inputValue, compositionKey])
 
   function buildParams(updates: Partial<FilterParams>): string {
     const params = new URLSearchParams(searchParams.toString())
@@ -118,6 +119,7 @@ export function FilterPanel({ filter, sort, isLoggedIn }: FilterPanelProps) {
           }}
           onCompositionEnd={() => {
             isComposingRef.current = false
+            setCompositionKey((k) => k + 1)
           }}
           onKeyDown={(e) => {
             if (e.key === 'Enter' && !e.nativeEvent.isComposing) navigate({ q: inputValue.trim() })
@@ -179,6 +181,7 @@ export function FilterPanel({ filter, sort, isLoggedIn }: FilterPanelProps) {
           }}
           onCompositionEnd={() => {
             isComposingRef.current = false
+            setCompositionKey((k) => k + 1)
           }}
           onKeyDown={(e) => {
             if (e.key === 'Enter' && !e.nativeEvent.isComposing) navigate({ q: inputValue.trim() })

--- a/src/types/roastery.ts
+++ b/src/types/roastery.ts
@@ -88,6 +88,7 @@ export const PRICE_OPTIONS = Object.keys(PRICE_RANGE_LABELS) as PriceRange[]
 export const ROASTING_LEVEL_LABELS: Record<string, string> = {
   LIGHT: '라이트',
   LIGHT_MEDIUM: '라이트 미디엄',
+  MEDIUM_LIGHT: '미디움 라이트',
   MEDIUM: '미디엄',
   MEDIUM_DARK: '미디엄 다크',
   DARK: '다크',


### PR DESCRIPTION
## 변경 사항
- 원두 생성/수정 폼(`BeanForm`)에 '미디움 라이트(MEDIUM_LIGHT)' 선택지 추가 (LIGHT와 MEDIUM 사이)
- 어드민 액션(`admin.ts`) ROASTING_LEVELS 허용 목록에 MEDIUM_LIGHT 추가
- 어드민 로스터리 상세/수정 페이지 표시 레이블 맵에 추가
- 공용 타입 `ROASTING_LEVEL_LABELS`에 추가 (유저 상세 페이지 등 표시에 반영)

## 테스트 방법
- [ ] 어드민에서 원두 추가 시 로스팅 포인트 선택 드롭다운에 '미디움 라이트'가 라이트와 미디엄 사이에 표시되는지 확인
- [x] 미디움 라이트로 저장 후 로스터리 상세 페이지에서 '미디움 라이트'로 표시되는지 확인
