### PR TITLE
fix: 서비스 설명 문구에서 '스페셜티' 제거

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -20,9 +20,7 @@ export default async function LoginPage({ searchParams }: Props) {
       {/* 로고 + 슬로건 */}
       <div className="space-y-2 text-center">
         <h1 className="text-2xl font-bold text-text-primary">roco</h1>
-        <p className="text-sm text-text-secondary">
-          취향에 맞는 스페셜티 커피 로스터리를 찾아보세요
-        </p>
+        <p className="text-sm text-text-secondary">취향에 맞는 커피 로스터리를 찾아보세요</p>
       </div>
 
       {error && <ErrorAlert error={error} provider={provider} />}

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -3,9 +3,9 @@ import { Suspense } from 'react'
 import { auth } from '@/lib/auth'
 
 export const metadata: Metadata = {
-  title: '취향에 맞는 스페셜티 커피 로스터리 추천',
+  title: '취향에 맞는 커피 로스터리 추천',
   description:
-    '취향 설문 한 번으로 나만의 스페셜티 커피 로스터리를 추천받으세요. 협업 필터링 기반의 개인화 추천 서비스.',
+    '취향 설문 한 번으로 나만의 커피 로스터리를 추천받으세요. 협업 필터링 기반의 개인화 추천 서비스.',
 }
 import { getRecommendations } from '@/lib/recommender'
 import { getFeaturedSections, getPopularRoasteries } from '@/lib/queries/recommendation'

--- a/src/app/(main)/roasteries/page.tsx
+++ b/src/app/(main)/roasteries/page.tsx
@@ -4,7 +4,7 @@ import { auth } from '@/lib/auth'
 
 export const metadata: Metadata = {
   title: '로스터리',
-  description: '한국 스페셜티 커피 로스터리를 취향에 맞게 찾아보세요.',
+  description: '한국 커피 로스터리를 취향에 맞게 찾아보세요.',
   alternates: {
     canonical: '/roasteries',
   },

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,7 +19,7 @@ export const metadata: Metadata = {
     default: 'roco',
     template: '%s | roco',
   },
-  description: '취향에 맞는 스페셜티 커피 로스터리 추천 서비스',
+  description: '취향에 맞는 커피 로스터리 추천 서비스',
   openGraph: {
     siteName: 'roco',
     locale: 'ko_KR',

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,7 +24,9 @@ export const metadata: Metadata = {
     siteName: 'roco',
     locale: 'ko_KR',
     type: 'website',
-    images: [{ url: '/opengraph-image', width: 1200, height: 630 }],
+    images: [
+      { url: '/opengraph-image', width: 1200, height: 630, alt: 'roco — 커피 로스터리 추천' },
+    ],
   },
   twitter: {
     card: 'summary_large_image',

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -2,7 +2,7 @@ import { readFile } from 'fs/promises'
 import { join } from 'path'
 import { ImageResponse } from 'next/og'
 
-export const alt = 'roco — 스페셜티 커피 로스터리 추천'
+export const alt = 'roco — 커피 로스터리 추천'
 export const size = { width: 1200, height: 630 }
 export const contentType = 'image/png'
 


### PR DESCRIPTION
## 변경 사항
- 서비스 설명 전반에서 '스페셜티 커피 로스터리' → '커피 로스터리'로 통일
- layout.tsx: 기본 메타 description 수정
- (main)/page.tsx: 홈 페이지 title/description 수정
- (auth)/login/page.tsx: 로그인 페이지 슬로건 수정
- (main)/roasteries/page.tsx: 로스터리 목록 페이지 description 수정
- opengraph-image.tsx: SNS 공유 이미지 alt 텍스트 수정

## 테스트 방법
- [x] 홈 페이지 브라우저 탭 title이 '취향에 맞는 커피 로스터리 추천'으로 표시되는지 확인
- [x] 로그인 페이지 슬로건이 '취향에 맞는 커피 로스터리를 찾아보세요'로 표시되는지 확인
- [x] SNS 공유 시 OG 이미지 alt가 'roco — 커피 로스터리 추천'으로 적용되는지 확인