### PR TITLE
fix: 한줄평 정렬 변경 시 / 리다이렉트 버그 수정

### DIFF
--- a/src/components/rating/RatingList.tsx
+++ b/src/components/rating/RatingList.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useEffect, useRef, useTransition } from 'react'
+import { toast } from 'sonner'
 import { RatingListItem } from './RatingListItem'
 import { RatingSortSelector } from './RatingSortSelector'
 import { fetchRoasteryRatings } from '@/actions/rating'
@@ -30,10 +31,16 @@ export function RatingList({
   // 정렬 변경 시 서버에서 재조회
   function handleSortChange(newSort: RatingSortOption) {
     setSort(newSort)
+    // 즉시 cursor를 null로 초기화해 IntersectionObserver가 이전 cursor로 동시 fetch하는 경쟁 조건 방지
+    setNextCursor(null)
     startTransition(async () => {
-      const page = await fetchRoasteryRatings({ roasteryId, sort: newSort, cursor: '' })
-      setItems(page.items)
-      setNextCursor(page.nextCursor)
+      try {
+        const page = await fetchRoasteryRatings({ roasteryId, sort: newSort, cursor: '' })
+        setItems(page.items)
+        setNextCursor(page.nextCursor)
+      } catch {
+        toast.error('한줄평을 불러오지 못했어요. 다시 시도해 주세요.')
+      }
     })
   }
 

--- a/src/components/rating/RatingSortSelector.tsx
+++ b/src/components/rating/RatingSortSelector.tsx
@@ -19,6 +19,7 @@ export function RatingSortSelector({ value, onChange }: RatingSortSelectorProps)
       {OPTIONS.map((opt) => (
         <button
           key={opt.value}
+          type="button"
           onClick={() => onChange(opt.value)}
           className={`text-xs px-3 py-1.5 rounded-full border transition-colors ${
             value === opt.value


### PR DESCRIPTION
## 변경 사항

- **RatingSortSelector**: 버튼에 `type="button"` 추가 — form submit 방지
- **RatingList**: `handleSortChange`에서 `setNextCursor(null)` 즉시 호출 — 정렬 변경 시 IntersectionObserver가 이전 cursor로 동시 fetch하는 경쟁 조건 제거
- **RatingList**: `fetchRoasteryRatings` 호출에 try-catch 추가 — Server Action 에러가 `startTransition` 밖으로 전파되어 Next.js가 예기치 않은 라우팅(/ 리다이렉트)을 일으키는 경우 차단

### 버그 원인 상세

정렬 변경 시 `setSort(newSort)` 호출 직후(단, `startTransition` 실행 전) 리렌더링이 발생하는 짧은 순간에 `sort = 새값`, `isPending = false` 상태가 됩니다. 이 시점에 `useEffect`(IntersectionObserver)가 재실행되면서, `nextCursor`가 남아 있는 경우 **이전 정렬의 cursor로 새 정렬 데이터를 가져오는 두 번째 `fetchRoasteryRatings` 호출이 동시에 발생**했습니다. 두 개의 동시 Server Action 호출이 충돌하거나 에러가 전파될 때, Next.js 16 + React 19 환경에서 `/`로 리다이렉트되는 문제가 생깁니다.

## 테스트 방법

- [x] 한줄평이 10개 이상인 로스터리 상세 페이지 진입
- [x] "낮은 순" 또는 "높은 순" 버튼 클릭 시 `/`로 리다이렉트되지 않고 정렬된 댓글이 표시되는지 확인
- [x] 정렬 변경 후 스크롤 다운 시 다음 페이지 댓글 정상 로드 확인
