### PR TITLE
fix: 평가 저장 후 네비게이션 및 한줄평 즉시 반영 버그 수정

### DIFF
--- a/src/components/home/HomeFeedClient.tsx
+++ b/src/components/home/HomeFeedClient.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { useState, useTransition } from 'react'
-import { useRouter } from 'next/navigation'
 import { motion } from 'framer-motion'
 import { DecafToggle } from './DecafToggle'
 import { RecommendSection } from './RecommendSection'
@@ -28,7 +27,6 @@ export function HomeFeedClient({
 }: HomeFeedClientProps) {
   const [decafOn, setDecafOn] = useState(false)
   const [, startTransition] = useTransition()
-  const router = useRouter()
 
   const handleCardClick = (roasteryId: string) => {
     startTransition(async () => {
@@ -40,7 +38,6 @@ export function HomeFeedClient({
         },
       })
     })
-    router.push(`/roasteries/${roasteryId}`)
   }
 
   const cfNewItems: RecommendationItem[] =

--- a/src/components/rating/RatingList.tsx
+++ b/src/components/rating/RatingList.tsx
@@ -28,13 +28,13 @@ export function RatingList({
   const [isPending, startTransition] = useTransition()
   const sentinelRef = useRef<HTMLDivElement>(null)
 
-  // router.refresh() 후 서버에서 새 props가 내려오면 state 동기화
+  // router.refresh() 후 서버에서 새 initialItems가 내려오면 state 동기화
+  // sort는 사용자가 선택한 값을 유지 (handleSortChange로만 변경)
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setItems(initialItems)
     setNextCursor(initialNextCursor)
-    setSort(initialSort)
-  }, [initialItems, initialNextCursor, initialSort])
+  }, [initialItems, initialNextCursor])
 
   // 정렬 변경 시 서버에서 재조회
   function handleSortChange(newSort: RatingSortOption) {

--- a/src/components/rating/RatingList.tsx
+++ b/src/components/rating/RatingList.tsx
@@ -29,12 +29,25 @@ export function RatingList({
   const sentinelRef = useRef<HTMLDivElement>(null)
 
   // router.refresh() 후 서버에서 새 initialItems가 내려오면 state 동기화
-  // sort는 사용자가 선택한 값을 유지 (handleSortChange로만 변경)
+  // 사용자가 initialSort와 다른 정렬을 선택 중이면 해당 정렬로 재조회
+  // sort는 의도적으로 deps 제외 — 정렬 변경은 handleSortChange가 단독 처리
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setItems(initialItems)
-    setNextCursor(initialNextCursor)
-  }, [initialItems, initialNextCursor])
+    if (sort === initialSort) {
+      setItems(initialItems)
+      setNextCursor(initialNextCursor)
+    } else {
+      startTransition(async () => {
+        try {
+          const page = await fetchRoasteryRatings({ roasteryId, sort, cursor: '' })
+          setItems(page.items)
+          setNextCursor(page.nextCursor)
+        } catch {
+          toast.error('한줄평을 불러오지 못했어요. 다시 시도해 주세요.')
+        }
+      })
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialItems, initialNextCursor, initialSort, roasteryId])
 
   // 정렬 변경 시 서버에서 재조회
   function handleSortChange(newSort: RatingSortOption) {

--- a/src/components/rating/RatingList.tsx
+++ b/src/components/rating/RatingList.tsx
@@ -28,12 +28,13 @@ export function RatingList({
   const [isPending, startTransition] = useTransition()
   const sentinelRef = useRef<HTMLDivElement>(null)
 
-  // router.refresh() 후 서버에서 새 initialItems가 내려오면 state 동기화
+  // router.refresh() 후 서버에서 새 props가 내려오면 state 동기화
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setItems(initialItems)
     setNextCursor(initialNextCursor)
-  }, [initialItems, initialNextCursor])
+    setSort(initialSort)
+  }, [initialItems, initialNextCursor, initialSort])
 
   // 정렬 변경 시 서버에서 재조회
   function handleSortChange(newSort: RatingSortOption) {

--- a/src/components/rating/RatingList.tsx
+++ b/src/components/rating/RatingList.tsx
@@ -28,6 +28,13 @@ export function RatingList({
   const [isPending, startTransition] = useTransition()
   const sentinelRef = useRef<HTMLDivElement>(null)
 
+  // router.refresh() 후 서버에서 새 initialItems가 내려오면 state 동기화
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setItems(initialItems)
+    setNextCursor(initialNextCursor)
+  }, [initialItems, initialNextCursor])
+
   // 정렬 변경 시 서버에서 재조회
   function handleSortChange(newSort: RatingSortOption) {
     setSort(newSort)


### PR DESCRIPTION
## 변경 사항
- 홈 피드에서 로스터리 카드 클릭 시 `RoasteryCard`의 `<Link>`와 `HomeFeedClient`의 `router.push()`가 동시에 발화해 history에 동일 URL이 중복 쌓이는 이중 navigation 버그 수정
- 평가 저장(`router.refresh()`) 후 `RatingList`의 `items`/`nextCursor`/`sort` state가 갱신되지 않는 버그 수정 — `useEffect`로 서버 props 변경 시 동기화

## 테스트 방법
- [ ] 홈(/)에서 로스터리 카드 클릭 → 로스터리 상세 진입 → 평가 저장 → 상세 페이지에 그대로 머무는지 확인
- [ ] 평가 저장 후 내 한줄평이 목록에 즉시 나타나는지 확인
- [ ] 3번째 평가 저장 후 정렬 기준이 HIGH → 유사도순으로 전환되는지 확인 (3개 미만 유저 기준)