### PR TITLE
feat: 관리자 로스터리 상세/수정 페이지에 공개 페이지 링크 추가

### DIFF
--- a/src/app/admin/roasteries/[id]/edit/page.tsx
+++ b/src/app/admin/roasteries/[id]/edit/page.tsx
@@ -28,11 +28,19 @@ export default async function EditRoasteryPage({ params }: Props) {
   return (
     <div className="mx-auto max-w-2xl flex flex-col gap-8">
       <div>
-        <div className="mb-6 flex items-center gap-3">
+        <div className="mb-6 flex items-center gap-3 flex-wrap">
           <Link href="/admin/roasteries" className="text-sm text-text-sub hover:text-text">
             ← 목록
           </Link>
           <h1 className="text-2xl font-bold text-text">로스터리 수정</h1>
+          <Link
+            href={`/roasteries/${id}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="ml-auto rounded-lg border border-border px-3 py-1.5 text-xs text-text-sub hover:text-text transition-colors"
+          >
+            공개 페이지 ↗
+          </Link>
         </div>
         <div className="rounded-xl border border-border bg-surface p-6">
           <RoasteryForm

--- a/src/app/admin/roasteries/[id]/page.tsx
+++ b/src/app/admin/roasteries/[id]/page.tsx
@@ -53,6 +53,14 @@ export default async function RoasteryDetailPage({ params }: Props) {
         {!isDeleted && !isClosed && isHidden && (
           <span className="rounded px-2 py-0.5 text-xs bg-gray-100 text-gray-600">숨김</span>
         )}
+        <Link
+          href={`/roasteries/${id}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="ml-auto rounded-lg border border-border px-3 py-1.5 text-xs text-text-sub hover:text-text transition-colors"
+        >
+          공개 페이지 ↗
+        </Link>
       </div>
 
       {/* 로스터리 정보 카드 */}


### PR DESCRIPTION
## 변경 사항
- 관리자 로스터리 상세 페이지 헤더 우측에 "공개 페이지 ↗" 버튼 추가
- 관리자 로스터리 수정 페이지 헤더 우측에 동일한 버튼 추가
- 새 탭으로 열림 (target="_blank")

## 테스트 방법
- [x] 관리자 로스터리 상세 페이지(/admin/roasteries/{id})에서 "공개 페이지 ↗" 버튼 확인
- [x] 버튼 클릭 시 /roasteries/{id} 공개 페이지가 새 탭으로 열리는지 확인
- [x] 관리자 로스터리 수정 페이지(/admin/roasteries/{id}/edit)에서도 동일하게 동작하는지 확인