### PR TITLE
feat: 온보딩 구매 빈도 질문을 첫 번째로 이동, 초보자 즉시 종료

### DIFF
--- a/src/actions/onboarding.ts
+++ b/src/actions/onboarding.ts
@@ -23,14 +23,15 @@ export async function submitOnboarding(data: OnboardingAnswers): Promise<ActionR
 
   const userId = session.user.id
   const { q1, q2, q3, q4, q5 } = parsed.data
+  const storedQ2 = q2 ?? '' // FIRST_TIME 시 q2 미입력 → 빈 문자열로 저장
   const storedQ3 = q3.filter((p) => p !== 'NO_PREFERENCE')
 
   try {
     await prisma.$transaction(async (tx) => {
       await tx.onboarding.upsert({
         where: { userId },
-        create: { userId, version: 3, q1, q2, q3: storedQ3, q4, q5: q5 ?? [] },
-        update: { version: 3, q1, q2, q3: storedQ3, q4, q5: q5 ?? [] },
+        create: { userId, version: 3, q1, q2: storedQ2, q3: storedQ3, q4, q5: q5 ?? [] },
+        update: { version: 3, q1, q2: storedQ2, q3: storedQ3, q4, q5: q5 ?? [] },
       })
 
       if (q4 !== 'FIRST_TIME' && q5 && q5.length > 0) {

--- a/src/components/onboarding/OnboardingWizard.test.tsx
+++ b/src/components/onboarding/OnboardingWizard.test.tsx
@@ -45,6 +45,11 @@ async function passQ0() {
   await userEvent.click(screen.getByRole('button', { name: '다음' }))
 }
 
+async function passQ4(frequency = '한 달에 한 번') {
+  await userEvent.click(screen.getByRole('button', { name: frequency }))
+  await userEvent.click(screen.getByRole('button', { name: '다음' }))
+}
+
 describe('OnboardingWizard', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -67,8 +72,8 @@ describe('OnboardingWizard', () => {
     expect(screen.getByText('1 / 6')).toBeInTheDocument()
   })
 
-  // C-20b: Q0 다음 → Q1 표시
-  it('C-20b: Q0에서 다음을 누르면 Q1 브루잉 방법 질문이 표시된다', async () => {
+  // C-20b: Q0 다음 → Q4(구매빈도) 표시
+  it('C-20b: Q0에서 다음을 누르면 구매 빈도 질문이 표시된다', async () => {
     render(
       <OnboardingWizard
         initialNickname={INITIAL_NICKNAME}
@@ -78,11 +83,11 @@ describe('OnboardingWizard', () => {
       />
     )
     await passQ0()
-    expect(screen.getByText(/어떤 방법으로 커피를 즐기시나요/i)).toBeInTheDocument()
+    expect(screen.getByText(/얼마나 자주 원두를 구매하시나요/i)).toBeInTheDocument()
     expect(screen.getByText('2 / 6')).toBeInTheDocument()
   })
 
-  // C-21: Q1 선택 → 다음 버튼 활성화
+  // C-21: Q4 통과 후 Q1에서 항목 선택하면 다음 버튼 활성화
   it('C-21: Q1에서 항목을 선택하면 다음 버튼이 활성화된다', async () => {
     render(
       <OnboardingWizard
@@ -93,6 +98,8 @@ describe('OnboardingWizard', () => {
       />
     )
     await passQ0()
+    await passQ4()
+
     const nextButton = screen.getByRole('button', { name: '다음' })
     expect(nextButton).toBeDisabled()
 
@@ -100,8 +107,8 @@ describe('OnboardingWizard', () => {
     expect(nextButton).toBeEnabled()
   })
 
-  // C-22: Q4=FIRST_TIME → Q5 스킵, 진행바 "5/5"
-  it('C-22: Q4에서 FIRST_TIME을 선택하면 총 5단계가 되고 "완료 및 제출" 버튼이 표시된다', async () => {
+  // C-22: Q4=FIRST_TIME → 즉시 종료, "2/2", "완료 및 제출" 버튼
+  it('C-22: Q4에서 FIRST_TIME을 선택하면 총 2단계가 되고 "완료 및 제출" 버튼이 표시된다', async () => {
     render(
       <OnboardingWizard
         initialNickname={INITIAL_NICKNAME}
@@ -112,28 +119,14 @@ describe('OnboardingWizard', () => {
     )
 
     await passQ0()
-
-    // Q1
-    await userEvent.click(screen.getByRole('button', { name: '에스프레소 머신' }))
-    await userEvent.click(screen.getByRole('button', { name: '다음' }))
-
-    // Q2
-    await userEvent.click(screen.getByRole('button', { name: '주로 온라인' }))
-    await userEvent.click(screen.getByRole('button', { name: '다음' }))
-
-    // Q3
-    await userEvent.click(screen.getByRole('button', { name: '크게 신경 안 써요' }))
-    await userEvent.click(screen.getByRole('button', { name: '다음' }))
-
-    // Q4 - FIRST_TIME 선택
     await userEvent.click(screen.getByRole('button', { name: '처음 구매해보려고요' }))
 
-    expect(screen.getByText('5 / 5')).toBeInTheDocument()
+    expect(screen.getByText('2 / 2')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: '완료 및 제출' })).toBeInTheDocument()
   })
 
-  // C-23: Q4≠FIRST_TIME → Q5 표시, 진행바 "6/6"
-  it('C-23: Q4에서 FIRST_TIME 외를 선택하고 다음으로 넘어가면 Q5가 표시된다', async () => {
+  // C-23: Q4≠FIRST_TIME → Q1→Q2→Q3→Q5 순서로 진행
+  it('C-23: Q4에서 FIRST_TIME 외를 선택하고 진행하면 Q5가 표시된다', async () => {
     render(
       <OnboardingWizard
         initialNickname={INITIAL_NICKNAME}
@@ -144,14 +137,13 @@ describe('OnboardingWizard', () => {
     )
 
     await passQ0()
+    await passQ4()
 
     await userEvent.click(screen.getByRole('button', { name: '에스프레소 머신' }))
     await userEvent.click(screen.getByRole('button', { name: '다음' }))
     await userEvent.click(screen.getByRole('button', { name: '주로 온라인' }))
     await userEvent.click(screen.getByRole('button', { name: '다음' }))
     await userEvent.click(screen.getByRole('button', { name: '크게 신경 안 써요' }))
-    await userEvent.click(screen.getByRole('button', { name: '다음' }))
-    await userEvent.click(screen.getByRole('button', { name: '한 달에 한 번' }))
     await userEvent.click(screen.getByRole('button', { name: '다음' }))
 
     expect(screen.getByText('6 / 6')).toBeInTheDocument()
@@ -170,14 +162,13 @@ describe('OnboardingWizard', () => {
     )
 
     await passQ0()
+    await passQ4()
 
     await userEvent.click(screen.getByRole('button', { name: '에스프레소 머신' }))
     await userEvent.click(screen.getByRole('button', { name: '다음' }))
     await userEvent.click(screen.getByRole('button', { name: '주로 온라인' }))
     await userEvent.click(screen.getByRole('button', { name: '다음' }))
     await userEvent.click(screen.getByRole('button', { name: '크게 신경 안 써요' }))
-    await userEvent.click(screen.getByRole('button', { name: '다음' }))
-    await userEvent.click(screen.getByRole('button', { name: '한 달에 한 번' }))
     await userEvent.click(screen.getByRole('button', { name: '다음' }))
 
     const submitButton = screen.getByRole('button', { name: '완료 및 제출' })

--- a/src/components/onboarding/OnboardingWizard.tsx
+++ b/src/components/onboarding/OnboardingWizard.tsx
@@ -19,7 +19,9 @@ import type {
   OnboardingAnswers,
 } from '@/types/onboarding'
 
+// 실제 표시 순서: Q0 → Q4(구매빈도, FIRST_TIME이면 즉시 종료) → Q1 → Q2 → Q3 → Q5
 type Step = 'Q0' | 'Q1' | 'Q2' | 'Q3' | 'Q4' | 'Q5'
+const STEP_ORDER: Step[] = ['Q0', 'Q4', 'Q1', 'Q2', 'Q3', 'Q5']
 
 interface Roastery {
   id: string
@@ -49,17 +51,14 @@ export function OnboardingWizard({
   const [isLoading, setIsLoading] = useState(false)
 
   const isFirstTime = q4 === 'FIRST_TIME'
-  const totalSteps = isFirstTime ? 5 : 6
-  const currentStep = ['Q0', 'Q1', 'Q2', 'Q3', 'Q4', 'Q5'].indexOf(step) + 1
+  const totalSteps = isFirstTime ? 2 : 6
+  const currentStep = STEP_ORDER.indexOf(step) + 1
 
   async function handleSubmit(answers: OnboardingAnswers) {
     setIsLoading(true)
     const result = await submitOnboarding(answers)
-    // 성공 시 서버가 redirect('/')를 호출 → 이 코드에 도달하지 않음
-    // 실패 시 서버가 ActionResult를 반환 → 에러 처리
     if (result && !result.success) {
       toast.error(result.error)
-      // FK 위반 (userId가 DB에 없음) → 세션 만료 → 로그아웃 후 /login
       if (result.code === 'UNAUTHORIZED') {
         await signOut({ callbackUrl: '/login' })
         return
@@ -76,7 +75,23 @@ export function OnboardingWizard({
           initialNickname={initialNickname}
           currentImage={currentImage}
           name={name}
+          onNext={() => setStep('Q4')}
+        />
+      </div>
+    )
+  }
+
+  if (step === 'Q4') {
+    return (
+      <div className="space-y-6">
+        <ProgressBar current={currentStep} total={totalSteps} />
+        <Q4Frequency
+          selected={q4}
+          onChange={setQ4}
           onNext={() => setStep('Q1')}
+          onSubmitEarly={() => handleSubmit({ q1: [], q3: [], q4: 'FIRST_TIME' })}
+          onBack={() => setStep('Q0')}
+          isLoading={isLoading}
         />
       </div>
     )
@@ -86,7 +101,12 @@ export function OnboardingWizard({
     return (
       <div className="space-y-6">
         <ProgressBar current={currentStep} total={totalSteps} />
-        <Q1BrewingMethod selected={q1} onChange={setQ1} onNext={() => setStep('Q2')} />
+        <Q1BrewingMethod
+          selected={q1}
+          onChange={setQ1}
+          onNext={() => setStep('Q2')}
+          onBack={() => setStep('Q4')}
+        />
       </div>
     )
   }
@@ -112,26 +132,8 @@ export function OnboardingWizard({
         <Q3PriceRange
           selected={q3}
           onChange={setQ3}
-          onNext={() => setStep('Q4')}
-          onBack={() => setStep('Q2')}
-        />
-      </div>
-    )
-  }
-
-  if (step === 'Q4') {
-    return (
-      <div className="space-y-6">
-        <ProgressBar current={currentStep} total={totalSteps} />
-        <Q4Frequency
-          selected={q4}
-          onChange={setQ4}
           onNext={() => setStep('Q5')}
-          onSubmitEarly={() => {
-            handleSubmit({ q1, q2: q2!, q3, q4: 'FIRST_TIME' })
-          }}
-          onBack={() => setStep('Q3')}
-          isLoading={isLoading}
+          onBack={() => setStep('Q2')}
         />
       </div>
     )
@@ -144,8 +146,8 @@ export function OnboardingWizard({
         roasteries={roasteries}
         selected={q5}
         onChange={setQ5}
-        onSubmit={() => handleSubmit({ q1, q2: q2!, q3, q4: q4!, q5 })}
-        onBack={() => setStep('Q4')}
+        onSubmit={() => handleSubmit({ q1, q2: q2 ?? undefined, q3, q4: q4!, q5 })}
+        onBack={() => setStep('Q3')}
         isLoading={isLoading}
       />
     </div>

--- a/src/components/onboarding/steps/Q1BrewingMethod.tsx
+++ b/src/components/onboarding/steps/Q1BrewingMethod.tsx
@@ -2,25 +2,19 @@ import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import { BREWING_METHODS, BREWING_METHOD_LABELS, type BrewingMethod } from '@/types/onboarding'
 
-const EQUIPMENT_METHODS = BREWING_METHODS.filter((m) => m !== 'NONE')
-
 interface Q1BrewingMethodProps {
   selected: BrewingMethod[]
   onChange: (value: BrewingMethod[]) => void
   onNext: () => void
+  onBack: () => void
 }
 
-export function Q1BrewingMethod({ selected, onChange, onNext }: Q1BrewingMethodProps) {
+export function Q1BrewingMethod({ selected, onChange, onNext, onBack }: Q1BrewingMethodProps) {
   function toggle(method: BrewingMethod) {
-    if (method === 'NONE') {
-      onChange(selected.includes('NONE') ? [] : ['NONE'])
-      return
-    }
-    const withoutNone = selected.filter((m) => m !== 'NONE')
-    if (withoutNone.includes(method)) {
-      onChange(withoutNone.filter((m) => m !== method))
+    if (selected.includes(method)) {
+      onChange(selected.filter((m) => m !== method))
     } else {
-      onChange([...withoutNone, method])
+      onChange([...selected, method])
     }
   }
 
@@ -33,42 +27,32 @@ export function Q1BrewingMethod({ selected, onChange, onNext }: Q1BrewingMethodP
         <p className="mt-1 text-sm text-text-secondary">해당하는 것을 모두 선택해주세요</p>
       </div>
 
-      <div className="space-y-3">
-        <div className="grid grid-cols-2 gap-3">
-          {EQUIPMENT_METHODS.map((method) => (
-            <button
-              key={method}
-              type="button"
-              onClick={() => toggle(method)}
-              className={cn(
-                'rounded-xl border px-4 py-3 text-left text-sm font-medium transition-colors',
-                selected.includes(method)
-                  ? 'border-primary bg-primary/10 text-primary'
-                  : 'border-border bg-card text-text-primary hover:border-primary/50'
-              )}
-            >
-              {BREWING_METHOD_LABELS[method]}
-            </button>
-          ))}
-        </div>
-
-        <button
-          type="button"
-          onClick={() => toggle('NONE')}
-          className={cn(
-            'w-full rounded-xl border px-4 py-3 text-left text-sm font-medium transition-colors',
-            selected.includes('NONE')
-              ? 'border-primary bg-primary/10 text-primary'
-              : 'border-border bg-card text-text-primary hover:border-primary/50'
-          )}
-        >
-          {BREWING_METHOD_LABELS['NONE']}
-        </button>
+      <div className="grid grid-cols-2 gap-3">
+        {BREWING_METHODS.map((method) => (
+          <button
+            key={method}
+            type="button"
+            onClick={() => toggle(method)}
+            className={cn(
+              'rounded-xl border px-4 py-3 text-left text-sm font-medium transition-colors',
+              selected.includes(method)
+                ? 'border-primary bg-primary/10 text-primary'
+                : 'border-border bg-card text-text-primary hover:border-primary/50'
+            )}
+          >
+            {BREWING_METHOD_LABELS[method]}
+          </button>
+        ))}
       </div>
 
-      <Button className="w-full" size="lg" onClick={onNext} disabled={selected.length === 0}>
-        다음
-      </Button>
+      <div className="flex gap-3">
+        <Button variant="outline" size="lg" onClick={onBack} className="shrink-0">
+          이전
+        </Button>
+        <Button className="flex-1" size="lg" onClick={onNext} disabled={selected.length === 0}>
+          다음
+        </Button>
+      </div>
     </div>
   )
 }

--- a/src/lib/schemas/onboarding.ts
+++ b/src/lib/schemas/onboarding.ts
@@ -3,19 +3,45 @@ import { BREWING_METHODS, PURCHASE_STYLES, PRICE_RANGES, FREQUENCIES } from '@/t
 
 export const onboardingSchema = z
   .object({
-    q1: z.array(z.enum(BREWING_METHODS)).min(1, '브루잉 방법을 최소 1개 선택해주세요'),
-    q2: z.enum(PURCHASE_STYLES),
-    q3: z.array(z.enum(PRICE_RANGES)).min(1, '가격대를 최소 1개 선택해주세요'),
+    q1: z.array(z.enum(BREWING_METHODS)),
+    q2: z.enum(PURCHASE_STYLES).optional(),
+    q3: z.array(z.enum(PRICE_RANGES)),
     q4: z.enum(FREQUENCIES),
     q5: z.array(z.string()).optional(),
   })
   .superRefine((data, ctx) => {
-    if (data.q1.includes('NONE') && data.q1.length > 1) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ['q1'],
-        message: '"아직 기구가 없어요"는 단독으로만 선택할 수 있습니다',
-      })
+    if (data.q4 !== 'FIRST_TIME') {
+      if (data.q1.length === 0) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['q1'],
+          message: '브루잉 방법을 최소 1개 선택해주세요',
+        })
+      }
+
+      if (!data.q2) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['q2'],
+          message: '구매 성향을 선택해주세요',
+        })
+      }
+
+      if (data.q3.length === 0) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['q3'],
+          message: '가격대를 최소 1개 선택해주세요',
+        })
+      }
+
+      if (!data.q5 || data.q5.length < 3) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['q5'],
+          message: '좋아하는 로스터리를 최소 3개 선택해주세요',
+        })
+      }
     }
 
     if (data.q3.includes('NO_PREFERENCE') && data.q3.length > 1) {
@@ -23,14 +49,6 @@ export const onboardingSchema = z
         code: z.ZodIssueCode.custom,
         path: ['q3'],
         message: '"크게 신경 안 써요"는 단독으로만 선택할 수 있습니다',
-      })
-    }
-
-    if (data.q4 !== 'FIRST_TIME' && (!data.q5 || data.q5.length < 3)) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ['q5'],
-        message: '좋아하는 로스터리를 최소 3개 선택해주세요',
       })
     }
   })

--- a/src/types/onboarding.ts
+++ b/src/types/onboarding.ts
@@ -5,7 +5,6 @@ export const BREWING_METHODS = [
   'COLD_BREW',
   'AEROPRESS',
   'MOKA_POT',
-  'NONE',
 ] as const
 
 export const PURCHASE_STYLES = ['ONLINE', 'OFFLINE', 'BOTH'] as const
@@ -27,7 +26,7 @@ export type Frequency = (typeof FREQUENCIES)[number]
 
 export interface OnboardingAnswers {
   q1: BrewingMethod[]
-  q2: PurchaseStyle
+  q2?: PurchaseStyle // q4 = FIRST_TIME이면 undefined
   q3: OnboardingPriceRange[]
   q4: Frequency
   q5?: string[] // roasteryId[], q4 = FIRST_TIME이면 undefined
@@ -40,7 +39,6 @@ export const BREWING_METHOD_LABELS: Record<BrewingMethod, string> = {
   COLD_BREW: '콜드브루',
   AEROPRESS: '에어로프레스',
   MOKA_POT: '모카포트',
-  NONE: '아직 기구가 없어요',
 }
 
 export const PURCHASE_STYLE_LABELS: Record<PurchaseStyle, string> = {


### PR DESCRIPTION
## 변경 사항
- Q4(구매빈도)를 온보딩 첫 번째 질문(Q0 프로필 다음)으로 이동
- **처음 구매해보려고요** 선택 시 나머지 질문(브루잉/구매성향/가격대/로스터리) 생략 → 즉시 온보딩 완료 (2/2 진행바)
- 경험자는 기존 순서대로 Q1→Q2→Q3→Q5 진행 (6단계)
- `NONE` 옵션 제거 (Q4 FIRST_TIME이 초보자 분기 전담)
- FIRST_TIME 시 q2 미입력 → DB 빈 문자열 저장 (DB 마이그레이션 없음)
- 스키마/액션/테스트 모두 새 플로우 기준으로 업데이트

## 테스트 방법
- [x] Q0(프로필) 완료 후 구매 빈도 질문이 표시된다
- [x] **처음 구매해보려고요** 선택 시 진행바가 2/2로 바뀌고 "완료 및 제출" 버튼이 표시된다
- [x] **처음 구매해보려고요** 완료 및 제출 → 온보딩 완료 후 홈으로 이동한다
- [x] 다른 빈도 선택 후 다음 → 브루잉 방법 질문(3/6)이 표시된다
- [x] 이전 버튼으로 Q4 → Q0 방향으로 돌아갈 수 있다