### PR TITLE
fix: 법적 문서 사업자명 플레이스홀더를 roco로 교체

### DIFF
--- a/src/app/(main)/legal/privacy/page.tsx
+++ b/src/app/(main)/legal/privacy/page.tsx
@@ -6,7 +6,7 @@ export const metadata: Metadata = {
 
 const EFFECTIVE_DATE = '2026년 4월 20일'
 const SERVICE_NAME = 'roco'
-const COMPANY_NAME = '[사업자명]'
+const COMPANY_NAME = 'roco'
 const CONTACT_EMAIL = 'roco.support@gmail.com'
 
 export default function PrivacyPage() {

--- a/src/app/(main)/legal/terms/page.tsx
+++ b/src/app/(main)/legal/terms/page.tsx
@@ -6,7 +6,7 @@ export const metadata: Metadata = {
 
 const EFFECTIVE_DATE = '2026년 4월 20일'
 const SERVICE_NAME = 'roco'
-const COMPANY_NAME = '[사업자명]'
+const COMPANY_NAME = 'roco'
 const CONTACT_EMAIL = 'roco.support@gmail.com'
 
 export default function TermsPage() {


### PR DESCRIPTION
## 변경 사항
- 개인정보처리방침 `COMPANY_NAME = '[사업자명]'` → `'roco'`
- 이용약관 `COMPANY_NAME = '[사업자명]'` → `'roco'`

## 테스트 방법
- [x] `/legal/privacy` 페이지 열어서 "roco(이하 "회사")는" 으로 표시되는지 확인
- [x] `/legal/terms` 페이지 열어서 "roco(이하 "회사")가 제공하는" 으로 표시되는지 확인