### PR TITLE
fix: 온보딩 완료 사용자의 JWT 갱신으로 홈 리다이렉트 버그 수정

### DIFF
--- a/src/app/(auth)/onboarding/page.tsx
+++ b/src/app/(auth)/onboarding/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from 'next/navigation'
-import { auth } from '@/lib/auth'
+import { auth, unstable_update } from '@/lib/auth'
 import { prisma } from '@/lib/prisma'
 import { generateUniqueNickname } from '@/lib/nickname'
 import { flattenTags } from '@/types/roastery'
@@ -17,7 +17,11 @@ export default async function OnboardingPage() {
       select: { nickname: true, image: true, name: true },
     }),
   ])
-  if (existing) redirect('/')
+  if (existing) {
+    // JWT에 onboardingVersion이 없는 경우를 처리: 갱신 후 리다이렉트
+    await unstable_update({})
+    redirect('/')
+  }
 
   // signIn 콜백 미실행 등으로 닉네임이 없는 경우 여기서 보완
   let nickname = user?.nickname ?? null


### PR DESCRIPTION
## 변경 사항
- JWT에 `onboardingVersion`이 없는 구 세션을 가진 로그인 사용자가 `/roasteries` 등 방문 시 미들웨어 → `/onboarding` → `/` 로 의도치 않게 리다이렉트되는 버그 수정
- `/onboarding` 페이지에서 이미 온보딩이 완료된 기록이 있을 때 `unstable_update()`로 JWT를 갱신 후 리다이렉트
- 이로써 다음 요청부터 미들웨어가 `onboardingComplete=true`로 인식해 정상 접근 가능

## 버그 원인
1. 미들웨어(Edge): `auth?.user?.onboardingVersion == null` → `/onboarding` 리다이렉트
2. `/onboarding` 페이지: DB에 기존 온보딩 기록 발견 → `redirect('/')`
3. 결과: 로스터리 상세, 소트 버튼 서버 액션 모두 홈으로 튕기는 현상

## 테스트 방법
- [x] 온보딩 완료 사용자가 `/roasteries/[id]` 접근 시 정상 렌더링 확인
- [x] 한줄평 영역 높은 순/낮은 순 클릭 시 데이터 정렬 (홈 리다이렉트 없음)