### PR TITLE
feat: framer-motion 기반 통일 spring 인터랙션 시스템 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@vercel/speed-insights": "^2.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "framer-motion": "^12.38.0",
     "lucide-react": "^0.577.0",
     "next": "16.1.6",
     "next-auth": "5.0.0-beta.30",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      framer-motion:
+        specifier: ^12.38.0
+        version: 12.38.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       lucide-react:
         specifier: ^0.577.0
         version: 0.577.0(react@19.2.3)
@@ -3020,6 +3023,20 @@ packages:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
 
+  framer-motion@12.38.0:
+    resolution: {integrity: sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
@@ -3752,6 +3769,12 @@ packages:
 
   module-details-from-path@1.0.4:
     resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
+
+  motion-dom@12.38.0:
+    resolution: {integrity: sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==}
+
+  motion-utils@12.36.0:
+    resolution: {integrity: sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -8158,6 +8181,15 @@ snapshots:
 
   forwarded@0.2.0: {}
 
+  framer-motion@12.38.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      motion-dom: 12.38.0
+      motion-utils: 12.36.0
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+
   fresh@2.0.0: {}
 
   fs-extra@11.3.4:
@@ -8810,6 +8842,12 @@ snapshots:
   minipass@7.1.3: {}
 
   module-details-from-path@1.0.4: {}
+
+  motion-dom@12.38.0:
+    dependencies:
+      motion-utils: 12.36.0
+
+  motion-utils@12.36.0: {}
 
   ms@2.1.3: {}
 

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -2,6 +2,7 @@ import { redirect } from 'next/navigation'
 import { auth } from '@/lib/auth'
 import { prisma } from '@/lib/prisma'
 import { Navigation } from '@/components/layout/Navigation'
+import { PageTransition } from '@/components/motion/PageTransition'
 
 export default async function MainLayout({ children }: { children: React.ReactNode }) {
   const session = await auth()
@@ -19,7 +20,7 @@ export default async function MainLayout({ children }: { children: React.ReactNo
       <Navigation />
       {/* 모바일: BottomTab 높이(64px)만큼 하단 패딩 */}
       <main className="flex-1 pb-[calc(4rem+env(safe-area-inset-bottom,0px))] lg:pb-0">
-        {children}
+        <PageTransition>{children}</PageTransition>
       </main>
     </div>
   )

--- a/src/components/bookmark/BookmarkButton.tsx
+++ b/src/components/bookmark/BookmarkButton.tsx
@@ -42,6 +42,7 @@ export function BookmarkButton({
     <motion.button
       type="button"
       aria-label={isBookmarked ? '즐겨찾기 해제' : '즐겨찾기 추가'}
+      aria-pressed={isBookmarked}
       disabled={isPending}
       onClick={handleClick}
       whileTap={TAP_SCALE}

--- a/src/components/bookmark/BookmarkButton.tsx
+++ b/src/components/bookmark/BookmarkButton.tsx
@@ -3,8 +3,10 @@
 import { useOptimistic, useTransition } from 'react'
 import { toast } from 'sonner'
 import { Bookmark } from 'lucide-react'
+import { motion, AnimatePresence } from 'framer-motion'
 import { toggleBookmark } from '@/actions/bookmark'
 import { cn } from '@/lib/utils'
+import { SPRING_SNAPPY, SPRING_POP, TAP_SCALE } from '@/lib/motion'
 
 interface BookmarkButtonProps {
   roasteryId: string
@@ -37,23 +39,36 @@ export function BookmarkButton({
   }
 
   return (
-    <button
+    <motion.button
       type="button"
       aria-label={isBookmarked ? '즐겨찾기 해제' : '즐겨찾기 추가'}
       disabled={isPending}
       onClick={handleClick}
+      whileTap={TAP_SCALE}
+      transition={SPRING_SNAPPY}
       className={cn(
-        'flex items-center justify-center rounded-full p-1.5 transition-colors',
+        'flex items-center justify-center rounded-full p-1.5',
         'hover:bg-muted disabled:pointer-events-none',
         className
       )}
     >
-      <Bookmark
-        className={cn(
-          'size-5 transition-colors',
-          isBookmarked ? 'fill-primary stroke-primary' : 'stroke-muted-foreground'
-        )}
-      />
-    </button>
+      <AnimatePresence mode="wait" initial={false}>
+        <motion.span
+          key={isBookmarked ? 'bookmarked' : 'unbookmarked'}
+          initial={{ scale: 0.4, rotate: isBookmarked ? -25 : 25, opacity: 0 }}
+          animate={{ scale: 1, rotate: 0, opacity: 1 }}
+          exit={{ scale: 0.4, opacity: 0 }}
+          transition={SPRING_POP}
+          className="flex"
+        >
+          <Bookmark
+            className={cn(
+              'size-5',
+              isBookmarked ? 'fill-primary stroke-primary' : 'stroke-muted-foreground'
+            )}
+          />
+        </motion.span>
+      </AnimatePresence>
+    </motion.button>
   )
 }

--- a/src/components/home/DecafToggle.tsx
+++ b/src/components/home/DecafToggle.tsx
@@ -1,3 +1,8 @@
+'use client'
+
+import { motion } from 'framer-motion'
+import { SPRING_SNAPPY, TAP_SCALE } from '@/lib/motion'
+
 interface DecafToggleProps {
   decafOn: boolean
   onToggle: () => void
@@ -5,9 +10,11 @@ interface DecafToggleProps {
 
 export function DecafToggle({ decafOn, onToggle }: DecafToggleProps) {
   return (
-    <button
+    <motion.button
       type="button"
       onClick={onToggle}
+      whileTap={TAP_SCALE}
+      transition={SPRING_SNAPPY}
       className={`inline-flex items-center gap-2 rounded-full border px-4 py-1.5 text-sm font-medium transition-colors cursor-pointer ${
         decafOn
           ? 'border-primary bg-primary text-primary-foreground'
@@ -15,6 +22,6 @@ export function DecafToggle({ decafOn, onToggle }: DecafToggleProps) {
       }`}
     >
       디카페인만 보기
-    </button>
+    </motion.button>
   )
 }

--- a/src/components/home/DecafToggle.tsx
+++ b/src/components/home/DecafToggle.tsx
@@ -12,6 +12,7 @@ export function DecafToggle({ decafOn, onToggle }: DecafToggleProps) {
   return (
     <motion.button
       type="button"
+      aria-pressed={decafOn}
       onClick={onToggle}
       whileTap={TAP_SCALE}
       transition={SPRING_SNAPPY}

--- a/src/components/home/HomeFeedClient.tsx
+++ b/src/components/home/HomeFeedClient.tsx
@@ -11,7 +11,7 @@ import { logClientEvent } from '@/actions/events'
 import type { RecommendationResult, RecommendationItem } from '@/lib/recommender'
 import type { FeaturedSectionData } from '@/lib/queries/recommendation'
 import type { RoasteryWithStats } from '@/types/roastery'
-import { fadeUpVariants, SPRING_MEDIUM } from '@/lib/motion'
+import { fadeUpVariants } from '@/lib/motion'
 
 interface HomeFeedClientProps {
   result: RecommendationResult
@@ -128,7 +128,6 @@ export function HomeFeedClient({
             initial="hidden"
             whileInView="visible"
             viewport={{ once: true, margin: '-60px' }}
-            transition={SPRING_MEDIUM}
           >
             {content}
           </motion.div>

--- a/src/components/home/HomeFeedClient.tsx
+++ b/src/components/home/HomeFeedClient.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useTransition } from 'react'
 import { useRouter } from 'next/navigation'
+import { motion } from 'framer-motion'
 import { DecafToggle } from './DecafToggle'
 import { RecommendSection } from './RecommendSection'
 import { PopularSection } from './PopularSection'
@@ -10,6 +11,7 @@ import { logClientEvent } from '@/actions/events'
 import type { RecommendationResult, RecommendationItem } from '@/lib/recommender'
 import type { FeaturedSectionData } from '@/lib/queries/recommendation'
 import type { RoasteryWithStats } from '@/types/roastery'
+import { fadeUpVariants, SPRING_MEDIUM } from '@/lib/motion'
 
 interface HomeFeedClientProps {
   result: RecommendationResult
@@ -67,51 +69,70 @@ export function HomeFeedClient({
       )}
 
       {sections.map((section) => {
+        let content: React.ReactNode = null
+
         switch (section.type) {
           case 'CF_NEW':
-            if (!isLoggedIn) return <LoginCTASection key={section.id} title={section.title} />
-            if (result.source === 'fallback') return null
-            return (
-              <RecommendSection
-                key={section.id}
-                title={section.title}
-                items={cfNewItems}
-                onCardClick={handleCardClick}
-              />
-            )
+            if (!isLoggedIn) content = <LoginCTASection title={section.title} />
+            else if (result.source === 'fallback') return null
+            else
+              content = (
+                <RecommendSection
+                  title={section.title}
+                  items={cfNewItems}
+                  onCardClick={handleCardClick}
+                />
+              )
+            break
 
           case 'CF_REPEAT':
-            if (!isLoggedIn) return <LoginCTASection key={section.id} title={section.title} />
-            if (result.source === 'fallback') return null
-            return (
-              <RecommendSection
-                key={section.id}
-                title={section.title}
-                items={cfRepeatItems}
-                onCardClick={handleCardClick}
-              />
-            )
+            if (!isLoggedIn) content = <LoginCTASection title={section.title} />
+            else if (result.source === 'fallback') return null
+            else
+              content = (
+                <RecommendSection
+                  title={section.title}
+                  items={cfRepeatItems}
+                  onCardClick={handleCardClick}
+                />
+              )
+            break
 
           case 'POPULAR':
-            return (
+            content = (
               <PopularSection
-                key={section.id}
                 title={section.title}
                 items={popularItems}
                 onCardClick={handleCardClick}
               />
             )
+            break
 
           case 'CUSTOM':
-            return (
+            content = (
               <PopularSection
-                key={section.id}
                 title={section.title}
                 items={section.roasteries}
                 onCardClick={handleCardClick}
               />
             )
+            break
         }
+
+        if (!content) return null
+
+        return (
+          <motion.div
+            key={section.id}
+            variants={fadeUpVariants}
+            initial="hidden"
+            whileInView="visible"
+            viewport={{ once: true, margin: '-60px' }}
+            transition={SPRING_MEDIUM}
+          >
+            {content}
+          </motion.div>
+        )
       })}
     </div>
   )

--- a/src/components/home/ScrollRow.tsx
+++ b/src/components/home/ScrollRow.tsx
@@ -1,6 +1,8 @@
 'use client'
 
 import { useRef } from 'react'
+import { motion } from 'framer-motion'
+import { fadeUpVariants, SPRING_MEDIUM } from '@/lib/motion'
 
 interface ScrollRowProps {
   children: React.ReactNode
@@ -28,14 +30,19 @@ export function ScrollRow({ children }: ScrollRowProps) {
   )
 }
 
-/** ScrollRow 내 개별 카드 래퍼 — 고정 너비 + snap */
+/** ScrollRow 내 개별 카드 래퍼 — 고정 너비 + snap + whileInView 등장 */
 export function ScrollItem({ children }: { children: React.ReactNode }) {
   return (
-    <div
+    <motion.div
       className="w-36 sm:w-40 lg:w-[calc((100%-6rem)/7)] flex-shrink-0"
       style={{ scrollSnapAlign: 'start' }}
+      variants={fadeUpVariants}
+      initial="hidden"
+      whileInView="visible"
+      viewport={{ once: true, amount: 0.2 }}
+      transition={SPRING_MEDIUM}
     >
       {children}
-    </div>
+    </motion.div>
   )
 }

--- a/src/components/home/ScrollRow.tsx
+++ b/src/components/home/ScrollRow.tsx
@@ -2,7 +2,7 @@
 
 import { useRef } from 'react'
 import { motion } from 'framer-motion'
-import { fadeUpVariants, SPRING_MEDIUM } from '@/lib/motion'
+import { fadeUpVariants } from '@/lib/motion'
 
 interface ScrollRowProps {
   children: React.ReactNode
@@ -40,7 +40,6 @@ export function ScrollItem({ children }: { children: React.ReactNode }) {
       initial="hidden"
       whileInView="visible"
       viewport={{ once: true, amount: 0.2 }}
-      transition={SPRING_MEDIUM}
     >
       {children}
     </motion.div>

--- a/src/components/layout/BottomTab.tsx
+++ b/src/components/layout/BottomTab.tsx
@@ -4,7 +4,9 @@ import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { useSession } from 'next-auth/react'
 import { Home, Coffee, LayoutList, User, Settings } from 'lucide-react'
+import { motion } from 'framer-motion'
 import { cn } from '@/lib/utils'
+import { SPRING_SNAPPY, TAP_SCALE } from '@/lib/motion'
 
 const authTabs = [
   { href: '/', label: '홈', Icon: Home },
@@ -36,17 +38,32 @@ export function BottomTab({ className }: { className?: string }) {
         {tabs.map(({ href, label, Icon }) => {
           const isActive = href === '/' ? pathname === '/' : pathname.startsWith(href)
           return (
-            <li key={href} className="flex flex-1 items-center justify-center">
-              <Link
-                href={href}
-                className={cn(
-                  'flex flex-col items-center gap-1 text-xs font-medium transition-colors',
-                  isActive ? 'text-text-primary' : 'text-text-disabled hover:text-text-secondary'
-                )}
-              >
-                <Icon className={cn('size-5', isActive ? 'stroke-[2.5]' : 'stroke-[1.5]')} />
-                <span className="whitespace-nowrap">{label}</span>
-              </Link>
+            <li key={href} className="relative flex flex-1 items-center justify-center">
+              {/* layoutId로 활성 탭 이동 시 인디케이터가 spring으로 슬라이드 */}
+              {isActive && (
+                <motion.div
+                  layoutId="bottom-tab-indicator"
+                  className="absolute top-0 left-1/2 -translate-x-1/2 h-0.5 w-6 rounded-full bg-primary"
+                  transition={SPRING_SNAPPY}
+                />
+              )}
+              <motion.div whileTap={TAP_SCALE} transition={SPRING_SNAPPY}>
+                <Link
+                  href={href}
+                  className={cn(
+                    'flex flex-col items-center gap-1 text-xs font-medium transition-colors',
+                    isActive ? 'text-text-primary' : 'text-text-disabled hover:text-text-secondary'
+                  )}
+                >
+                  <motion.div
+                    animate={{ scale: isActive ? 1.1 : 1, y: isActive ? -1 : 0 }}
+                    transition={SPRING_SNAPPY}
+                  >
+                    <Icon className={cn('size-5', isActive ? 'stroke-[2.5]' : 'stroke-[1.5]')} />
+                  </motion.div>
+                  <span className="whitespace-nowrap">{label}</span>
+                </Link>
+              </motion.div>
             </li>
           )
         })}

--- a/src/components/layout/ThemeProvider.tsx
+++ b/src/components/layout/ThemeProvider.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { createContext, useContext, useEffect, useState } from 'react'
+import { MotionConfig } from 'framer-motion'
 
 export type Theme = 'light' | 'dark' | 'system'
 type ResolvedTheme = 'light' | 'dark'
@@ -57,9 +58,11 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
   const resolvedTheme: ResolvedTheme = typeof window !== 'undefined' ? resolveTheme(theme) : 'light'
 
   return (
-    <ThemeContext.Provider value={{ theme, resolvedTheme, mounted, setTheme }}>
-      {children}
-    </ThemeContext.Provider>
+    <MotionConfig reducedMotion="user">
+      <ThemeContext.Provider value={{ theme, resolvedTheme, mounted, setTheme }}>
+        {children}
+      </ThemeContext.Provider>
+    </MotionConfig>
   )
 }
 

--- a/src/components/motion/PageTransition.tsx
+++ b/src/components/motion/PageTransition.tsx
@@ -1,0 +1,23 @@
+'use client'
+
+import { motion } from 'framer-motion'
+import { usePathname } from 'next/navigation'
+import { SPRING_GENTLE } from '@/lib/motion'
+
+// 라우트 이동 시 페이지가 아래에서 스르륵 올라오는 entrance 전환
+// key={pathname}으로 경로가 바뀔 때마다 새 인스턴스 생성 → 애니메이션 재실행
+// App Router에서 exit 애니메이션은 구조상 지원 어려워 entrance만 적용
+export function PageTransition({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname()
+
+  return (
+    <motion.div
+      key={pathname}
+      initial={{ opacity: 0, y: 10 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={SPRING_GENTLE}
+    >
+      {children}
+    </motion.div>
+  )
+}

--- a/src/components/rating/StarSelector.tsx
+++ b/src/components/rating/StarSelector.tsx
@@ -1,6 +1,8 @@
 'use client'
 
 import { useState } from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
+import { SPRING_SNAPPY, TAP_SCALE } from '@/lib/motion'
 
 interface StarSelectorProps {
   value: number
@@ -24,22 +26,48 @@ export function StarSelector({ value, onChange }: StarSelectorProps) {
     <div className="flex flex-col items-center gap-2">
       <div className="flex gap-1">
         {[1, 2, 3, 4, 5].map((star) => (
-          <button
+          <motion.button
             key={star}
             type="button"
             aria-label={`${star}점`}
-            className="text-3xl leading-none transition-transform hover:scale-110 focus-visible:outline-none"
+            className="text-3xl leading-none focus-visible:outline-none"
+            whileHover={{ scale: 1.3 }}
+            whileTap={TAP_SCALE}
+            transition={SPRING_SNAPPY}
             onMouseEnter={() => setHovered(star)}
             onMouseLeave={() => setHovered(0)}
             onClick={() => onChange(star)}
           >
-            <span className={star <= active ? 'text-accent' : 'text-muted'}>★</span>
-          </button>
+            <motion.span
+              animate={{ scale: star === value ? [1, 1.45, 1] : 1 }}
+              transition={{
+                duration: 0.38,
+                ease: ['easeOut', 'easeIn'],
+                times: [0, 0.4, 1],
+              }}
+              className={star <= active ? 'text-accent' : 'text-muted'}
+              style={{ display: 'inline-block' }}
+            >
+              ★
+            </motion.span>
+          </motion.button>
         ))}
       </div>
-      <span className="text-sm text-muted-foreground h-5">
-        {active > 0 ? LABELS[active] : '별점을 선택하세요'}
-      </span>
+
+      <div className="h-5 flex items-center">
+        <AnimatePresence mode="wait">
+          <motion.span
+            key={active}
+            initial={{ opacity: 0, y: 4 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -4 }}
+            transition={SPRING_SNAPPY}
+            className="text-sm text-muted-foreground"
+          >
+            {active > 0 ? LABELS[active] : '별점을 선택하세요'}
+          </motion.span>
+        </AnimatePresence>
+      </div>
     </div>
   )
 }

--- a/src/components/rating/StarSelector.tsx
+++ b/src/components/rating/StarSelector.tsx
@@ -30,7 +30,7 @@ export function StarSelector({ value, onChange }: StarSelectorProps) {
             key={star}
             type="button"
             aria-label={`${star}점`}
-            className="text-3xl leading-none focus-visible:outline-none"
+            className="text-3xl leading-none focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring rounded-sm"
             whileHover={{ scale: 1.3 }}
             whileTap={TAP_SCALE}
             transition={SPRING_SNAPPY}

--- a/src/components/roastery/RoasteryCard.tsx
+++ b/src/components/roastery/RoasteryCard.tsx
@@ -1,10 +1,14 @@
+'use client'
+
 import Link from 'next/link'
 import Image from 'next/image'
+import { motion } from 'framer-motion'
 import { Badge } from '@/components/ui/badge'
 import { RegionDisplay } from './RegionDisplay'
 import { RatingDisplay } from './RatingDisplay'
 import type { RoasteryWithStats } from '@/types/roastery'
 import { PRICE_RANGE_LABELS, getRegions, getCharacteristicTags } from '@/types/roastery'
+import { SPRING_SNAPPY, TAP_SCALE } from '@/lib/motion'
 
 interface RoasteryCardProps {
   roastery: RoasteryWithStats
@@ -52,7 +56,11 @@ export function RoasteryCard({
         href={`/roasteries/${roastery.id}`}
         className="block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-xl"
       >
-        <div className="group flex flex-row items-start gap-3 rounded-xl p-2 hover:bg-muted/50 transition-colors">
+        <motion.div
+          className="group flex flex-row items-start gap-3 rounded-xl p-2 hover:bg-muted/50 transition-colors"
+          whileTap={TAP_SCALE}
+          transition={SPRING_SNAPPY}
+        >
           <div className="relative w-16 h-16 flex-shrink-0 overflow-hidden rounded-lg bg-muted">
             {roastery.imageUrl ? (
               <Image
@@ -88,7 +96,7 @@ export function RoasteryCard({
               )}
             </div>
           </div>
-        </div>
+        </motion.div>
       </Link>
     )
   }
@@ -99,7 +107,11 @@ export function RoasteryCard({
       href={`/roasteries/${roastery.id}`}
       className="block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-xl"
     >
-      <div className="group flex flex-col gap-2">
+      <motion.div
+        className="group flex flex-col gap-2"
+        whileTap={TAP_SCALE}
+        transition={SPRING_SNAPPY}
+      >
         <div className="relative aspect-[3/4] w-full overflow-hidden rounded-xl bg-muted">
           {roastery.imageUrl ? (
             <Image
@@ -140,7 +152,7 @@ export function RoasteryCard({
             ))}
           </div>
         </div>
-      </div>
+      </motion.div>
     </Link>
   )
 }

--- a/src/components/roastery/RoasteryGrid.tsx
+++ b/src/components/roastery/RoasteryGrid.tsx
@@ -1,5 +1,9 @@
+'use client'
+
+import { motion } from 'framer-motion'
 import { RoasteryCard } from './RoasteryCard'
 import type { RoasteryWithStats } from '@/types/roastery'
+import { staggerContainerVariants, fadeUpVariants } from '@/lib/motion'
 
 interface RoasteryGridProps {
   roasteries: RoasteryWithStats[]
@@ -8,16 +12,22 @@ interface RoasteryGridProps {
 
 export function RoasteryGrid({ roasteries, activeRegions }: RoasteryGridProps) {
   return (
-    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+    <motion.div
+      variants={staggerContainerVariants}
+      initial="hidden"
+      animate="visible"
+      className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
+    >
       {roasteries.map((roastery, i) => (
-        <RoasteryCard
-          key={roastery.id}
-          roastery={roastery}
-          priority={i < 4}
-          activeRegions={activeRegions}
-          variant="landscape"
-        />
+        <motion.div key={roastery.id} variants={fadeUpVariants}>
+          <RoasteryCard
+            roastery={roastery}
+            priority={i < 4}
+            activeRegions={activeRegions}
+            variant="landscape"
+          />
+        </motion.div>
       ))}
-    </div>
+    </motion.div>
   )
 }

--- a/src/lib/motion.ts
+++ b/src/lib/motion.ts
@@ -1,0 +1,53 @@
+import type { Transition, Variants } from 'framer-motion'
+
+// 토스처럼 모든 인터랙션에 통일된 spring 물리 적용
+// stiffness↑ = 빠르고 탄성, damping↑ = 덜 튕김
+
+export const SPRING_SNAPPY: Transition = {
+  type: 'spring',
+  stiffness: 380,
+  damping: 30,
+}
+
+export const SPRING_MEDIUM: Transition = {
+  type: 'spring',
+  stiffness: 300,
+  damping: 28,
+}
+
+export const SPRING_GENTLE: Transition = {
+  type: 'spring',
+  stiffness: 240,
+  damping: 26,
+}
+
+// 북마크처럼 "뭔가 됐다"는 피드백이 필요한 순간에만
+export const SPRING_POP: Transition = {
+  type: 'spring',
+  stiffness: 520,
+  damping: 18,
+}
+
+// 모든 리스트 아이템에 통일 적용
+export const fadeUpVariants: Variants = {
+  hidden: { opacity: 0, y: 12 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: SPRING_MEDIUM,
+  },
+}
+
+// stagger 컨테이너 — children이 순서대로 등장
+export const staggerContainerVariants: Variants = {
+  hidden: {},
+  visible: {
+    transition: {
+      staggerChildren: 0.055,
+      delayChildren: 0.04,
+    },
+  },
+}
+
+// 모든 탭/클릭 가능한 요소에 통일 적용 (whileTap prop에 직접 사용)
+export const TAP_SCALE = { scale: 0.96 } as const

--- a/src/lib/recommender/index.ts
+++ b/src/lib/recommender/index.ts
@@ -21,7 +21,7 @@ export async function getRecommendations(userId?: string): Promise<Recommendatio
     return getPopularFallback(userId)
   }
 
-  // new: 유저가 평가하지 않은 로스터리, cfScore 내림차순 상위 5개
+  // new: 유저가 평가하지 않은 로스터리, cfScore 내림차순 상위 7개
   const newItems = stored
     .filter((r) => r.userRating === undefined)
     .sort((a, b) => b.cfScore - a.cfScore)

--- a/src/lib/recommender/item-cf.ts
+++ b/src/lib/recommender/item-cf.ts
@@ -70,7 +70,10 @@ export async function computeAndSaveCF(userId: string): Promise<void> {
   if (ratings.length === 0) return
 
   const userRatings = ratings.filter((r) => r.userId === userId)
-  if (userRatings.length < 3) return
+  if (userRatings.length < 3) {
+    await prisma.recommendation.deleteMany({ where: { userId } })
+    return
+  }
 
   const matrix = buildSimilarityMatrix(ratings)
   const userRatedMap = new Map(userRatings.map((r) => [r.roasteryId, r.score]))


### PR DESCRIPTION
## 변경 사항

- framer-motion v12 도입 및 공유 spring preset 4종 정의 (`src/lib/motion.ts`)
- **통일 인터랙션 규칙**: 모든 탭/클릭 가능 요소 `whileTap scale 0.96`, 모든 등장 `opacity 0→1, y 12→0` spring
- **페이지 전환**: 라우트 이동 시 fade-up entrance (`PageTransition` 컴포넌트)
- **RoasteryCard**: `'use client'` 전환, portrait/landscape 동일 tap 피드백
- **RoasteryGrid**: stagger container로 카드 순차 fade-up 등장 (0.055s 간격)
- **BookmarkButton**: `AnimatePresence` + `SPRING_POP`으로 북마크 ON/OFF 팝 애니메이션
- **StarSelector**: `whileHover scale 1.3`, 선택 시 keyframe 팝, AnimatePresence 레이블 교체
- **BottomTab**: `layoutId="bottom-tab-indicator"` 슬라이딩 인디케이터 (탭 이동 시 spring 슬라이드)
- **HomeFeedClient**: 각 섹션 `whileInView` scroll reveal
- **ScrollRow/ScrollItem**: 가로 스크롤 카드 `whileInView` 등장
- **DecafToggle**: `'use client'` 추가, whileTap 통일 피드백
- **접근성**: `MotionConfig reducedMotion="user"` 전역 적용, `aria-pressed` 추가, focus-visible 스타일

## 테스트 방법

- [x] 홈 → 로스터리 탭 이동 시 페이지가 아래에서 스르륵 올라오는지 확인
- [x] 로스터리 목록 카드들이 순서대로 등장하는지 확인
- [x] 카드 터치/클릭 시 살짝 수축하는 tactile 피드백 확인
- [x] 로스터리 상세 > 북마크 버튼 탭 시 아이콘이 팡 튀는지 확인
- [x] 로스터리 상세 > 별점 선택 시 별이 팝 → 레이블 문구가 교체되는지 확인
- [x] 모바일에서 BottomTab 탭 이동 시 상단 인디케이터 슬라이드 확인
- [x] 홈 피드 스크롤 시 섹션들이 순서대로 등장하는지 확인
- [ ] 시스템 설정 "동작 줄이기" 켜면 애니메이션 비활성화되는지 확인
