### PR TITLE
fix: ScrollItem 가로 스크롤 중 세로 간섭 제거

### DIFF
--- a/src/components/home/ScrollRow.tsx
+++ b/src/components/home/ScrollRow.tsx
@@ -2,7 +2,6 @@
 
 import { useRef } from 'react'
 import { motion } from 'framer-motion'
-import { fadeUpVariants } from '@/lib/motion'
 
 interface ScrollRowProps {
   children: React.ReactNode
@@ -36,10 +35,10 @@ export function ScrollItem({ children }: { children: React.ReactNode }) {
     <motion.div
       className="w-36 sm:w-40 lg:w-[calc((100%-6rem)/7)] flex-shrink-0"
       style={{ scrollSnapAlign: 'start' }}
-      variants={fadeUpVariants}
-      initial="hidden"
-      whileInView="visible"
+      initial={{ opacity: 0 }}
+      whileInView={{ opacity: 1 }}
       viewport={{ once: true, amount: 0.2 }}
+      transition={{ duration: 0.25 }}
     >
       {children}
     </motion.div>


### PR DESCRIPTION
## 변경 사항
- `ScrollItem`의 `fadeUpVariants`(y: 12→0) 애니메이션을 opacity-only로 교체
- 가로 스크롤 중 `whileInView`가 `y` 이동을 실행하며 세로 스크롤처럼 보이던 문제 수정
- 스크롤 끝까지 도달 후 문제가 사라지던 현상(`viewport: { once: true }` 특성)도 함께 해소

## 테스트 방법
- [x] 모바일(또는 개발자 도구 모바일 시뮬레이터)에서 홈 화면 접속
- [x] 로스터리 카드 행을 가로 스크롤 시 화면이 세로로 흔들리지 않는지 확인
- [x] 카드가 뷰포트에 진입할 때 자연스럽게 페이드인되는지 확인