### PR TITLE
feat: 원두 로스팅 포인트 선택 안 함 옵션 추가

### DIFF
--- a/src/actions/admin.ts
+++ b/src/actions/admin.ts
@@ -141,7 +141,7 @@ export interface CreateBeanInput {
   prices: BeanPriceInput[]
 }
 
-const ROASTING_LEVELS = ['LIGHT', 'MEDIUM_LIGHT', 'MEDIUM', 'MEDIUM_DARK', 'DARK']
+const ROASTING_LEVELS = ['', 'LIGHT', 'MEDIUM_LIGHT', 'MEDIUM', 'MEDIUM_DARK', 'DARK']
 
 /** 현재 visible 원두(deletedAt=null, hidden=false) 기준으로 Roastery.decaf를 재동기화 */
 async function syncRoasteryDecaf(roasteryId: string): Promise<void> {

--- a/src/components/admin/BeanForm.tsx
+++ b/src/components/admin/BeanForm.tsx
@@ -42,6 +42,7 @@ interface BeanFormProps {
 }
 
 const ROASTING_LEVELS = [
+  { value: '', label: '선택 안 함' },
   { value: 'LIGHT', label: '라이트' },
   { value: 'MEDIUM_LIGHT', label: '미디엄 라이트' },
   { value: 'MEDIUM', label: '미디엄' },
@@ -66,7 +67,7 @@ export function BeanForm({
   )
   const [name, setName] = useState(initialData?.name ?? '')
   const [origins, setOrigins] = useState<string[]>(initialData?.origins ?? [])
-  const [roastingLevel, setRoastingLevel] = useState(initialData?.roastingLevel ?? 'MEDIUM')
+  const [roastingLevel, setRoastingLevel] = useState(initialData?.roastingLevel ?? '')
   const [decaf, setDecaf] = useState(initialData?.decaf ?? false)
   const [cupNotes, setCupNotes] = useState<string[]>(initialData?.cupNotes ?? [])
   const [imageUrl, setImageUrl] = useState(initialData?.imageUrl ?? '')
@@ -200,9 +201,7 @@ export function BeanForm({
 
       {/* 로스팅 레벨 */}
       <div className="flex flex-col gap-1.5">
-        <label className="text-sm font-medium text-text">
-          로스팅 레벨 <span className="text-error">*</span>
-        </label>
+        <label className="text-sm font-medium text-text">로스팅 레벨</label>
         <select
           value={roastingLevel}
           onChange={(e) => setRoastingLevel(e.target.value)}


### PR DESCRIPTION
## 변경 사항
- 원두 추가/수정 폼의 로스팅 레벨 드롭다운 최상단에 '선택 안 함' 옵션 추가
- 신규 원두 등록 시 기본값을 MEDIUM → 선택 안 함(빈 문자열)으로 변경
- 로스팅 레벨 필수 표시(\*) 제거
- 서버 액션 유효성 검사에서 빈 문자열 허용

## 테스트 방법
- [x] 관리자 원두 추가 폼에서 로스팅 레벨 드롭다운에 '선택 안 함'이 첫 번째 옵션으로 표시되는지 확인
- [x] '선택 안 함'으로 원두를 저장했을 때 오류 없이 저장되는지 확인
- [x] 기존 원두 수정 폼에서 기존 로스팅 레벨이 정상적으로 표시되는지 확인
- [x] '선택 안 함'으로 저장된 원두가 공개 페이지에서 로스팅 레벨 없이 표시되는지 확인