### PR TITLE
fix: 평가 제출 후 / 리다이렉트 및 세션 로딩 버그 수정

### DIFF
--- a/src/components/rating/RatingButton.tsx
+++ b/src/components/rating/RatingButton.tsx
@@ -2,13 +2,13 @@
 
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
+import { useSession } from 'next-auth/react'
 import { Button } from '@/components/ui/button'
 import { RatingModal } from './RatingModal'
 
 interface RatingButtonProps {
   roasteryId: string
   roasteryName: string
-  isLoggedIn: boolean
   existingScore?: number
   existingComment?: string
 }
@@ -16,14 +16,16 @@ interface RatingButtonProps {
 export function RatingButton({
   roasteryId,
   roasteryName,
-  isLoggedIn,
   existingScore,
   existingComment,
 }: RatingButtonProps) {
   const [open, setOpen] = useState(false)
   const [currentScore, setCurrentScore] = useState(existingScore)
   const [currentComment, setCurrentComment] = useState(existingComment)
+  const { data: session } = useSession()
   const router = useRouter()
+
+  const isLoggedIn = !!session?.user?.id
 
   function handleClick() {
     if (!isLoggedIn) {

--- a/src/components/rating/RatingButton.tsx
+++ b/src/components/rating/RatingButton.tsx
@@ -21,6 +21,8 @@ export function RatingButton({
   existingComment,
 }: RatingButtonProps) {
   const [open, setOpen] = useState(false)
+  const [currentScore, setCurrentScore] = useState(existingScore)
+  const [currentComment, setCurrentComment] = useState(existingComment)
   const router = useRouter()
 
   function handleClick() {
@@ -31,10 +33,16 @@ export function RatingButton({
     setOpen(true)
   }
 
+  function handleSuccess(score?: number, comment?: string) {
+    setCurrentScore(score)
+    setCurrentComment(comment)
+    window.dispatchEvent(new CustomEvent('roco:rating-changed', { detail: { roasteryId } }))
+  }
+
   return (
     <>
-      <Button variant={existingScore ? 'secondary' : 'default'} onClick={handleClick}>
-        {existingScore ? `내 평가: ${existingScore}점 ★` : '평가하기'}
+      <Button variant={currentScore ? 'secondary' : 'default'} onClick={handleClick}>
+        {currentScore ? `내 평가: ${currentScore}점 ★` : '평가하기'}
       </Button>
 
       {isLoggedIn && (
@@ -43,9 +51,9 @@ export function RatingButton({
           onOpenChange={setOpen}
           roasteryId={roasteryId}
           roasteryName={roasteryName}
-          existingScore={existingScore}
-          existingComment={existingComment}
-          onSuccess={() => router.refresh()}
+          existingScore={currentScore}
+          existingComment={currentComment}
+          onSuccess={handleSuccess}
         />
       )}
     </>

--- a/src/components/rating/RatingButton.tsx
+++ b/src/components/rating/RatingButton.tsx
@@ -22,12 +22,13 @@ export function RatingButton({
   const [open, setOpen] = useState(false)
   const [currentScore, setCurrentScore] = useState(existingScore)
   const [currentComment, setCurrentComment] = useState(existingComment)
-  const { data: session } = useSession()
+  const { status } = useSession()
   const router = useRouter()
 
-  const isLoggedIn = !!session?.user?.id
+  const isLoggedIn = status === 'authenticated'
 
   function handleClick() {
+    if (status === 'loading') return
     if (!isLoggedIn) {
       router.push('/login')
       return

--- a/src/components/rating/RatingForm.tsx
+++ b/src/components/rating/RatingForm.tsx
@@ -10,7 +10,7 @@ interface RatingFormProps {
   roasteryId: string
   initialScore?: number
   initialComment?: string
-  onSuccess: () => void
+  onSuccess: (score: number, comment?: string) => void
 }
 
 export function RatingForm({
@@ -34,7 +34,7 @@ export function RatingForm({
       const result = await upsertRating({ roasteryId, score, comment: comment.trim() || undefined })
       if (result.success) {
         toast.success('평가가 저장됐어요.')
-        onSuccess()
+        onSuccess(score, comment.trim() || undefined)
       } else {
         toast.error(result.error)
       }

--- a/src/components/rating/RatingList.tsx
+++ b/src/components/rating/RatingList.tsx
@@ -44,6 +44,25 @@ export function RatingList({
     })
   }
 
+  // 평가 제출/삭제 시 roco:rating-changed 이벤트를 수신해 첫 페이지를 재조회
+  useEffect(() => {
+    function handleRatingChanged(e: Event) {
+      const detail = (e as CustomEvent<{ roasteryId: string }>).detail
+      if (detail.roasteryId !== roasteryId) return
+      startTransition(async () => {
+        try {
+          const page = await fetchRoasteryRatings({ roasteryId, sort, cursor: '' })
+          setItems(page.items)
+          setNextCursor(page.nextCursor)
+        } catch {
+          toast.error('한줄평을 불러오지 못했어요. 다시 시도해 주세요.')
+        }
+      })
+    }
+    window.addEventListener('roco:rating-changed', handleRatingChanged)
+    return () => window.removeEventListener('roco:rating-changed', handleRatingChanged)
+  }, [roasteryId, sort])
+
   // IntersectionObserver — 스크롤 바닥 감지
   useEffect(() => {
     if (!nextCursor || !sentinelRef.current) return

--- a/src/components/rating/RatingModal.tsx
+++ b/src/components/rating/RatingModal.tsx
@@ -13,7 +13,7 @@ interface RatingModalProps {
   roasteryName: string
   existingScore?: number
   existingComment?: string
-  onSuccess: () => void
+  onSuccess: (score?: number, comment?: string) => void
 }
 
 export function RatingModal({
@@ -27,9 +27,9 @@ export function RatingModal({
 }: RatingModalProps) {
   const [deleteOpen, setDeleteOpen] = useState(false)
 
-  function handleSuccess() {
+  function handleSuccess(score?: number, comment?: string) {
     onOpenChange(false)
-    onSuccess()
+    onSuccess(score, comment)
   }
 
   return (
@@ -45,7 +45,7 @@ export function RatingModal({
             roasteryId={roasteryId}
             initialScore={existingScore ?? 0}
             initialComment={existingComment ?? ''}
-            onSuccess={handleSuccess}
+            onSuccess={(score, comment) => handleSuccess(score, comment)}
           />
 
           {existingScore && (

--- a/src/components/roastery/RoasteryDetail.tsx
+++ b/src/components/roastery/RoasteryDetail.tsx
@@ -125,9 +125,8 @@ export function RoasteryDetail({
         beans={roastery.beans}
       />
 
-      {/* 한줄평 목록 — userRating이 바뀔 때 key가 바뀌어 remount, 최신 서버 데이터로 초기화 */}
+      {/* 한줄평 목록 */}
       <RatingList
-        key={`${userRating?.score ?? 'none'}-${userRating?.comment ?? ''}`}
         roasteryId={roastery.id}
         initialItems={initialRatings}
         initialNextCursor={initialNextCursor}

--- a/src/components/roastery/RoasteryDetail.tsx
+++ b/src/components/roastery/RoasteryDetail.tsx
@@ -81,7 +81,6 @@ export function RoasteryDetail({
               <RatingButton
                 roasteryId={roastery.id}
                 roasteryName={roastery.name}
-                isLoggedIn={isLoggedIn}
                 existingScore={userRating?.score}
                 existingComment={userRating?.comment}
               />

--- a/src/components/roastery/RoasteryDetail.tsx
+++ b/src/components/roastery/RoasteryDetail.tsx
@@ -125,8 +125,9 @@ export function RoasteryDetail({
         beans={roastery.beans}
       />
 
-      {/* 한줄평 목록 */}
+      {/* 한줄평 목록 — userRating이 바뀔 때 key가 바뀌어 remount, 최신 서버 데이터로 초기화 */}
       <RatingList
+        key={`${userRating?.score ?? 'none'}-${userRating?.comment ?? ''}`}
         roasteryId={roastery.id}
         initialItems={initialRatings}
         initialNextCursor={initialNextCursor}


### PR DESCRIPTION
## 변경 사항
- `router.refresh()` 제거 — Next.js App Router에서 revalidatePath 이후 router.refresh() 호출 시 / 로 이동하는 버그 원인 차단
- `RatingButton`에 로컬 state(`currentScore`, `currentComment`) 추가 — 평가 성공 시 인라인 업데이트, 페이지 이동 없음
- `RatingButton`을 `useSession()` 기반으로 전환 — 라우터 캐시가 `isLoggedIn=false`인 오래된 페이지를 서빙해도 클라이언트 세션 기준으로 동작
- 세션 `status === 'loading'` 중 클릭 무시 처리 추가
- `roco:rating-changed` 커스텀 이벤트 디스패치 — `RatingList`가 이벤트 수신 후 `fetchRoasteryRatings` 직접 호출해 목록 즉시 갱신

## 테스트 방법
- [ ] 로그인한 상태에서 로스터리 상세 페이지 접속 → 평가하기 클릭 → 별점 선택 후 평가 저장 → **/ 로 이동하지 않고 현재 페이지에 유지됨** + 한줄평 목록이 즉시 갱신됨
- [ ] 평가 수정 (기존 평가 있는 경우) 동일하게 테스트
- [ ] 평가 삭제 후에도 현재 페이지에 유지됨
- [ ] 비로그인 상태에서 평가하기 클릭 → /login 이동