### PR TITLE
feat: Axiom 미들웨어 로깅 및 withUser 헬퍼 추가

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,51 @@ pnpm prisma db seed        # 시드 재실행
 - 본문: 한국어, `-` 목록
 - Co-Authored-By 포함
 
+## Axiom 로깅
+
+패키지: `next-axiom`. 환경변수: `AXIOM_TOKEN`, `AXIOM_DATASET` (서버), `NEXT_PUBLIC_AXIOM_TOKEN`, `NEXT_PUBLIC_AXIOM_DATASET` (클라이언트).
+
+### 레이어별 사용법
+
+**Middleware (`src/proxy.ts`)** — 자동 request 로깅, 수동 변경 불필요
+```ts
+const logger = new Logger({ source: 'middleware' })
+await logger.middleware(request, { logRequestDetails: ['nextUrl', 'method'] })
+event.waitUntil(logger.flush())
+```
+
+**Server Action** — `withUser`로 userId 공통 필드 자동 첨부
+```ts
+import { withUser } from '@/lib/logger'
+const log = withUser(session?.user?.id)
+log.info('action.name', { ...payload })
+log.error('action.failed', { error: String(err) })
+await log.flush() // 필수
+```
+
+**Server Component**
+```ts
+import { Logger } from 'next-axiom'
+const log = new Logger()
+log.info('event', { field: value })
+await log.flush() // 필수
+```
+
+**Client Component**
+```ts
+'use client'
+import { useLogger } from 'next-axiom'
+const log = useLogger()
+log.info('event', { field: value })
+```
+
+### 규칙
+- Server Action / Server Component 끝에서 `await log.flush()` 필수 — 없으면 Vercel 서버리스에서 로그 유실
+- `logRequestDetails`에 `body`, `headers` 추가 금지 — PII·Authorization 헤더 노출 위험
+- 로깅 실패가 사용자 플로우를 막으면 안 됨 — try/catch로 감싸고 실패는 무시
+- Web Vitals(`<AxiomWebVitals />`)는 production 배포에서만 전송됨
+- `source` 필드: middleware=`"middleware"`, Server Action/Component=`"server"`, 클라이언트=`"client"`
+
 ## 릴리즈 절차 ("배포하자" 트리거)
 사용자가 "배포하자"를 요청하면 아래 순서를 실행한다.
 

--- a/src/actions/events.ts
+++ b/src/actions/events.ts
@@ -1,7 +1,7 @@
 'use server'
 
 import { auth } from '@/lib/auth'
-import { logger } from '@/lib/logger'
+import { withUser } from '@/lib/logger'
 import type { ActionResult } from '@/types/action'
 
 export async function logClientEvent(input: {
@@ -9,11 +9,11 @@ export async function logClientEvent(input: {
   payload?: Record<string, unknown>
 }): Promise<ActionResult> {
   const session = await auth()
-  const userId = session?.user?.id ?? undefined
+  const log = withUser(session?.user?.id)
 
   try {
-    logger.info(input.event, { userId: userId ?? 'anonymous', ...input.payload })
-    await logger.flush()
+    log.info(input.event, input.payload ?? {})
+    await log.flush()
   } catch {
     // 로깅 실패는 사용자 플로우에 영향을 주지 않음
   }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata, Viewport } from 'next'
 import { Analytics } from '@vercel/analytics/next'
 import { SpeedInsights } from '@vercel/speed-insights/next'
 import { GoogleAnalytics } from '@next/third-parties/google'
+import { AxiomWebVitals } from 'next-axiom'
 import { auth } from '@/lib/auth'
 import { SessionProvider } from '@/components/layout/SessionProvider'
 import { ThemeProvider } from '@/components/layout/ThemeProvider'
@@ -55,6 +56,7 @@ export default async function RootLayout({
             <Toaster position="top-center" richColors />
             <Analytics />
             <SpeedInsights />
+            <AxiomWebVitals />
             {process.env.NEXT_PUBLIC_GA_ID && (
               <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GA_ID} />
             )}

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,3 +1,7 @@
 import { Logger } from 'next-axiom'
 
 export const logger = new Logger({ source: 'server' })
+
+export function withUser(userId: string | undefined) {
+  return logger.with({ userId: userId ?? 'anonymous' })
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,8 +1,19 @@
 import NextAuth from 'next-auth'
 import { authConfig } from '@/lib/auth.config'
+import { Logger } from 'next-axiom'
+import type { NextFetchEvent, NextRequest } from 'next/server'
 
-// Edge Runtime 호환 — authConfig만 사용 (Prisma adapter 없음)
-export default NextAuth(authConfig).auth
+const authMiddleware = NextAuth(authConfig).auth as unknown as (
+  req: NextRequest,
+  event: NextFetchEvent
+) => Promise<Response>
+
+export default async function middleware(request: NextRequest, event: NextFetchEvent) {
+  const logger = new Logger({ source: 'middleware' })
+  await logger.middleware(request, { logRequestDetails: ['nextUrl', 'method'] })
+  event.waitUntil(logger.flush())
+  return authMiddleware(request, event)
+}
 
 export const config = {
   matcher: [


### PR DESCRIPTION
## 변경 사항
- `proxy.ts`: withAxiom 래핑 제거 → Logger + logger.middleware() 공식 패턴으로 교체, logRequestDetails 추가
- `logger.ts`: withUser(userId) 헬퍼 추가 — Server Action에서 userId 공통 필드 자동 첨부
- `events.ts`: withUser 패턴으로 교체
- `layout.tsx`: AxiomWebVitals 컴포넌트 추가 (production Web Vitals 자동 수집)
- `CLAUDE.md`: Axiom 로깅 레이어별 사용법 및 규칙 문서화

## 테스트 방법
- [ ] 로컬에서 `pnpm dev` 실행 후 페이지 이동 시 Axiom 대시보드에 `source == "middleware"` 데이터 수집 확인
- [x] `pnpm lint && pnpm format:check && pnpm test --run` 통과 확인