### PR TITLE
feat: 내 활동 리스트 검색/정렬 개선 및 UX 수정

### DIFF
--- a/src/components/bookmark/BookmarkList.tsx
+++ b/src/components/bookmark/BookmarkList.tsx
@@ -56,9 +56,9 @@ export function BookmarkList({ bookmarks, initialSort }: BookmarkListProps) {
           {search.trim() ? '검색 결과가 없습니다.' : '즐겨찾기한 로스터리가 없습니다.'}
         </p>
       ) : (
-        <ul className="flex flex-col gap-1 pt-2">
+        <div className="flex flex-col gap-1 pt-2">
           {filtered.map((item) => (
-            <li key={item.id} className={`rounded-md ${item.isUnavailable ? 'opacity-50' : ''}`}>
+            <div key={item.id} className={`rounded-md ${item.isUnavailable ? 'opacity-50' : ''}`}>
               {item.isUnavailable ? (
                 <div className="flex items-center gap-3 px-3 py-3">
                   <div className="flex min-w-0 flex-1 flex-col gap-0.5">
@@ -112,9 +112,9 @@ export function BookmarkList({ bookmarks, initialSort }: BookmarkListProps) {
                   </button>
                 </div>
               )}
-            </li>
+            </div>
           ))}
-        </ul>
+        </div>
       )}
 
       {removeTarget && (

--- a/src/components/bookmark/BookmarkList.tsx
+++ b/src/components/bookmark/BookmarkList.tsx
@@ -41,7 +41,7 @@ export function BookmarkList({ bookmarks, initialSort }: BookmarkListProps) {
     : sorted
 
   return (
-    <>
+    <div className="flex flex-col">
       <ListToolbar
         searchValue={search}
         onSearchChange={setSearch}
@@ -56,9 +56,9 @@ export function BookmarkList({ bookmarks, initialSort }: BookmarkListProps) {
           {search.trim() ? '검색 결과가 없습니다.' : '즐겨찾기한 로스터리가 없습니다.'}
         </p>
       ) : (
-        <div className="flex flex-col gap-1 pt-2">
+        <ul className="flex flex-col gap-1 pt-2">
           {filtered.map((item) => (
-            <div key={item.id} className={`rounded-md ${item.isUnavailable ? 'opacity-50' : ''}`}>
+            <li key={item.id} className={`rounded-md ${item.isUnavailable ? 'opacity-50' : ''}`}>
               {item.isUnavailable ? (
                 <div className="flex items-center gap-3 px-3 py-3">
                   <div className="flex min-w-0 flex-1 flex-col gap-0.5">
@@ -112,9 +112,9 @@ export function BookmarkList({ bookmarks, initialSort }: BookmarkListProps) {
                   </button>
                 </div>
               )}
-            </div>
+            </li>
           ))}
-        </div>
+        </ul>
       )}
 
       {removeTarget && (
@@ -128,6 +128,6 @@ export function BookmarkList({ bookmarks, initialSort }: BookmarkListProps) {
           onSuccess={() => router.refresh()}
         />
       )}
-    </>
+    </div>
   )
 }

--- a/src/components/bookmark/BookmarkList.tsx
+++ b/src/components/bookmark/BookmarkList.tsx
@@ -4,13 +4,14 @@ import { useState } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { Badge } from '@/components/ui/badge'
-import { SortDropdown } from '@/components/ui/sort-dropdown'
+import { ListToolbar } from '@/components/ui/list-toolbar'
 import { RemoveBookmarkDialog } from './RemoveBookmarkDialog'
 import type { BookmarkWithRoastery, BookmarkSort } from '@/types/bookmark'
 
 const SORT_OPTIONS: { value: BookmarkSort; label: string }[] = [
   { value: 'name', label: '이름순' },
-  { value: 'myRating', label: '내 별점순' },
+  { value: 'myRating_desc', label: '별점 높은순' },
+  { value: 'myRating_asc', label: '별점 낮은순' },
 ]
 
 interface BookmarkListProps {
@@ -20,80 +21,101 @@ interface BookmarkListProps {
 
 export function BookmarkList({ bookmarks, initialSort }: BookmarkListProps) {
   const [sort, setSort] = useState<BookmarkSort>(initialSort)
+  const [search, setSearch] = useState('')
   const [removeTarget, setRemoveTarget] = useState<BookmarkWithRoastery | null>(null)
   const router = useRouter()
 
   const sorted = [...bookmarks].sort((a, b) => {
     if (sort === 'name') return a.roastery.name.localeCompare(b.roastery.name, 'ko')
+    const dir = sort === 'myRating_desc' ? -1 : 1
     if (a.myRating === null && b.myRating === null) return 0
     if (a.myRating === null) return 1
     if (b.myRating === null) return -1
-    return b.myRating - a.myRating
+    return dir * (a.myRating - b.myRating)
   })
+
+  const filtered = search.trim()
+    ? sorted.filter((item) =>
+        item.roastery.name.toLowerCase().includes(search.trim().toLowerCase())
+      )
+    : sorted
 
   return (
     <>
-      <div className="flex justify-end py-3 border-b border-[var(--color-border)]">
-        <SortDropdown value={sort} options={SORT_OPTIONS} onChange={setSort} />
-      </div>
+      <ListToolbar
+        searchValue={search}
+        onSearchChange={setSearch}
+        searchPlaceholder="로스터리 검색"
+        sortValue={sort}
+        sortOptions={SORT_OPTIONS}
+        onSortChange={setSort}
+      />
 
-      <ul className="flex flex-col gap-1 pt-2">
-        {sorted.map((item) => (
-          <li key={item.id} className={`rounded-md ${item.isUnavailable ? 'opacity-50' : ''}`}>
-            {item.isUnavailable ? (
-              <div className="flex items-center gap-3 px-3 py-3">
-                <div className="flex flex-1 flex-col gap-0.5 min-w-0">
-                  <span className="text-sm font-medium text-muted-foreground truncate">
-                    {item.roastery.name}
-                  </span>
-                  <span className="text-xs text-muted-foreground">
-                    더 이상 이용할 수 없는 로스터리입니다
-                  </span>
-                </div>
-                <button
-                  type="button"
-                  onClick={() => setRemoveTarget(item)}
-                  className="text-xs text-destructive hover:underline cursor-pointer shrink-0"
-                >
-                  해제
-                </button>
-              </div>
-            ) : (
-              <div className="flex items-center gap-3 px-3 py-3 rounded-md hover:bg-[var(--color-surface)] transition-colors">
-                <Link
-                  href={`/roasteries/${item.roasteryId}`}
-                  className="flex flex-1 items-center gap-2 min-w-0"
-                >
-                  <span className="text-sm font-medium text-[var(--color-text-primary)] truncate">
-                    {item.roastery.name}
-                  </span>
-                  {item.isClosed && (
-                    <Badge
-                      variant="outline"
-                      className="text-xs shrink-0 text-amber-700 border-amber-300 bg-amber-50"
-                    >
-                      폐업
-                    </Badge>
-                  )}
-                  {item.myRating !== null && (
-                    <span className="text-xs text-[var(--color-accent)] shrink-0 ml-auto">
-                      {'★'.repeat(item.myRating)}
-                      {'☆'.repeat(5 - item.myRating)}
+      {filtered.length === 0 ? (
+        <p className="py-8 text-center text-sm text-[var(--color-text-secondary)]">
+          {search.trim() ? '검색 결과가 없습니다.' : '즐겨찾기한 로스터리가 없습니다.'}
+        </p>
+      ) : (
+        <ul className="flex flex-col gap-1 pt-2">
+          {filtered.map((item) => (
+            <li key={item.id} className={`rounded-md ${item.isUnavailable ? 'opacity-50' : ''}`}>
+              {item.isUnavailable ? (
+                <div className="flex items-center gap-3 px-3 py-3">
+                  <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                    <span className="truncate text-sm font-medium text-muted-foreground">
+                      {item.roastery.name}
                     </span>
-                  )}
-                </Link>
-                <button
-                  type="button"
-                  onClick={() => setRemoveTarget(item)}
-                  className="text-xs text-destructive hover:underline cursor-pointer shrink-0"
-                >
-                  해제
-                </button>
-              </div>
-            )}
-          </li>
-        ))}
-      </ul>
+                    <span className="text-xs text-muted-foreground">
+                      더 이상 이용할 수 없는 로스터리입니다
+                    </span>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => setRemoveTarget(item)}
+                    className="shrink-0 cursor-pointer text-xs text-destructive hover:underline"
+                  >
+                    해제
+                  </button>
+                </div>
+              ) : (
+                <div className="relative flex items-center gap-3 rounded-md px-3 py-3 transition-colors hover:bg-[var(--color-surface)] active:bg-[var(--color-surface)]">
+                  <Link
+                    href={`/roasteries/${item.roasteryId}`}
+                    className="absolute inset-0 rounded-md"
+                    aria-label={item.roastery.name}
+                  />
+                  <div className="pointer-events-none flex min-w-0 flex-1 items-center gap-2">
+                    <span className="truncate text-sm font-medium text-[var(--color-text-primary)]">
+                      {item.roastery.name}
+                    </span>
+                    {item.isClosed && (
+                      <Badge
+                        variant="outline"
+                        className="shrink-0 border-amber-300 bg-amber-50 text-xs text-amber-700"
+                      >
+                        폐업
+                      </Badge>
+                    )}
+                    {item.myRating !== null && (
+                      <span className="ml-auto shrink-0 text-xs text-[var(--color-accent)]">
+                        {'★'.repeat(item.myRating)}
+                        {'☆'.repeat(5 - item.myRating)}
+                      </span>
+                    )}
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => setRemoveTarget(item)}
+                    className="relative z-10 shrink-0 cursor-pointer text-xs text-destructive hover:underline"
+                  >
+                    해제
+                  </button>
+                </div>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
 
       {removeTarget && (
         <RemoveBookmarkDialog

--- a/src/components/profile/MyRatingList.tsx
+++ b/src/components/profile/MyRatingList.tsx
@@ -122,7 +122,7 @@ function MyRatingRow({ item }: { item: MyRatingItem }) {
   return (
     <Link
       href={`/roasteries/${item.roastery.id}`}
-      className="flex min-h-[3.5rem] flex-col justify-center gap-1 rounded-md px-3 py-3 transition-colors hover:bg-[var(--color-surface)] active:bg-[var(--color-surface)]"
+      className="flex flex-col gap-1 rounded-md px-3 py-3 transition-colors hover:bg-[var(--color-surface)] active:bg-[var(--color-surface)]"
     >
       <div className="flex items-center justify-between gap-2">
         <span className="truncate text-sm font-medium text-[var(--color-text-primary)]">

--- a/src/components/profile/MyRatingList.tsx
+++ b/src/components/profile/MyRatingList.tsx
@@ -89,17 +89,23 @@ export function MyRatingList({ initialItems, initialNextCursor }: MyRatingListPr
         <p className="py-4 text-center text-sm text-[var(--color-text-secondary)]">
           불러오는 중...
         </p>
-      ) : !isPending && filtered.length === 0 ? (
+      ) : items.length === 0 ? (
         <p className="py-4 text-center text-sm text-[var(--color-text-secondary)]">
-          {search.trim() ? '검색 결과가 없습니다.' : '아직 작성한 한줄평이 없습니다.'}
+          아직 작성한 한줄평이 없습니다.
         </p>
       ) : (
         <>
-          <div className="flex flex-col gap-1 pt-2">
-            {filtered.map((item) => (
-              <MyRatingRow key={item.id} item={item} />
-            ))}
-          </div>
+          {filtered.length === 0 ? (
+            <p className="py-4 text-center text-sm text-[var(--color-text-secondary)]">
+              검색 결과가 없습니다.
+            </p>
+          ) : (
+            <div className="flex flex-col gap-1 pt-2">
+              {filtered.map((item) => (
+                <MyRatingRow key={item.id} item={item} />
+              ))}
+            </div>
+          )}
           <div ref={sentinelRef} className="h-1" />
           {isPending && (
             <p className="py-4 text-center text-sm text-[var(--color-text-secondary)]">

--- a/src/components/profile/MyRatingList.tsx
+++ b/src/components/profile/MyRatingList.tsx
@@ -3,18 +3,19 @@
 import { useState, useEffect, useRef, useTransition } from 'react'
 import Link from 'next/link'
 import { fetchUserRatings } from '@/actions/rating'
-import { SortDropdown } from '@/components/ui/sort-dropdown'
+import { ListToolbar } from '@/components/ui/list-toolbar'
 import type { MyRatingItem, MyRatingSort } from '@/types/rating'
 
 const SORT_OPTIONS: { value: MyRatingSort; label: string }[] = [
   { value: 'date_desc', label: '최신순' },
+  { value: 'date_asc', label: '오래된순' },
   { value: 'score_desc', label: '별점 높은순' },
   { value: 'score_asc', label: '별점 낮은순' },
 ]
 
 function StarRow({ score }: { score: number }) {
   return (
-    <span className="text-xs text-[var(--color-accent)] shrink-0">
+    <span className="shrink-0 text-xs text-[var(--color-accent)]">
       {'★'.repeat(score)}
       {'☆'.repeat(5 - score)}
     </span>
@@ -28,6 +29,7 @@ interface MyRatingListProps {
 
 export function MyRatingList({ initialItems, initialNextCursor }: MyRatingListProps) {
   const [sort, setSort] = useState<MyRatingSort>('date_desc')
+  const [search, setSearch] = useState('')
   const [items, setItems] = useState<MyRatingItem[]>(initialItems)
   const [nextCursor, setNextCursor] = useState<string | null>(initialNextCursor)
   const [isPending, startTransition] = useTransition()
@@ -64,30 +66,43 @@ export function MyRatingList({ initialItems, initialNextCursor }: MyRatingListPr
     return () => observer.disconnect()
   }, [nextCursor, isPending, sort])
 
+  const filtered = search.trim()
+    ? items.filter(
+        (item) =>
+          item.roastery.name.toLowerCase().includes(search.trim().toLowerCase()) ||
+          item.comment?.toLowerCase().includes(search.trim().toLowerCase())
+      )
+    : items
+
   return (
     <div className="flex flex-col">
-      <div className="flex justify-end py-3 border-b border-[var(--color-border)]">
-        <SortDropdown value={sort} options={SORT_OPTIONS} onChange={handleSortChange} />
-      </div>
+      <ListToolbar
+        searchValue={search}
+        onSearchChange={setSearch}
+        searchPlaceholder="로스터리명 또는 한줄평 검색"
+        sortValue={sort}
+        sortOptions={SORT_OPTIONS}
+        onSortChange={handleSortChange}
+      />
 
       {isPending && items.length === 0 ? (
-        <p className="text-sm text-[var(--color-text-secondary)] py-4 text-center">
+        <p className="py-4 text-center text-sm text-[var(--color-text-secondary)]">
           불러오는 중...
         </p>
-      ) : !isPending && items.length === 0 ? (
-        <p className="text-sm text-[var(--color-text-secondary)] py-4 text-center">
-          아직 작성한 한줄평이 없습니다.
+      ) : !isPending && filtered.length === 0 ? (
+        <p className="py-4 text-center text-sm text-[var(--color-text-secondary)]">
+          {search.trim() ? '검색 결과가 없습니다.' : '아직 작성한 한줄평이 없습니다.'}
         </p>
       ) : (
         <>
           <div className="flex flex-col gap-1 pt-2">
-            {items.map((item) => (
+            {filtered.map((item) => (
               <MyRatingRow key={item.id} item={item} />
             ))}
           </div>
           <div ref={sentinelRef} className="h-1" />
           {isPending && (
-            <p className="text-sm text-[var(--color-text-secondary)] py-4 text-center">
+            <p className="py-4 text-center text-sm text-[var(--color-text-secondary)]">
               불러오는 중...
             </p>
           )}
@@ -101,16 +116,16 @@ function MyRatingRow({ item }: { item: MyRatingItem }) {
   return (
     <Link
       href={`/roasteries/${item.roastery.id}`}
-      className="flex flex-col gap-1 px-3 py-3 rounded-md hover:bg-[var(--color-surface)] transition-colors"
+      className="flex min-h-[3.5rem] flex-col justify-center gap-1 rounded-md px-3 py-3 transition-colors hover:bg-[var(--color-surface)] active:bg-[var(--color-surface)]"
     >
       <div className="flex items-center justify-between gap-2">
-        <span className="text-sm font-medium text-[var(--color-text-primary)] truncate">
+        <span className="truncate text-sm font-medium text-[var(--color-text-primary)]">
           {item.roastery.name}
         </span>
         <StarRow score={item.score} />
       </div>
       {item.comment && (
-        <p className="text-sm text-[var(--color-text-secondary)] line-clamp-2">{item.comment}</p>
+        <p className="line-clamp-2 text-sm text-[var(--color-text-secondary)]">{item.comment}</p>
       )}
     </Link>
   )

--- a/src/components/ui/list-toolbar.tsx
+++ b/src/components/ui/list-toolbar.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import { Search } from 'lucide-react'
+import { SortDropdown } from './sort-dropdown'
+
+interface ListToolbarProps<T extends string> {
+  searchValue: string
+  onSearchChange: (value: string) => void
+  searchPlaceholder?: string
+  sortValue: T
+  sortOptions: { value: T; label: string }[]
+  onSortChange: (value: T) => void
+}
+
+export function ListToolbar<T extends string>({
+  searchValue,
+  onSearchChange,
+  searchPlaceholder = '검색',
+  sortValue,
+  sortOptions,
+  onSortChange,
+}: ListToolbarProps<T>) {
+  return (
+    <div className="flex items-center gap-2 py-3 border-b border-[var(--color-border)]">
+      <div className="relative min-w-0 flex-1">
+        <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-[var(--color-text-secondary)]" />
+        <input
+          type="text"
+          value={searchValue}
+          onChange={(e) => onSearchChange(e.target.value)}
+          placeholder={searchPlaceholder}
+          className="w-full rounded-md border border-border bg-background py-1.5 pl-8 pr-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+        />
+      </div>
+      <SortDropdown value={sortValue} options={sortOptions} onChange={onSortChange} />
+    </div>
+  )
+}

--- a/src/lib/queries/bookmark.ts
+++ b/src/lib/queries/bookmark.ts
@@ -71,12 +71,13 @@ export async function getBookmarks(
     isUnavailable: b.roastery.deletedAt !== null || b.roastery.hidden,
   }))
 
-  if (sort === 'myRating') {
+  if (sort === 'myRating_desc' || sort === 'myRating_asc') {
+    const dir = sort === 'myRating_desc' ? -1 : 1
     result.sort((a, b) => {
       if (a.myRating === null && b.myRating === null) return 0
       if (a.myRating === null) return 1
       if (b.myRating === null) return -1
-      return b.myRating - a.myRating
+      return dir * (a.myRating - b.myRating)
     })
   }
 

--- a/src/lib/queries/rating.ts
+++ b/src/lib/queries/rating.ts
@@ -98,6 +98,7 @@ export async function getUserRatings(
 ): Promise<{ items: MyRatingItem[]; nextCursor: string | null }> {
   const orderBy = {
     date_desc: [{ updatedAt: 'desc' as const }],
+    date_asc: [{ updatedAt: 'asc' as const }],
     score_desc: [{ score: 'desc' as const }, { updatedAt: 'desc' as const }],
     score_asc: [{ score: 'asc' as const }, { updatedAt: 'desc' as const }],
   }[sort]

--- a/src/types/bookmark.ts
+++ b/src/types/bookmark.ts
@@ -9,4 +9,4 @@ export interface BookmarkWithRoastery {
   isUnavailable: boolean
 }
 
-export type BookmarkSort = 'name' | 'myRating'
+export type BookmarkSort = 'name' | 'myRating_desc' | 'myRating_asc'

--- a/src/types/rating.ts
+++ b/src/types/rating.ts
@@ -1,6 +1,6 @@
 export type RatingSortOption = 'SIMILAR' | 'HIGH' | 'LOW'
 
-export type MyRatingSort = 'date_desc' | 'score_desc' | 'score_asc'
+export type MyRatingSort = 'date_desc' | 'date_asc' | 'score_desc' | 'score_asc'
 
 export interface RatingListItem {
   id: string


### PR DESCRIPTION
## 변경 사항
- **ListToolbar** 공용 컴포넌트 추가 — 검색 input(좌) + 정렬 드롭다운(우) 동일 구조
- **즐겨찾기** 정렬에 별점 높은순 / 별점 낮은순 추가 (기존 '내 별점순' 대체)
- **내 평가** 정렬에 오래된순(date_asc) 추가
- 즐겨찾기·내 평가 모두 로컬 검색 필터링 지원
  - 즐겨찾기: 로스터리명
  - 내 평가: 로스터리명 + 한줄평
- 즐겨찾기 클릭 영역 수정 — `absolute inset-0` Link로 hover 영역 전체 클릭 가능, 해제 버튼은 `z-10`으로 분리
- `active:bg-surface` 추가로 모바일 터치 피드백 제공
- 내 평가 행 `min-h-[3.5rem] justify-center`로 한줄평 유무 관계없이 높이 균일화
- 내 평가 검색 중 로컬 결과 없어도 무한스크롤 유지 (sentinel 항상 렌더링)

## 테스트 방법
- [ ] `/activity` → 내 평가 탭: 검색 input 입력 후 로스터리명/한줄평 필터 확인
- [ ] 내 평가 탭: 오래된순 정렬 선택 후 순서 확인
- [ ] 즐겨찾기 탭: 검색 input 입력 후 로스터리명 필터 확인
- [ ] 즐겨찾기 탭: 별점 높은순 / 별점 낮은순 정렬 확인
- [ ] 즐겨찾기 탭: 행 전체 영역 클릭 시 로스터리 상세 이동 확인
- [ ] 즐겨찾기 탭: 해제 버튼 클릭이 정상 동작 확인 (페이지 이동 X)
- [ ] 모바일: 내 평가/즐겨찾기 행 터치 시 배경색 피드백 확인