### PR TITLE
style: 스켈레톤 UI를 현재 컴포넌트 레이아웃에 맞게 재구성

### DIFF
--- a/src/app/(main)/roasteries/[id]/loading.tsx
+++ b/src/app/(main)/roasteries/[id]/loading.tsx
@@ -4,23 +4,76 @@ import { Separator } from '@/components/ui/separator'
 export default function RoasteryDetailLoading() {
   return (
     <div className="page-wrapper py-8 flex flex-col gap-8">
-      <Skeleton className="aspect-[16/7] w-full rounded-2xl" />
-      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-        <div className="flex flex-col gap-2">
-          <Skeleton className="h-8 w-48" />
-          <Skeleton className="h-4 w-24" />
-          <Skeleton className="h-4 w-80" />
+      {/* 뒤로가기 버튼 */}
+      <Skeleton className="h-8 w-16 rounded-lg" />
+
+      {/* 기본 정보 */}
+      <div className="flex flex-col gap-2">
+        {/* 이미지 + 이름/평점 행 */}
+        <div className="flex gap-4 items-start">
+          <Skeleton className="size-20 rounded-xl shrink-0" />
+          <div className="flex flex-col gap-1.5 flex-1">
+            <Skeleton className="h-8 w-48" />
+            <div className="flex items-center justify-between">
+              <Skeleton className="h-5 w-24" />
+              <Skeleton className="h-8 w-20 rounded-full" />
+            </div>
+          </div>
         </div>
-        <div className="flex flex-col gap-3">
-          <Skeleton className="h-6 w-24" />
-          <Skeleton className="h-6 w-20" />
+
+        {/* 지역 */}
+        <Skeleton className="h-4 w-20" />
+
+        {/* 설명 */}
+        <Skeleton className="h-4 w-full max-w-prose" />
+        <Skeleton className="h-4 w-3/4 max-w-prose" />
+
+        {/* 배지 row */}
+        <div className="flex gap-1.5 pt-1">
+          <Skeleton className="h-6 w-16 rounded-full" />
+          <Skeleton className="h-6 w-14 rounded-full" />
+          <Skeleton className="h-6 w-20 rounded-full" />
         </div>
       </div>
+
       <Separator />
+
+      {/* 원두 라인업 */}
       <div className="flex flex-col gap-4">
-        <Skeleton className="h-7 w-40" />
+        <Skeleton className="h-6 w-32" />
         {Array.from({ length: 3 }).map((_, i) => (
-          <Skeleton key={i} className="h-24 w-full rounded-xl" />
+          <div key={i} className="flex gap-4 rounded-xl border border-border p-4">
+            <Skeleton className="size-16 rounded-lg shrink-0" />
+            <div className="flex flex-col gap-2 flex-1">
+              <div className="flex items-start justify-between">
+                <Skeleton className="h-4 w-1/3" />
+                <Skeleton className="h-4 w-16" />
+              </div>
+              <Skeleton className="h-3 w-1/2" />
+              <div className="flex gap-1">
+                <Skeleton className="h-4 w-12 rounded-full" />
+                <Skeleton className="h-4 w-16 rounded-full" />
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <Separator />
+
+      {/* 한줄평 목록 */}
+      <div className="flex flex-col gap-4">
+        <Skeleton className="h-6 w-20" />
+        {Array.from({ length: 2 }).map((_, i) => (
+          <div key={i} className="flex flex-col gap-2">
+            <div className="flex items-center gap-2">
+              <Skeleton className="size-8 rounded-full" />
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="h-4 w-16 ml-auto" />
+            </div>
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-2/3" />
+          </div>
         ))}
       </div>
     </div>

--- a/src/app/(main)/roasteries/loading.tsx
+++ b/src/app/(main)/roasteries/loading.tsx
@@ -3,17 +3,16 @@ import { Skeleton } from '@/components/ui/skeleton'
 export default function RoasteriesLoading() {
   return (
     <div className="page-wrapper py-8 flex flex-col gap-6">
-      <div className="flex items-center justify-between">
-        <Skeleton className="h-7 w-24" />
-        <Skeleton className="h-9 w-28" />
-      </div>
+      <Skeleton className="h-7 w-24" />
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
         {Array.from({ length: 8 }).map((_, i) => (
-          <div key={i} className="flex flex-col gap-3 rounded-xl border border-border p-4">
-            <Skeleton className="aspect-[4/3] w-full rounded-lg" />
-            <Skeleton className="h-5 w-3/4" />
-            <Skeleton className="h-4 w-1/2" />
-            <Skeleton className="h-4 w-1/3" />
+          <div key={i} className="flex flex-row items-start gap-3 rounded-xl p-2">
+            <Skeleton className="size-16 rounded-lg shrink-0" />
+            <div className="flex flex-col justify-between h-16 min-w-0 flex-1">
+              <Skeleton className="h-4 w-3/4" />
+              <Skeleton className="h-3 w-1/2" />
+              <Skeleton className="h-3 w-1/3" />
+            </div>
           </div>
         ))}
       </div>

--- a/src/components/home/FeedSkeleton.tsx
+++ b/src/components/home/FeedSkeleton.tsx
@@ -2,33 +2,49 @@ import { Skeleton } from '@/components/ui/skeleton'
 
 function CardSkeleton() {
   return (
-    <div className="flex flex-col gap-2 rounded-xl border p-4">
-      <Skeleton className="h-36 w-full rounded-lg" />
-      <Skeleton className="h-4 w-2/3" />
-      <Skeleton className="h-3 w-1/3" />
+    <div className="w-36 sm:w-40 lg:w-[calc((100%-6rem)/7)] flex-shrink-0 flex flex-col gap-2">
+      <Skeleton className="aspect-[3/4] w-full rounded-xl" />
+      <div className="flex flex-col gap-0.5 px-0.5">
+        <Skeleton className="h-4 w-2/3" />
+        <Skeleton className="h-3 w-1/2" />
+        <div className="flex gap-1.5 pt-0.5">
+          <Skeleton className="h-4 w-8" />
+          <Skeleton className="h-4 w-10" />
+        </div>
+      </div>
     </div>
+  )
+}
+
+function SectionSkeleton({ titleWidth }: { titleWidth: string }) {
+  return (
+    <section className="flex flex-col gap-3">
+      <div className="page-wrapper">
+        <Skeleton className={`h-5 ${titleWidth} border-b border-border pb-2`} />
+      </div>
+      <div>
+        {/* 모바일/태블릿: 가로 스크롤 */}
+        <div className="lg:hidden flex gap-4 pl-4 md:pl-8 overflow-x-hidden">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <CardSkeleton key={i} />
+          ))}
+        </div>
+        {/* 데스크탑: flex row */}
+        <div className="hidden lg:flex gap-4 page-wrapper">
+          {Array.from({ length: 7 }).map((_, i) => (
+            <CardSkeleton key={i} />
+          ))}
+        </div>
+      </div>
+    </section>
   )
 }
 
 export function FeedSkeleton() {
   return (
     <div className="flex flex-col gap-8">
-      <div className="flex flex-col gap-4">
-        <Skeleton className="h-5 w-32 border-b border-border pb-2" />
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {Array.from({ length: 3 }).map((_, i) => (
-            <CardSkeleton key={i} />
-          ))}
-        </div>
-      </div>
-      <div className="flex flex-col gap-4">
-        <Skeleton className="h-5 w-40 border-b border-border pb-2" />
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {Array.from({ length: 3 }).map((_, i) => (
-            <CardSkeleton key={i} />
-          ))}
-        </div>
-      </div>
+      <SectionSkeleton titleWidth="w-32" />
+      <SectionSkeleton titleWidth="w-40" />
     </div>
   )
 }

--- a/src/lib/recommender/accuracy.test.ts
+++ b/src/lib/recommender/accuracy.test.ts
@@ -142,4 +142,78 @@ describe('추천 정확도 (offline)', () => {
       }
     }
   })
+
+  // A-06: 100명 시뮬레이션 Leave-one-out Hit Rate
+  // 취향 그룹 3개(과일향/진한로스팅/라이트로스팅)로 100명 생성 후,
+  // 각 유저의 최고 평점 아이템 1개를 제외한 나머지로 CF 실행.
+  // 숨긴 아이템이 예측 상위 5개에 포함되는 비율(Hit Rate @5)이 60% 이상이어야 한다.
+  it('A-06: 100명 시뮬레이션 Leave-one-out Hit Rate @5 >= 60%', () => {
+    // 결정론적 LCG 난수 생성기 (seed=42, 재현 가능)
+    let seed = 42
+    const rand = () => {
+      seed = (seed * 1103515245 + 12345) & 0x7fffffff
+      return seed / 0x7fffffff
+    }
+    const pickHigh = (): number => (rand() > 0.5 ? 5 : 4)
+    const pickLow = (): number => (rand() > 0.5 ? 1 : 2)
+
+    // 취향 아키타입: [highItems, lowItems, midItems(50% 확률 포함)]
+    const archetypes = [
+      { high: ['r1', 'r2', 'r3'], low: ['r4', 'r5'], mid: ['r7', 'r8'] }, // 과일향
+      { high: ['r4', 'r5', 'r6'], low: ['r1', 'r2'], mid: ['r8', 'r9'] }, // 진한 로스팅
+      { high: ['r7', 'r8', 'r9'], low: ['r2'], mid: ['r3', 'r5'] }, // 라이트 로스팅
+    ]
+    const groupSizes = [35, 35, 30]
+
+    const allRatings: RawRating[] = []
+    const holdouts: { userId: string; roasteryId: string }[] = []
+
+    for (let g = 0; g < archetypes.length; g++) {
+      const { high, low, mid } = archetypes[g]
+
+      for (let i = 0; i < groupSizes[g]; i++) {
+        const userId = `u_g${g}_${i}`
+        const userRatings: RawRating[] = []
+
+        for (const rid of high) userRatings.push({ userId, roasteryId: rid, score: pickHigh() })
+        for (const rid of low) userRatings.push({ userId, roasteryId: rid, score: pickLow() })
+        for (const rid of mid) {
+          if (rand() > 0.5) userRatings.push({ userId, roasteryId: rid, score: 3 })
+        }
+
+        // holdout: high 아이템 중 점수 가장 높은 것 1개 제거
+        const highRatings = userRatings.filter((r) => high.includes(r.roasteryId))
+        const holdout = [...highRatings].sort(
+          (a, b) => b.score - a.score || a.roasteryId.localeCompare(b.roasteryId)
+        )[0]
+        holdouts.push({ userId, roasteryId: holdout.roasteryId })
+
+        allRatings.push(...userRatings.filter((r) => r.roasteryId !== holdout.roasteryId))
+      }
+    }
+
+    const matrix = buildSimilarityMatrix(allRatings)
+    const allItemIds = [...new Set(allRatings.map((r) => r.roasteryId))]
+
+    let hits = 0
+
+    for (const { userId, roasteryId: heldId } of holdouts) {
+      const userMap = new Map(
+        allRatings.filter((r) => r.userId === userId).map((r) => [r.roasteryId, r.score])
+      )
+
+      const top5 = allItemIds
+        .filter((id) => !userMap.has(id))
+        .map((id) => ({ id, score: predictScore(matrix, userMap, id) }))
+        .filter((p) => p.score > 0)
+        .sort((a, b) => b.score - a.score)
+        .slice(0, 5)
+        .map((p) => p.id)
+
+      if (top5.includes(heldId)) hits++
+    }
+
+    const hitRate = hits / holdouts.length
+    expect(hitRate).toBeGreaterThanOrEqual(0.6)
+  })
 })


### PR DESCRIPTION
## 변경 사항

- **FeedSkeleton**: ScrollRow 구조로 전환, 이미지 비율 수정, 배지 row 추가
  - grid → 가로 스크롤(모바일) + flex row(데스크탑)
  - 이미지 `h-36` → `aspect-[3/4]`, 카드 너비 `w-36 sm:w-40 lg:w-[calc((100%-6rem)/7)]`
  - 배지 row(평점 + 태그) 추가, 섹션 헤더 `page-wrapper` 적용

- **`/roasteries` loading**: landscape 카드 레이아웃으로 변경
  - 세로 portrait(full-width 이미지) → 가로 landscape(64×64 썸네일 + 텍스트 3줄)
  - 헤더 옆 불필요한 버튼 skeleton 제거

- **`/roasteries/[id]` loading**: 실제 상세 레이아웃으로 재구성
  - `aspect-[16/7]` 히어로 이미지 → `size-20` 썸네일
  - 뒤로가기 버튼, 지역/설명/배지 섹션 추가
  - 원두 라인업: 이미지+텍스트+컵노트 구조로 변경
  - 한줄평 목록 섹션 추가

## 테스트 방법
- [x] 홈(`/`) 로딩 중 스켈레톤이 카드 가로 스크롤 형태로 표시되는지 확인
- [x] `/roasteries` 로딩 중 스켈레톤이 landscape 카드(가로 줄) 형태로 표시되는지 확인
- [x] `/roasteries/[id]` 로딩 중 스켈레톤이 실제 상세 페이지와 유사한 구조로 표시되는지 확인