### PR TITLE
fix: 공개 전 보안 취약점 수정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       DATABASE_URL: postgresql://ci:ci@localhost:5432/ci_test
       AUTH_SECRET: test-secret-for-ci-only-not-real-value-32x
       AUTH_URL: http://localhost:3000
-      TEST_SESSION_TOKEN: GJqJOE9YwkHOYhZlD49Dl4s32qTsDKp4pPWwBKLMJb4=
+      TEST_SESSION_TOKEN: ${{ secrets.TEST_SESSION_TOKEN }}
       ENABLE_TEST_API: "1"
 
     steps:

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "clsx": "^2.1.1",
     "framer-motion": "^12.38.0",
     "lucide-react": "^0.577.0",
-    "next": "16.1.6",
+    "next": "16.2.4",
     "next-auth": "5.0.0-beta.30",
     "next-axiom": "^1.10.0",
     "next-themes": "^0.4.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
         version: 1.2.0(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@next/third-parties':
         specifier: ^16.2.4
-        version: 16.2.4(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
+        version: 16.2.4(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       '@prisma/adapter-pg':
         specifier: ^7.4.2
         version: 7.4.2
@@ -25,16 +25,16 @@ importers:
         version: 7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3)
       '@sentry/nextjs':
         specifier: ^10.49.0
-        version: 10.49.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(webpack@5.106.2)
+        version: 10.49.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(webpack@5.106.2)
       '@vercel/analytics':
         specifier: ^2.0.1
-        version: 2.0.1(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
+        version: 2.0.1(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       '@vercel/blob':
         specifier: ^2.3.1
         version: 2.3.1
       '@vercel/speed-insights':
         specifier: ^2.0.0
-        version: 2.0.0(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
+        version: 2.0.0(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -48,14 +48,14 @@ importers:
         specifier: ^0.577.0
         version: 0.577.0(react@19.2.3)
       next:
-        specifier: 16.1.6
-        version: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        specifier: 16.2.4
+        version: 16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       next-auth:
         specifier: 5.0.0-beta.30
-        version: 5.0.0-beta.30(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
+        version: 5.0.0-beta.30(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       next-axiom:
         specifier: ^1.10.0
-        version: 1.10.0(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
+        version: 1.10.0(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -934,56 +934,56 @@ packages:
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
-  '@next/env@16.1.6':
-    resolution: {integrity: sha512-N1ySLuZjnAtN3kFnwhAwPvZah8RJxKasD7x1f8shFqhncnWZn4JMfg37diLNuoHsLAlrDfM3g4mawVdtAG8XLQ==}
+  '@next/env@16.2.4':
+    resolution: {integrity: sha512-dKkkOzOSwFYe5RX6y26fZgkSpVAlIOJKQHIiydQcrWH6y/97+RceSOAdjZ14Qa3zLduVUy0TXcn+EiM6t4rPgw==}
 
   '@next/eslint-plugin-next@16.1.6':
     resolution: {integrity: sha512-/Qq3PTagA6+nYVfryAtQ7/9FEr/6YVyvOtl6rZnGsbReGLf0jZU6gkpr1FuChAQpvV46a78p4cmHOVP8mbfSMQ==}
 
-  '@next/swc-darwin-arm64@16.1.6':
-    resolution: {integrity: sha512-wTzYulosJr/6nFnqGW7FrG3jfUUlEf8UjGA0/pyypJl42ExdVgC6xJgcXQ+V8QFn6niSG2Pb8+MIG1mZr2vczw==}
+  '@next/swc-darwin-arm64@16.2.4':
+    resolution: {integrity: sha512-OXTFFox5EKN1Ym08vfrz+OXxmCcEjT4SFMbNRsWZE99dMqt2Kcusl5MqPXcW232RYkMLQTy0hqgAMEsfEd/l2A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@16.1.6':
-    resolution: {integrity: sha512-BLFPYPDO+MNJsiDWbeVzqvYd4NyuRrEYVB5k2N3JfWncuHAy2IVwMAOlVQDFjj+krkWzhY2apvmekMkfQR0CUQ==}
+  '@next/swc-darwin-x64@16.2.4':
+    resolution: {integrity: sha512-XhpVnUfmYWvD3YrXu55XdcAkQtOnvaI6wtQa8fuF5fGoKoxIUZ0kWPtcOfqJEWngFF/lOS9l3+O9CcownhiQxQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@16.1.6':
-    resolution: {integrity: sha512-OJYkCd5pj/QloBvoEcJ2XiMnlJkRv9idWA/j0ugSuA34gMT6f5b7vOiCQHVRpvStoZUknhl6/UxOXL4OwtdaBw==}
+  '@next/swc-linux-arm64-gnu@16.2.4':
+    resolution: {integrity: sha512-Mx/tjlNA3G8kg14QvuGAJ4xBwPk1tUHq56JxZ8CXnZwz1Etz714soCEzGQQzVMz4bEnGPowzkV6Xrp6wAkEWOQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-arm64-musl@16.1.6':
-    resolution: {integrity: sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ==}
+  '@next/swc-linux-arm64-musl@16.2.4':
+    resolution: {integrity: sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-x64-gnu@16.1.6':
-    resolution: {integrity: sha512-2eEBDkFlMMNQnkTyPBhQOAyn2qMxyG2eE7GPH2WIDGEpEILcBPI/jdSv4t6xupSP+ot/jkfrCShLAa7+ZUPcJQ==}
+  '@next/swc-linux-x64-gnu@16.2.4':
+    resolution: {integrity: sha512-EZOvm1aQWgnI/N/xcWOlnS3RQBk0VtVav5Zo7n4p0A7UKyTDx047k8opDbXgBpHl4CulRqRfbw3QrX2w5UOXMQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-linux-x64-musl@16.1.6':
-    resolution: {integrity: sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg==}
+  '@next/swc-linux-x64-musl@16.2.4':
+    resolution: {integrity: sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-win32-arm64-msvc@16.1.6':
-    resolution: {integrity: sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw==}
+  '@next/swc-win32-arm64-msvc@16.2.4':
+    resolution: {integrity: sha512-3NdJV5OXMSOeJYijX+bjaLge3mJBlh4ybydbT4GFoB/2hAojWHtMhl3CYlYoMrjPuodp0nzFVi4Tj2+WaMg+Ow==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@16.1.6':
-    resolution: {integrity: sha512-NRfO39AIrzBnixKbjuo2YiYhB6o9d8v/ymU9m/Xk8cyVk+k7XylniXkHwjs4s70wedVffc6bQNbufk5v0xEm0A==}
+  '@next/swc-win32-x64-msvc@16.2.4':
+    resolution: {integrity: sha512-kMVGgsqhO5YTYODD9IPGGhA6iprWidQckK3LmPeW08PIFENRmgfb4MjXHO+p//d+ts2rpjvK5gXWzXSMrPl9cw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -3850,8 +3850,8 @@ packages:
       react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
       react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
 
-  next@16.1.6:
-    resolution: {integrity: sha512-hkyRkcu5x/41KoqnROkfTm2pZVbKxvbZRuNvKXLRXxs3VfyO0WhY50TQS40EuKO9SW3rBj/sF3WbVwDACeMZyw==}
+  next@16.2.4:
+    resolution: {integrity: sha512-kPvz56wF5frc+FxlHI5qnklCzbq53HTwORaWBGdT0vNoKh1Aya9XC8aPauH4NJxqtzbWsS5mAbctm4cr+EkQ2Q==}
     engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
@@ -5870,39 +5870,39 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@next/env@16.1.6': {}
+  '@next/env@16.2.4': {}
 
   '@next/eslint-plugin-next@16.1.6':
     dependencies:
       fast-glob: 3.3.1
 
-  '@next/swc-darwin-arm64@16.1.6':
+  '@next/swc-darwin-arm64@16.2.4':
     optional: true
 
-  '@next/swc-darwin-x64@16.1.6':
+  '@next/swc-darwin-x64@16.2.4':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@16.1.6':
+  '@next/swc-linux-arm64-gnu@16.2.4':
     optional: true
 
-  '@next/swc-linux-arm64-musl@16.1.6':
+  '@next/swc-linux-arm64-musl@16.2.4':
     optional: true
 
-  '@next/swc-linux-x64-gnu@16.1.6':
+  '@next/swc-linux-x64-gnu@16.2.4':
     optional: true
 
-  '@next/swc-linux-x64-musl@16.1.6':
+  '@next/swc-linux-x64-musl@16.2.4':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@16.1.6':
+  '@next/swc-win32-arm64-msvc@16.2.4':
     optional: true
 
-  '@next/swc-win32-x64-msvc@16.1.6':
+  '@next/swc-win32-x64-msvc@16.2.4':
     optional: true
 
-  '@next/third-parties@16.2.4(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
+  '@next/third-parties@16.2.4(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
     dependencies:
-      next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
       third-party-capital: 1.0.20
 
@@ -6482,7 +6482,7 @@ snapshots:
 
   '@sentry/core@10.49.0': {}
 
-  '@sentry/nextjs@10.49.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(webpack@5.106.2)':
+  '@sentry/nextjs@10.49.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(webpack@5.106.2)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.40.0
@@ -6495,7 +6495,7 @@ snapshots:
       '@sentry/react': 10.49.0(react@19.2.3)
       '@sentry/vercel-edge': 10.49.0
       '@sentry/webpack-plugin': 5.2.0(webpack@5.106.2)
-      next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       rollup: 4.59.0
       stacktrace-parser: 0.1.11
     transitivePeerDependencies:
@@ -6951,9 +6951,9 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vercel/analytics@2.0.1(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
+  '@vercel/analytics@2.0.1(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
     optionalDependencies:
-      next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
 
   '@vercel/blob@2.3.1':
@@ -6973,9 +6973,9 @@ snapshots:
       '@types/ms': 2.1.0
       ms: 2.1.3
 
-  '@vercel/speed-insights@2.0.0(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
+  '@vercel/speed-insights@2.0.0(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
     optionalDependencies:
-      next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
 
   '@vitejs/plugin-react@5.1.4(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0))':
@@ -8904,16 +8904,16 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next-auth@5.0.0-beta.30(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3):
+  next-auth@5.0.0-beta.30(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3):
     dependencies:
       '@auth/core': 0.41.0
-      next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
 
-  next-axiom@1.10.0(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3):
+  next-axiom@1.10.0(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3):
     dependencies:
       '@vercel/functions': 2.2.13
-      next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
       use-deep-compare: 1.3.0(react@19.2.3)
       whatwg-fetch: 3.6.20
@@ -8925,9 +8925,9 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
-  next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
-      '@next/env': 16.1.6
+      '@next/env': 16.2.4
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.0
       caniuse-lite: 1.0.30001777
@@ -8936,14 +8936,14 @@ snapshots:
       react-dom: 19.2.3(react@19.2.3)
       styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.3)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 16.1.6
-      '@next/swc-darwin-x64': 16.1.6
-      '@next/swc-linux-arm64-gnu': 16.1.6
-      '@next/swc-linux-arm64-musl': 16.1.6
-      '@next/swc-linux-x64-gnu': 16.1.6
-      '@next/swc-linux-x64-musl': 16.1.6
-      '@next/swc-win32-arm64-msvc': 16.1.6
-      '@next/swc-win32-x64-msvc': 16.1.6
+      '@next/swc-darwin-arm64': 16.2.4
+      '@next/swc-darwin-x64': 16.2.4
+      '@next/swc-linux-arm64-gnu': 16.2.4
+      '@next/swc-linux-arm64-musl': 16.2.4
+      '@next/swc-linux-x64-gnu': 16.2.4
+      '@next/swc-linux-x64-musl': 16.2.4
+      '@next/swc-win32-arm64-msvc': 16.2.4
+      '@next/swc-win32-x64-msvc': 16.2.4
       '@opentelemetry/api': 1.9.1
       '@playwright/test': 1.58.2
       sharp: 0.34.5

--- a/src/actions/feedback.ts
+++ b/src/actions/feedback.ts
@@ -6,6 +6,15 @@ import { prisma } from '@/lib/prisma'
 import { submitFeedbackSchema } from '@/lib/schemas/feedback'
 import type { ActionResult } from '@/types/action'
 
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;')
+}
+
 const resend = new Resend(process.env.RESEND_API_KEY)
 
 export async function submitFeedback(input: {
@@ -50,12 +59,12 @@ export async function submitFeedback(input: {
         await resend.emails.send({
           from: 'roco <onboarding@resend.dev>',
           to: emails,
-          subject: `[roco] 새로운 의견이 도착했어요${category ? ` — ${category}` : ''}`,
+          subject: `[roco] 새로운 의견이 도착했어요${category ? ` — ${escapeHtml(category)}` : ''}`,
           html: [
-            `<p><strong>보낸 사람</strong>: ${session.user.name ?? '(이름 없음)'} (${session.user.email ?? '이메일 없음'})</p>`,
-            category ? `<p><strong>카테고리</strong>: ${category}</p>` : '',
+            `<p><strong>보낸 사람</strong>: ${escapeHtml(session.user.name ?? '(이름 없음)')} (${escapeHtml(session.user.email ?? '이메일 없음')})</p>`,
+            category ? `<p><strong>카테고리</strong>: ${escapeHtml(category)}</p>` : '',
             `<p><strong>내용</strong>:</p>`,
-            `<blockquote style="border-left:3px solid #ccc;margin:0;padding:0 1em;color:#555">${content.replace(/\n/g, '<br/>')}</blockquote>`,
+            `<blockquote style="border-left:3px solid #ccc;margin:0;padding:0 1em;color:#555">${escapeHtml(content).replace(/\n/g, '<br/>')}</blockquote>`,
           ]
             .filter(Boolean)
             .join('\n'),

--- a/src/actions/feedback.ts
+++ b/src/actions/feedback.ts
@@ -59,7 +59,7 @@ export async function submitFeedback(input: {
         await resend.emails.send({
           from: 'roco <onboarding@resend.dev>',
           to: emails,
-          subject: `[roco] 새로운 의견이 도착했어요${category ? ` — ${escapeHtml(category)}` : ''}`,
+          subject: `[roco] 새로운 의견이 도착했어요${category ? ` — ${category.replace(/[\r\n]/g, '')}` : ''}`,
           html: [
             `<p><strong>보낸 사람</strong>: ${escapeHtml(session.user.name ?? '(이름 없음)')} (${escapeHtml(session.user.email ?? '이메일 없음')})</p>`,
             category ? `<p><strong>카테고리</strong>: ${escapeHtml(category)}</p>` : '',

--- a/src/actions/upload.test.ts
+++ b/src/actions/upload.test.ts
@@ -36,6 +36,23 @@ function makeFormData(file: File): FormData {
   return fd
 }
 
+// MIME 타입별 매직 바이트 (12바이트 고정)
+const MAGIC: Record<string, number[]> = {
+  'image/jpeg': [0xff, 0xd8, 0xff, 0xe0, 0, 0, 0, 0, 0, 0, 0, 0],
+  'image/png': [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0, 0, 0, 0],
+  // RIFF(4) + size(4) + WEBP(4)
+  'image/webp': [0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50],
+}
+
+/** 올바른 매직 바이트가 포함된 이미지 파일을 생성한다 */
+function makeImageFile(name: string, type: string, sizeBytes: number): File {
+  const buf = new Uint8Array(Math.max(sizeBytes, 12))
+  const magic = MAGIC[type]
+  if (magic) magic.forEach((b, i) => (buf[i] = b))
+  return new File([buf], name, { type })
+}
+
+/** 매직 바이트 없이 빈 버퍼로 파일을 생성한다 (유효하지 않은 파일 테스트용) */
 function makeFile(name: string, type: string, sizeBytes: number): File {
   const buf = new Uint8Array(sizeBytes)
   return new File([buf], name, { type })
@@ -86,7 +103,7 @@ describe('uploadAvatar', () => {
     vi.mocked(put).mockResolvedValue({ url: 'https://blob.vercel.test/avatar.jpg' } as never)
     vi.mocked(prisma.user.update).mockResolvedValue({} as never)
 
-    const fd = makeFormData(makeFile('photo.jpg', 'image/jpeg', 1024))
+    const fd = makeFormData(makeImageFile('photo.jpg', 'image/jpeg', 1024))
     const result = await uploadAvatar(fd)
 
     expect(put).toHaveBeenCalledOnce()
@@ -102,7 +119,7 @@ describe('uploadAvatar', () => {
     vi.mocked(put).mockResolvedValue({ url: 'https://blob.vercel.test/avatar.png' } as never)
     vi.mocked(prisma.user.update).mockResolvedValue({} as never)
 
-    const fd = makeFormData(makeFile('photo.png', 'image/png', 512))
+    const fd = makeFormData(makeImageFile('photo.png', 'image/png', 512))
     const result = await uploadAvatar(fd)
     expect(result).toMatchObject({ success: true })
   })
@@ -112,9 +129,17 @@ describe('uploadAvatar', () => {
     vi.mocked(put).mockResolvedValue({ url: 'https://blob.vercel.test/avatar.webp' } as never)
     vi.mocked(prisma.user.update).mockResolvedValue({} as never)
 
-    const fd = makeFormData(makeFile('photo.webp', 'image/webp', 512))
+    const fd = makeFormData(makeImageFile('photo.webp', 'image/webp', 512))
     const result = await uploadAvatar(fd)
     expect(result).toMatchObject({ success: true })
+  })
+
+  // 매직 바이트 불일치 (MIME 스푸핑)
+  it('MIME 타입은 image/jpeg이지만 실제 파일이 이미지가 아니면 VALIDATION을 반환한다', async () => {
+    vi.mocked(auth).mockResolvedValue({ user: { id: 'user-1' } } as never)
+    const fd = makeFormData(makeFile('malicious.jpg', 'image/jpeg', 1024))
+    const result = await uploadAvatar(fd)
+    expect(result).toEqual({ success: false, error: expect.any(String), code: 'VALIDATION' })
   })
 
   // 기존 Blob 이미지 삭제
@@ -125,7 +150,7 @@ describe('uploadAvatar', () => {
     vi.mocked(put).mockResolvedValue({ url: 'https://blob.vercel.test/new.jpg' } as never)
     vi.mocked(prisma.user.update).mockResolvedValue({} as never)
 
-    const fd = makeFormData(makeFile('photo.jpg', 'image/jpeg', 1024))
+    const fd = makeFormData(makeImageFile('photo.jpg', 'image/jpeg', 1024))
     await uploadAvatar(fd)
 
     expect(del).toHaveBeenCalledWith('https://abc.public.blob.vercel-storage.com/old.jpg')
@@ -138,7 +163,7 @@ describe('uploadAvatar', () => {
     vi.mocked(put).mockResolvedValue({ url: 'https://blob.vercel.test/new.jpg' } as never)
     vi.mocked(prisma.user.update).mockResolvedValue({} as never)
 
-    const fd = makeFormData(makeFile('photo.jpg', 'image/jpeg', 1024))
+    const fd = makeFormData(makeImageFile('photo.jpg', 'image/jpeg', 1024))
     await uploadAvatar(fd)
 
     expect(del).not.toHaveBeenCalled()
@@ -149,7 +174,7 @@ describe('uploadAvatar', () => {
     vi.mocked(auth).mockResolvedValue({ user: { id: 'user-1' } } as never)
     vi.mocked(put).mockRejectedValue(new Error('network error'))
 
-    const fd = makeFormData(makeFile('photo.jpg', 'image/jpeg', 1024))
+    const fd = makeFormData(makeImageFile('photo.jpg', 'image/jpeg', 1024))
     const result = await uploadAvatar(fd)
 
     expect(result).toEqual({ success: false, error: expect.any(String), code: 'UPLOAD_ERROR' })

--- a/src/actions/upload.test.ts
+++ b/src/actions/upload.test.ts
@@ -142,6 +142,18 @@ describe('uploadAvatar', () => {
     expect(result).toEqual({ success: false, error: expect.any(String), code: 'VALIDATION' })
   })
 
+  it('PNG 매직 바이트인데 image/jpeg로 선언하면 VALIDATION을 반환한다', async () => {
+    vi.mocked(auth).mockResolvedValue({ user: { id: 'user-1' } } as never)
+    // PNG 매직 바이트 + image/jpeg 선언 → 불일치
+    const fd = makeFormData(makeImageFile('spoof.jpg', 'image/png', 512))
+    const file = fd.get('file') as File
+    // file.type을 image/jpeg로 바꿔 만든 새 File
+    const spoofed = new File([file], 'spoof.jpg', { type: 'image/jpeg' })
+    const fd2 = makeFormData(spoofed)
+    const result = await uploadAvatar(fd2)
+    expect(result).toEqual({ success: false, error: expect.any(String), code: 'VALIDATION' })
+  })
+
   // 기존 Blob 이미지 삭제
   it('기존 이미지가 Vercel Blob URL이면 del()을 호출한다', async () => {
     vi.mocked(auth).mockResolvedValue({

--- a/src/actions/upload.ts
+++ b/src/actions/upload.ts
@@ -137,7 +137,7 @@ export async function uploadAdminImage(
   }
 
   const detectedMime = await detectMimeFromBytes(file)
-  if (!detectedMime || !ALLOWED_TYPES.includes(detectedMime)) {
+  if (!detectedMime || !ALLOWED_TYPES.includes(detectedMime) || detectedMime !== file.type) {
     return {
       success: false,
       error: '실제 이미지 파일이 아닙니다',
@@ -178,7 +178,7 @@ export async function uploadAvatar(formData: FormData): Promise<ActionResult<{ u
   }
 
   const detectedMime = await detectMimeFromBytes(file)
-  if (!detectedMime || !ALLOWED_TYPES.includes(detectedMime)) {
+  if (!detectedMime || !ALLOWED_TYPES.includes(detectedMime) || detectedMime !== file.type) {
     return {
       success: false,
       error: '실제 이미지 파일이 아닙니다',

--- a/src/actions/upload.ts
+++ b/src/actions/upload.ts
@@ -13,11 +13,41 @@ const BLOB_HOST = 'blob.vercel-storage.com'
 const LOCAL_UPLOADS_PATH = '/uploads/avatars'
 const LOCAL_ADMIN_UPLOADS_PATH = '/uploads/admin'
 
+// file.type은 클라이언트가 조작 가능하므로 서버에서 안전한 확장자로 변환
+const MIME_TO_EXT: Record<string, string> = {
+  'image/jpeg': 'jpg',
+  'image/png': 'png',
+  'image/webp': 'webp',
+}
+
+// 각 MIME 타입의 파일 시그니처 (매직 바이트)
+const MAGIC_SIGNATURES: Array<{ mime: string; bytes: number[]; offset?: number }> = [
+  { mime: 'image/jpeg', bytes: [0xff, 0xd8, 0xff] },
+  { mime: 'image/png', bytes: [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a] },
+  // WebP: "RIFF" at 0, "WEBP" at 8
+  { mime: 'image/webp', bytes: [0x52, 0x49, 0x46, 0x46] },
+]
+
+async function detectMimeFromBytes(file: File): Promise<string | null> {
+  const buffer = await file.slice(0, 12).arrayBuffer()
+  const bytes = new Uint8Array(buffer)
+
+  for (const sig of MAGIC_SIGNATURES) {
+    if (sig.bytes.every((b, i) => bytes[i] === b)) {
+      if (sig.mime === 'image/webp') {
+        const webp = [0x57, 0x45, 0x42, 0x50]
+        if (!webp.every((b, i) => bytes[8 + i] === b)) continue
+      }
+      return sig.mime
+    }
+  }
+  return null
+}
+
 /** 로컬 dev: public/uploads/avatars/ 에 저장, 프로덕션: Vercel Blob */
-async function putFile(userId: string, file: File): Promise<string> {
+async function putFile(userId: string, file: File, ext: string): Promise<string> {
   // BLOB_READ_WRITE_TOKEN이 없을 때만 로컬 파일시스템 사용 (호출 시점에 평가)
   const useLocalFS = !process.env.BLOB_READ_WRITE_TOKEN
-  const ext = file.type.split('/')[1]
   // 업로드마다 고유 파일명 → 브라우저 캐시 자동 무효화
   const filename = `${userId}_${Date.now()}.${ext}`
 
@@ -38,9 +68,8 @@ async function putFile(userId: string, file: File): Promise<string> {
 }
 
 /** 로컬 dev: public/uploads/admin/ 에 저장, 프로덕션: Vercel Blob admin/ */
-async function putAdminFile(folder: string, file: File): Promise<string> {
+async function putAdminFile(folder: string, file: File, ext: string): Promise<string> {
   const useLocalFS = !process.env.BLOB_READ_WRITE_TOKEN
-  const ext = file.type.split('/')[1]
   const filename = `${Date.now()}.${ext}`
 
   if (useLocalFS) {
@@ -107,8 +136,18 @@ export async function uploadAdminImage(
     return { success: false, error: '파일 크기는 4MB 이하여야 합니다', code: 'VALIDATION' }
   }
 
+  const detectedMime = await detectMimeFromBytes(file)
+  if (!detectedMime || !ALLOWED_TYPES.includes(detectedMime)) {
+    return {
+      success: false,
+      error: '실제 이미지 파일이 아닙니다',
+      code: 'VALIDATION',
+    }
+  }
+  const ext = MIME_TO_EXT[detectedMime]
+
   try {
-    const url = await putAdminFile(folder, file)
+    const url = await putAdminFile(folder, file, ext)
     return { success: true, data: { url } }
   } catch {
     return { success: false, error: '업로드 중 오류가 발생했습니다', code: 'UPLOAD_ERROR' }
@@ -138,9 +177,19 @@ export async function uploadAvatar(formData: FormData): Promise<ActionResult<{ u
     return { success: false, error: '파일 크기는 4MB 이하여야 합니다', code: 'VALIDATION' }
   }
 
+  const detectedMime = await detectMimeFromBytes(file)
+  if (!detectedMime || !ALLOWED_TYPES.includes(detectedMime)) {
+    return {
+      success: false,
+      error: '실제 이미지 파일이 아닙니다',
+      code: 'VALIDATION',
+    }
+  }
+  const ext = MIME_TO_EXT[detectedMime]
+
   let url: string
   try {
-    url = await putFile(session.user.id, file)
+    url = await putFile(session.user.id, file, ext)
   } catch {
     return { success: false, error: '업로드 중 오류가 발생했습니다', code: 'UPLOAD_ERROR' }
   }


### PR DESCRIPTION
## 변경 사항
- Next.js 16.1.6 → 16.2.4 업그레이드 (DoS 취약점 GHSA-q4gf-8mx6-v5v3 패치)
- CI 워크플로우 `TEST_SESSION_TOKEN` 하드코딩 → GitHub Secret 이전
- 피드백 이메일 HTML Injection 방지 (`escapeHtml()` 적용, subject는 개행 문자만 제거)
- 파일 업로드 MIME 타입 스푸핑 방지 (매직 바이트 검증 + 선언 MIME 불일치 시 거부)

## 테스트 방법
- [ ] 아바타 업로드: jpeg/png/webp 정상 이미지 업로드 성공 확인
- [ ] 아바타 업로드: 이미지가 아닌 파일(txt, pdf) 업로드 시 거부 확인
- [ ] 아바타 업로드: PNG 파일을 image/jpeg로 위장해 업로드 시 거부 확인
- [ ] 피드백 제출: 특수문자(`<script>`, `&`) 포함 내용 제출 후 수신 이메일에 엔티티 없이 올바르게 표시 확인