### PR TITLE
fix: 미디움 라이트 → 미디엄 라이트 오타 수정

### DIFF
--- a/src/app/admin/roasteries/[id]/edit/page.tsx
+++ b/src/app/admin/roasteries/[id]/edit/page.tsx
@@ -7,7 +7,7 @@ import type { PriceRange } from '@prisma/client'
 
 const ROASTING_LEVEL_LABEL: Record<string, string> = {
   LIGHT: '라이트',
-  MEDIUM_LIGHT: '미디움 라이트',
+  MEDIUM_LIGHT: '미디엄 라이트',
   MEDIUM: '미디엄',
   MEDIUM_DARK: '미디엄 다크',
   DARK: '다크',

--- a/src/app/admin/roasteries/[id]/page.tsx
+++ b/src/app/admin/roasteries/[id]/page.tsx
@@ -13,7 +13,7 @@ const PRICE_RANGE_LABEL: Record<string, string> = {
 
 const ROASTING_LEVEL_LABEL: Record<string, string> = {
   LIGHT: '라이트',
-  MEDIUM_LIGHT: '미디움 라이트',
+  MEDIUM_LIGHT: '미디엄 라이트',
   MEDIUM: '미디엄',
   MEDIUM_DARK: '미디엄 다크',
   DARK: '다크',

--- a/src/components/admin/BeanForm.tsx
+++ b/src/components/admin/BeanForm.tsx
@@ -43,7 +43,7 @@ interface BeanFormProps {
 
 const ROASTING_LEVELS = [
   { value: 'LIGHT', label: '라이트' },
-  { value: 'MEDIUM_LIGHT', label: '미디움 라이트' },
+  { value: 'MEDIUM_LIGHT', label: '미디엄 라이트' },
   { value: 'MEDIUM', label: '미디엄' },
   { value: 'MEDIUM_DARK', label: '미디엄 다크' },
   { value: 'DARK', label: '다크' },

--- a/src/types/roastery.ts
+++ b/src/types/roastery.ts
@@ -88,7 +88,7 @@ export const PRICE_OPTIONS = Object.keys(PRICE_RANGE_LABELS) as PriceRange[]
 export const ROASTING_LEVEL_LABELS: Record<string, string> = {
   LIGHT: '라이트',
   LIGHT_MEDIUM: '라이트 미디엄',
-  MEDIUM_LIGHT: '미디움 라이트',
+  MEDIUM_LIGHT: '미디엄 라이트',
   MEDIUM: '미디엄',
   MEDIUM_DARK: '미디엄 다크',
   DARK: '다크',


### PR DESCRIPTION
## 변경 사항
- `미디움 라이트`를 `미디엄 라이트`로 오타 수정
- 수정 파일: `src/types/roastery.ts`, `src/app/admin/roasteries/[id]/page.tsx`, `src/app/admin/roasteries/[id]/edit/page.tsx`, `src/components/admin/BeanForm.tsx`

## 테스트 방법
- [x] 원두 등록/편집 시 로스팅 레벨 선택지에 "미디엄 라이트"가 표시되는지 확인
- [x] 로스터리 상세/편집 페이지에서 MEDIUM_LIGHT 로스팅 레벨이 "미디엄 라이트"로 표시되는지 확인