### PR TITLE
fix: 평가 3개 미만 시 stale Recommendation 레코드 정리

### DIFF
--- a/src/lib/recommender/index.ts
+++ b/src/lib/recommender/index.ts
@@ -21,7 +21,7 @@ export async function getRecommendations(userId?: string): Promise<Recommendatio
     return getPopularFallback(userId)
   }
 
-  // new: 유저가 평가하지 않은 로스터리, cfScore 내림차순 상위 5개
+  // new: 유저가 평가하지 않은 로스터리, cfScore 내림차순 상위 7개
   const newItems = stored
     .filter((r) => r.userRating === undefined)
     .sort((a, b) => b.cfScore - a.cfScore)

--- a/src/lib/recommender/item-cf.ts
+++ b/src/lib/recommender/item-cf.ts
@@ -70,7 +70,10 @@ export async function computeAndSaveCF(userId: string): Promise<void> {
   if (ratings.length === 0) return
 
   const userRatings = ratings.filter((r) => r.userId === userId)
-  if (userRatings.length < 3) return
+  if (userRatings.length < 3) {
+    await prisma.recommendation.deleteMany({ where: { userId } })
+    return
+  }
 
   const matrix = buildSimilarityMatrix(ratings)
   const userRatedMap = new Map(userRatings.map((r) => [r.roasteryId, r.score]))


### PR DESCRIPTION
## 변경 사항
- `computeAndSaveCF`: 평가 수가 3개 미만으로 내려갈 때 해당 유저의 Recommendation 레코드를 삭제하도록 변경
  - 기존: 3개 미만이면 early return → 기존 추천 레코드가 DB에 stale 상태로 남음
  - 변경: 삭제 후 return → 평가 삭제로 CF 비활성화 상태가 되면 DB도 즉시 정리
- `index.ts` 주석 오타 수정: "상위 5개" → "상위 7개" (코드는 `.slice(0, 7)`로 이미 정확했음)

## 테스트 방법
- [x] 평가 3개 이상인 유저가 평가를 삭제해 2개로 줄어들면 Recommendation 테이블에서 해당 유저 레코드가 삭제되는지 확인
- [x] 평가 3개 이상 유지 시 CF 재계산이 정상 동작하는지 확인