### PR TITLE
fix: 한글 IME 조합 중 검색 debounce 처리 개선

### DIFF
--- a/src/components/roastery/FilterPanel.tsx
+++ b/src/components/roastery/FilterPanel.tsx
@@ -25,9 +25,7 @@ export function FilterPanel({ filter, sort, isLoggedIn }: FilterPanelProps) {
   const [isPending, startTransition] = useTransition()
   const [openPill, setOpenPill] = useState<PillId | null>(null)
   const [inputValue, setInputValue] = useState(filter.q)
-  const [compositionKey, setCompositionKey] = useState(0)
   const searchId = useId()
-  const isComposingRef = useRef(false)
   const isFocusedRef = useRef(false)
 
   useEffect(() => {
@@ -35,11 +33,11 @@ export function FilterPanel({ filter, sort, isLoggedIn }: FilterPanelProps) {
   }, [filter.q])
 
   useEffect(() => {
-    if (inputValue.trim() === filter.q || isComposingRef.current) return
-    const t = setTimeout(() => navigate({ q: inputValue.trim() }), 400)
+    if (inputValue.trim() === filter.q) return
+    const t = setTimeout(() => navigate({ q: inputValue.trim() }), 500)
     return () => clearTimeout(t)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [inputValue, compositionKey])
+  }, [inputValue])
 
   function buildParams(updates: Partial<FilterParams>): string {
     const params = new URLSearchParams(searchParams.toString())
@@ -121,13 +119,6 @@ export function FilterPanel({ filter, sort, isLoggedIn }: FilterPanelProps) {
           onBlur={() => {
             isFocusedRef.current = false
           }}
-          onCompositionStart={() => {
-            isComposingRef.current = true
-          }}
-          onCompositionEnd={() => {
-            isComposingRef.current = false
-            setCompositionKey((k) => k + 1)
-          }}
           onKeyDown={(e) => {
             if (e.key === 'Enter' && !e.nativeEvent.isComposing) navigate({ q: inputValue.trim() })
           }}
@@ -188,13 +179,6 @@ export function FilterPanel({ filter, sort, isLoggedIn }: FilterPanelProps) {
           }}
           onBlur={() => {
             isFocusedRef.current = false
-          }}
-          onCompositionStart={() => {
-            isComposingRef.current = true
-          }}
-          onCompositionEnd={() => {
-            isComposingRef.current = false
-            setCompositionKey((k) => k + 1)
           }}
           onKeyDown={(e) => {
             if (e.key === 'Enter' && !e.nativeEvent.isComposing) navigate({ q: inputValue.trim() })


### PR DESCRIPTION
## 변경 사항
- `isComposingRef` 체크 제거 → 한글 조합 중에도 debounce 타이머 시작
- debounce 타임아웃 400ms → 500ms (자모 중간 상태 검색 방지)
- 불필요한 `compositionKey` state, `isComposingRef` ref, `onCompositionStart`/`onCompositionEnd` 핸들러 제거

## 테스트 방법
- [x] 한글 '모' 입력 후 500ms 대기 → 검색 결과 갱신 확인
- [x] 영어 'mo' 입력 후 500ms 대기 → 검색 결과 갱신 확인
- [x] 빠르게 연속 입력 시 마지막 글자 기준으로 검색되는지 확인 (debounce)
- [x] Enter 키로 즉시 검색 동작 확인