### PR TITLE
fix: next-axiom withAxiom 래퍼 추가

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,6 @@
 import type { NextConfig } from 'next'
 import { withSentryConfig } from '@sentry/nextjs'
+import { withAxiom } from 'next-axiom'
 
 const securityHeaders = [
   // DNS 프리페칭 허용: 외부 도메인 DNS를 미리 조회해 페이지 로딩 속도 향상
@@ -89,7 +90,7 @@ const nextConfig: NextConfig = {
   },
 }
 
-export default withSentryConfig(nextConfig, {
+export default withSentryConfig(withAxiom(nextConfig), {
   // Sentry 프로젝트 설정
   org: process.env.SENTRY_ORG,
   project: process.env.SENTRY_PROJECT,

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -5,5 +5,7 @@ import { authConfig } from '@/lib/auth.config'
 export default NextAuth(authConfig).auth
 
 export const config = {
-  matcher: ['/((?!_next/static|_next/image|favicon.ico|robots.txt|sitemap.xml|brand/|icons/).*)'],
+  matcher: [
+    '/((?!_next/static|_next/image|favicon.ico|robots.txt|sitemap.xml|brand/|icons/|_axiom/).*)',
+  ],
 }


### PR DESCRIPTION
## 변경 사항
- `next.config.ts`에 `withAxiom` 래퍼 누락으로 Axiom 로깅이 동작하지 않는 문제 수정
- `withSentryConfig(withAxiom(nextConfig))`로 체인하여 서버 사이드 로그 flush 정상화
- `proxy.ts` matcher에 `_axiom` 경로 제외 추가 (auth 미들웨어가 `/_axiom/*` 차단하는 문제 수정)

> **참고**: 이 프로젝트는 서버 사이드 로깅만 사용합니다. 클라이언트 사이드 `/_axiom/logs` 프록시는 Vercel 통합(로그 드레인)이 없으면 인증 헤더 없이 Axiom API를 직접 호출하므로 활성화되지 않습니다.

## 테스트 방법
- [x] `pnpm dev` 실행 후 서버 액션(`events.ts`) 호출 시 콘솔에 Axiom 관련 경고 없음 확인
- [ ] Axiom 대시보드(`roco-log` 데이터셋)에서 서버 로그 수집 확인 (배포 후 수동 확인)