### PR TITLE
style: 내 활동 리스트 항목에 라운딩 카드 스타일 적용

### DIFF
--- a/src/components/bookmark/BookmarkList.tsx
+++ b/src/components/bookmark/BookmarkList.tsx
@@ -37,14 +37,11 @@ export function BookmarkList({ bookmarks, initialSort }: BookmarkListProps) {
         <SortDropdown value={sort} options={SORT_OPTIONS} onChange={setSort} />
       </div>
 
-      <ul className="flex flex-col">
+      <ul className="flex flex-col gap-1 pt-2">
         {sorted.map((item) => (
-          <li
-            key={item.id}
-            className={`border-b border-[var(--color-border)] last-of-type:border-b-0 ${item.isUnavailable ? 'opacity-50' : ''}`}
-          >
+          <li key={item.id} className={`rounded-md ${item.isUnavailable ? 'opacity-50' : ''}`}>
             {item.isUnavailable ? (
-              <div className="flex items-center gap-3 py-4">
+              <div className="flex items-center gap-3 px-3 py-3">
                 <div className="flex flex-1 flex-col gap-0.5 min-w-0">
                   <span className="text-sm font-medium text-muted-foreground truncate">
                     {item.roastery.name}
@@ -62,7 +59,7 @@ export function BookmarkList({ bookmarks, initialSort }: BookmarkListProps) {
                 </button>
               </div>
             ) : (
-              <div className="flex items-center gap-3 py-4 hover:bg-[var(--color-surface)] transition-colors">
+              <div className="flex items-center gap-3 px-3 py-3 rounded-md hover:bg-[var(--color-surface)] transition-colors">
                 <Link
                   href={`/roasteries/${item.roasteryId}`}
                   className="flex flex-1 items-center gap-2 min-w-0"

--- a/src/components/bookmark/BookmarkList.tsx
+++ b/src/components/bookmark/BookmarkList.tsx
@@ -4,13 +4,14 @@ import { useState } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { Badge } from '@/components/ui/badge'
-import { SortDropdown } from '@/components/ui/sort-dropdown'
+import { ListToolbar } from '@/components/ui/list-toolbar'
 import { RemoveBookmarkDialog } from './RemoveBookmarkDialog'
 import type { BookmarkWithRoastery, BookmarkSort } from '@/types/bookmark'
 
 const SORT_OPTIONS: { value: BookmarkSort; label: string }[] = [
   { value: 'name', label: '이름순' },
-  { value: 'myRating', label: '내 별점순' },
+  { value: 'myRating_desc', label: '별점 높은순' },
+  { value: 'myRating_asc', label: '별점 낮은순' },
 ]
 
 interface BookmarkListProps {
@@ -20,80 +21,101 @@ interface BookmarkListProps {
 
 export function BookmarkList({ bookmarks, initialSort }: BookmarkListProps) {
   const [sort, setSort] = useState<BookmarkSort>(initialSort)
+  const [search, setSearch] = useState('')
   const [removeTarget, setRemoveTarget] = useState<BookmarkWithRoastery | null>(null)
   const router = useRouter()
 
   const sorted = [...bookmarks].sort((a, b) => {
     if (sort === 'name') return a.roastery.name.localeCompare(b.roastery.name, 'ko')
+    const dir = sort === 'myRating_desc' ? -1 : 1
     if (a.myRating === null && b.myRating === null) return 0
     if (a.myRating === null) return 1
     if (b.myRating === null) return -1
-    return b.myRating - a.myRating
+    return dir * (a.myRating - b.myRating)
   })
 
-  return (
-    <>
-      <div className="flex justify-end py-3 border-b border-[var(--color-border)]">
-        <SortDropdown value={sort} options={SORT_OPTIONS} onChange={setSort} />
-      </div>
+  const filtered = search.trim()
+    ? sorted.filter((item) =>
+        item.roastery.name.toLowerCase().includes(search.trim().toLowerCase())
+      )
+    : sorted
 
-      <ul className="flex flex-col gap-1 pt-2">
-        {sorted.map((item) => (
-          <li key={item.id} className={`rounded-md ${item.isUnavailable ? 'opacity-50' : ''}`}>
-            {item.isUnavailable ? (
-              <div className="flex items-center gap-3 px-3 py-3">
-                <div className="flex flex-1 flex-col gap-0.5 min-w-0">
-                  <span className="text-sm font-medium text-muted-foreground truncate">
-                    {item.roastery.name}
-                  </span>
-                  <span className="text-xs text-muted-foreground">
-                    더 이상 이용할 수 없는 로스터리입니다
-                  </span>
-                </div>
-                <button
-                  type="button"
-                  onClick={() => setRemoveTarget(item)}
-                  className="text-xs text-destructive hover:underline cursor-pointer shrink-0"
-                >
-                  해제
-                </button>
-              </div>
-            ) : (
-              <div className="flex items-center gap-3 px-3 py-3 rounded-md hover:bg-[var(--color-surface)] transition-colors">
-                <Link
-                  href={`/roasteries/${item.roasteryId}`}
-                  className="flex flex-1 items-center gap-2 min-w-0"
-                >
-                  <span className="text-sm font-medium text-[var(--color-text-primary)] truncate">
-                    {item.roastery.name}
-                  </span>
-                  {item.isClosed && (
-                    <Badge
-                      variant="outline"
-                      className="text-xs shrink-0 text-amber-700 border-amber-300 bg-amber-50"
-                    >
-                      폐업
-                    </Badge>
-                  )}
-                  {item.myRating !== null && (
-                    <span className="text-xs text-[var(--color-accent)] shrink-0 ml-auto">
-                      {'★'.repeat(item.myRating)}
-                      {'☆'.repeat(5 - item.myRating)}
+  return (
+    <div className="flex flex-col">
+      <ListToolbar
+        searchValue={search}
+        onSearchChange={setSearch}
+        searchPlaceholder="로스터리 검색"
+        sortValue={sort}
+        sortOptions={SORT_OPTIONS}
+        onSortChange={setSort}
+      />
+
+      {filtered.length === 0 ? (
+        <p className="py-8 text-center text-sm text-[var(--color-text-secondary)]">
+          {search.trim() ? '검색 결과가 없습니다.' : '즐겨찾기한 로스터리가 없습니다.'}
+        </p>
+      ) : (
+        <ul className="flex flex-col gap-1 pt-2">
+          {filtered.map((item) => (
+            <li key={item.id} className={`rounded-md ${item.isUnavailable ? 'opacity-50' : ''}`}>
+              {item.isUnavailable ? (
+                <div className="flex items-center gap-3 px-3 py-3">
+                  <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                    <span className="truncate text-sm font-medium text-muted-foreground">
+                      {item.roastery.name}
                     </span>
-                  )}
-                </Link>
-                <button
-                  type="button"
-                  onClick={() => setRemoveTarget(item)}
-                  className="text-xs text-destructive hover:underline cursor-pointer shrink-0"
-                >
-                  해제
-                </button>
-              </div>
-            )}
-          </li>
-        ))}
-      </ul>
+                    <span className="text-xs text-muted-foreground">
+                      더 이상 이용할 수 없는 로스터리입니다
+                    </span>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => setRemoveTarget(item)}
+                    className="shrink-0 cursor-pointer text-xs text-destructive hover:underline"
+                  >
+                    해제
+                  </button>
+                </div>
+              ) : (
+                <div className="relative flex items-center gap-3 rounded-md px-3 py-3 transition-colors hover:bg-[var(--color-surface)] active:bg-[var(--color-surface)]">
+                  <Link
+                    href={`/roasteries/${item.roasteryId}`}
+                    className="absolute inset-0 rounded-md"
+                    aria-label={item.roastery.name}
+                  />
+                  <div className="pointer-events-none flex min-w-0 flex-1 items-center gap-2">
+                    <span className="truncate text-sm font-medium text-[var(--color-text-primary)]">
+                      {item.roastery.name}
+                    </span>
+                    {item.isClosed && (
+                      <Badge
+                        variant="outline"
+                        className="shrink-0 border-amber-300 bg-amber-50 text-xs text-amber-700"
+                      >
+                        폐업
+                      </Badge>
+                    )}
+                    {item.myRating !== null && (
+                      <span className="ml-auto shrink-0 text-xs text-[var(--color-accent)]">
+                        {'★'.repeat(item.myRating)}
+                        {'☆'.repeat(5 - item.myRating)}
+                      </span>
+                    )}
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => setRemoveTarget(item)}
+                    className="relative z-10 shrink-0 cursor-pointer text-xs text-destructive hover:underline"
+                  >
+                    해제
+                  </button>
+                </div>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
 
       {removeTarget && (
         <RemoveBookmarkDialog
@@ -106,6 +128,6 @@ export function BookmarkList({ bookmarks, initialSort }: BookmarkListProps) {
           onSuccess={() => router.refresh()}
         />
       )}
-    </>
+    </div>
   )
 }

--- a/src/components/profile/MyRatingList.tsx
+++ b/src/components/profile/MyRatingList.tsx
@@ -80,9 +80,11 @@ export function MyRatingList({ initialItems, initialNextCursor }: MyRatingListPr
         </p>
       ) : (
         <>
-          {items.map((item) => (
-            <MyRatingRow key={item.id} item={item} />
-          ))}
+          <div className="flex flex-col gap-1 pt-2">
+            {items.map((item) => (
+              <MyRatingRow key={item.id} item={item} />
+            ))}
+          </div>
           <div ref={sentinelRef} className="h-1" />
           {isPending && (
             <p className="text-sm text-[var(--color-text-secondary)] py-4 text-center">
@@ -99,7 +101,7 @@ function MyRatingRow({ item }: { item: MyRatingItem }) {
   return (
     <Link
       href={`/roasteries/${item.roastery.id}`}
-      className="flex flex-col gap-1 py-4 border-b border-[var(--color-border)] last-of-type:border-b-0 hover:bg-[var(--color-surface)] transition-colors"
+      className="flex flex-col gap-1 px-3 py-3 rounded-md hover:bg-[var(--color-surface)] transition-colors"
     >
       <div className="flex items-center justify-between gap-2">
         <span className="text-sm font-medium text-[var(--color-text-primary)] truncate">

--- a/src/components/profile/MyRatingList.tsx
+++ b/src/components/profile/MyRatingList.tsx
@@ -3,18 +3,19 @@
 import { useState, useEffect, useRef, useTransition } from 'react'
 import Link from 'next/link'
 import { fetchUserRatings } from '@/actions/rating'
-import { SortDropdown } from '@/components/ui/sort-dropdown'
+import { ListToolbar } from '@/components/ui/list-toolbar'
 import type { MyRatingItem, MyRatingSort } from '@/types/rating'
 
 const SORT_OPTIONS: { value: MyRatingSort; label: string }[] = [
   { value: 'date_desc', label: '최신순' },
+  { value: 'date_asc', label: '오래된순' },
   { value: 'score_desc', label: '별점 높은순' },
   { value: 'score_asc', label: '별점 낮은순' },
 ]
 
 function StarRow({ score }: { score: number }) {
   return (
-    <span className="text-xs text-[var(--color-accent)] shrink-0">
+    <span className="shrink-0 text-xs text-[var(--color-accent)]">
       {'★'.repeat(score)}
       {'☆'.repeat(5 - score)}
     </span>
@@ -28,6 +29,7 @@ interface MyRatingListProps {
 
 export function MyRatingList({ initialItems, initialNextCursor }: MyRatingListProps) {
   const [sort, setSort] = useState<MyRatingSort>('date_desc')
+  const [search, setSearch] = useState('')
   const [items, setItems] = useState<MyRatingItem[]>(initialItems)
   const [nextCursor, setNextCursor] = useState<string | null>(initialNextCursor)
   const [isPending, startTransition] = useTransition()
@@ -64,30 +66,49 @@ export function MyRatingList({ initialItems, initialNextCursor }: MyRatingListPr
     return () => observer.disconnect()
   }, [nextCursor, isPending, sort])
 
+  const filtered = search.trim()
+    ? items.filter(
+        (item) =>
+          item.roastery.name.toLowerCase().includes(search.trim().toLowerCase()) ||
+          item.comment?.toLowerCase().includes(search.trim().toLowerCase())
+      )
+    : items
+
   return (
     <div className="flex flex-col">
-      <div className="flex justify-end py-3 border-b border-[var(--color-border)]">
-        <SortDropdown value={sort} options={SORT_OPTIONS} onChange={handleSortChange} />
-      </div>
+      <ListToolbar
+        searchValue={search}
+        onSearchChange={setSearch}
+        searchPlaceholder="로스터리명 또는 한줄평 검색"
+        sortValue={sort}
+        sortOptions={SORT_OPTIONS}
+        onSortChange={handleSortChange}
+      />
 
       {isPending && items.length === 0 ? (
-        <p className="text-sm text-[var(--color-text-secondary)] py-4 text-center">
+        <p className="py-4 text-center text-sm text-[var(--color-text-secondary)]">
           불러오는 중...
         </p>
-      ) : !isPending && items.length === 0 ? (
-        <p className="text-sm text-[var(--color-text-secondary)] py-4 text-center">
+      ) : items.length === 0 ? (
+        <p className="py-4 text-center text-sm text-[var(--color-text-secondary)]">
           아직 작성한 한줄평이 없습니다.
         </p>
       ) : (
         <>
-          <div className="flex flex-col gap-1 pt-2">
-            {items.map((item) => (
-              <MyRatingRow key={item.id} item={item} />
-            ))}
-          </div>
+          {filtered.length === 0 ? (
+            <p className="py-4 text-center text-sm text-[var(--color-text-secondary)]">
+              검색 결과가 없습니다.
+            </p>
+          ) : (
+            <div className="flex flex-col gap-1 pt-2">
+              {filtered.map((item) => (
+                <MyRatingRow key={item.id} item={item} />
+              ))}
+            </div>
+          )}
           <div ref={sentinelRef} className="h-1" />
           {isPending && (
-            <p className="text-sm text-[var(--color-text-secondary)] py-4 text-center">
+            <p className="py-4 text-center text-sm text-[var(--color-text-secondary)]">
               불러오는 중...
             </p>
           )}
@@ -101,16 +122,16 @@ function MyRatingRow({ item }: { item: MyRatingItem }) {
   return (
     <Link
       href={`/roasteries/${item.roastery.id}`}
-      className="flex flex-col gap-1 px-3 py-3 rounded-md hover:bg-[var(--color-surface)] transition-colors"
+      className="flex flex-col gap-1 rounded-md px-3 py-3 transition-colors hover:bg-[var(--color-surface)] active:bg-[var(--color-surface)]"
     >
       <div className="flex items-center justify-between gap-2">
-        <span className="text-sm font-medium text-[var(--color-text-primary)] truncate">
+        <span className="truncate text-sm font-medium text-[var(--color-text-primary)]">
           {item.roastery.name}
         </span>
         <StarRow score={item.score} />
       </div>
       {item.comment && (
-        <p className="text-sm text-[var(--color-text-secondary)] line-clamp-2">{item.comment}</p>
+        <p className="line-clamp-2 text-sm text-[var(--color-text-secondary)]">{item.comment}</p>
       )}
     </Link>
   )

--- a/src/components/ui/list-toolbar.tsx
+++ b/src/components/ui/list-toolbar.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import { Search } from 'lucide-react'
+import { SortDropdown } from './sort-dropdown'
+
+interface ListToolbarProps<T extends string> {
+  searchValue: string
+  onSearchChange: (value: string) => void
+  searchPlaceholder?: string
+  sortValue: T
+  sortOptions: { value: T; label: string }[]
+  onSortChange: (value: T) => void
+}
+
+export function ListToolbar<T extends string>({
+  searchValue,
+  onSearchChange,
+  searchPlaceholder = '검색',
+  sortValue,
+  sortOptions,
+  onSortChange,
+}: ListToolbarProps<T>) {
+  return (
+    <div className="flex items-center gap-2 py-3 border-b border-[var(--color-border)]">
+      <div className="relative min-w-0 flex-1">
+        <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-[var(--color-text-secondary)]" />
+        <input
+          type="text"
+          value={searchValue}
+          onChange={(e) => onSearchChange(e.target.value)}
+          placeholder={searchPlaceholder}
+          className="w-full rounded-md border border-border bg-background py-1.5 pl-8 pr-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+        />
+      </div>
+      <SortDropdown value={sortValue} options={sortOptions} onChange={onSortChange} />
+    </div>
+  )
+}

--- a/src/lib/queries/bookmark.ts
+++ b/src/lib/queries/bookmark.ts
@@ -71,12 +71,13 @@ export async function getBookmarks(
     isUnavailable: b.roastery.deletedAt !== null || b.roastery.hidden,
   }))
 
-  if (sort === 'myRating') {
+  if (sort === 'myRating_desc' || sort === 'myRating_asc') {
+    const dir = sort === 'myRating_desc' ? -1 : 1
     result.sort((a, b) => {
       if (a.myRating === null && b.myRating === null) return 0
       if (a.myRating === null) return 1
       if (b.myRating === null) return -1
-      return b.myRating - a.myRating
+      return dir * (a.myRating - b.myRating)
     })
   }
 

--- a/src/lib/queries/rating.ts
+++ b/src/lib/queries/rating.ts
@@ -98,6 +98,7 @@ export async function getUserRatings(
 ): Promise<{ items: MyRatingItem[]; nextCursor: string | null }> {
   const orderBy = {
     date_desc: [{ updatedAt: 'desc' as const }],
+    date_asc: [{ updatedAt: 'asc' as const }],
     score_desc: [{ score: 'desc' as const }, { updatedAt: 'desc' as const }],
     score_asc: [{ score: 'asc' as const }, { updatedAt: 'desc' as const }],
   }[sort]

--- a/src/types/bookmark.ts
+++ b/src/types/bookmark.ts
@@ -9,4 +9,4 @@ export interface BookmarkWithRoastery {
   isUnavailable: boolean
 }
 
-export type BookmarkSort = 'name' | 'myRating'
+export type BookmarkSort = 'name' | 'myRating_desc' | 'myRating_asc'

--- a/src/types/rating.ts
+++ b/src/types/rating.ts
@@ -1,6 +1,6 @@
 export type RatingSortOption = 'SIMILAR' | 'HIGH' | 'LOW'
 
-export type MyRatingSort = 'date_desc' | 'score_desc' | 'score_asc'
+export type MyRatingSort = 'date_desc' | 'date_asc' | 'score_desc' | 'score_asc'
 
 export interface RatingListItem {
   id: string


### PR DESCRIPTION
## 변경 사항
- `MyRatingList`, `BookmarkList` 행의 `border-b` 구분선 제거
- 각 행에 `px-3 py-3 rounded-md` 적용 → hover 시 라운딩된 카드 형태
- 리스트 컨테이너에 `gap-1 pt-2` 적용

## 테스트 방법
- [x] `/activity` 진입 후 내 평가 탭에서 리스트 항목 hover 확인
- [x] 즐겨찾기 탭에서 리스트 항목 hover 확인
- [x] 즐겨찾기 탭에서 이용 불가 항목(opacity) 표시 확인