### PR TITLE
feat: 원두 디카페인 여부에 따라 로스터리 decaf 자동 동기화

### DIFF
--- a/src/actions/admin.ts
+++ b/src/actions/admin.ts
@@ -143,6 +143,17 @@ export interface CreateBeanInput {
 
 const ROASTING_LEVELS = ['LIGHT', 'MEDIUM_LIGHT', 'MEDIUM', 'MEDIUM_DARK', 'DARK']
 
+/** 현재 visible 원두(deletedAt=null, hidden=false) 기준으로 Roastery.decaf를 재동기화 */
+async function syncRoasteryDecaf(roasteryId: string): Promise<void> {
+  const count = await prisma.bean.count({
+    where: { roasteryId, decaf: true, deletedAt: null, hidden: false },
+  })
+  await prisma.roastery.update({
+    where: { id: roasteryId },
+    data: { decaf: count > 0 },
+  })
+}
+
 export async function createBean(input: CreateBeanInput): Promise<ActionResult<{ id: string }>> {
   const check = await requireAdmin()
   if ('error' in check) {
@@ -181,6 +192,7 @@ export async function createBean(input: CreateBeanInput): Promise<ActionResult<{
       },
       select: { id: true },
     })
+    await syncRoasteryDecaf(input.roasteryId)
     return { success: true, data: { id: bean.id } }
   } catch {
     return { success: false, error: '저장 중 오류가 발생했습니다', code: 'DB_ERROR' }
@@ -298,6 +310,7 @@ export async function updateBean(
       },
       select: { id: true },
     })
+    await syncRoasteryDecaf(input.roasteryId)
     return { success: true, data: { id: bean.id } }
   } catch {
     return { success: false, error: '저장 중 오류가 발생했습니다', code: 'DB_ERROR' }
@@ -385,7 +398,12 @@ export async function softDeleteBean(id: string): Promise<ActionResult<void>> {
   const check = await requireAdmin()
   if ('error' in check) return { success: false, error: check.error, code: check.code }
   try {
-    await prisma.bean.update({ where: { id }, data: { deletedAt: new Date() } })
+    const bean = await prisma.bean.update({
+      where: { id },
+      data: { deletedAt: new Date() },
+      select: { roasteryId: true },
+    })
+    await syncRoasteryDecaf(bean.roasteryId)
     revalidatePath('/admin/roasteries')
     return { success: true, data: undefined }
   } catch {
@@ -397,7 +415,12 @@ export async function restoreBean(id: string): Promise<ActionResult<void>> {
   const check = await requireAdmin()
   if ('error' in check) return { success: false, error: check.error, code: check.code }
   try {
-    await prisma.bean.update({ where: { id }, data: { deletedAt: null } })
+    const bean = await prisma.bean.update({
+      where: { id },
+      data: { deletedAt: null },
+      select: { roasteryId: true },
+    })
+    await syncRoasteryDecaf(bean.roasteryId)
     revalidatePath('/admin/roasteries')
     return { success: true, data: undefined }
   } catch {
@@ -409,9 +432,13 @@ export async function toggleHideBean(id: string): Promise<ActionResult<void>> {
   const check = await requireAdmin()
   if ('error' in check) return { success: false, error: check.error, code: check.code }
   try {
-    const current = await prisma.bean.findUnique({ where: { id }, select: { hidden: true } })
+    const current = await prisma.bean.findUnique({
+      where: { id },
+      select: { hidden: true, roasteryId: true },
+    })
     if (!current) return { success: false, error: '존재하지 않는 원두입니다', code: 'VALIDATION' }
     await prisma.bean.update({ where: { id }, data: { hidden: !current.hidden } })
+    await syncRoasteryDecaf(current.roasteryId)
     revalidatePath('/admin/roasteries')
     return { success: true, data: undefined }
   } catch {

--- a/src/actions/admin.ts
+++ b/src/actions/admin.ts
@@ -288,6 +288,7 @@ export async function updateBean(
 
   try {
     const validPrices = input.prices.filter((p) => p.price !== null && p.price >= 0)
+    const prev = await prisma.bean.findUnique({ where: { id }, select: { roasteryId: true } })
     const bean = await prisma.bean.update({
       where: { id },
       data: {
@@ -310,7 +311,9 @@ export async function updateBean(
       },
       select: { id: true },
     })
-    await syncRoasteryDecaf(input.roasteryId)
+    const syncTargets = new Set([input.roasteryId])
+    if (prev?.roasteryId) syncTargets.add(prev.roasteryId)
+    await Promise.all([...syncTargets].map(syncRoasteryDecaf))
     return { success: true, data: { id: bean.id } }
   } catch {
     return { success: false, error: '저장 중 오류가 발생했습니다', code: 'DB_ERROR' }


### PR DESCRIPTION
## 변경 사항
- `syncRoasteryDecaf(roasteryId)` 헬퍼 추가: visible 원두(`deletedAt=null, hidden=false`) 중 하나라도 `decaf: true`이면 `Roastery.decaf=true`, 없으면 `false`로 자동 갱신
- `createBean` / `updateBean` / `softDeleteBean` / `restoreBean` / `toggleHideBean` 5곳에서 bean 뮤테이션 후 자동 호출
- `updateBean`에서 `roasteryId`가 바뀌는 경우(원두 이동) 이전 로스터리도 함께 재동기화

## 테스트 방법
- [x] 어드민에서 디카페인 원두 추가 → 로스터리 목록에서 디카페인 필터 ON 시 해당 로스터리 노출 확인
- [x] 해당 원두 soft delete → 다른 디카페인 원두 없으면 로스터리 decaf=false, 디카페인 필터에서 사라짐 확인
- [x] 원두 숨김(hide) 토글 → decaf 상태 재동기화 확인