### PR TITLE
fix: 인기 섹션에서 userId 필터 제거

### DIFF
--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -16,7 +16,7 @@ async function HomeFeed({ userId }: { userId?: string }) {
   const [result, sections, popularItems] = await Promise.all([
     getRecommendations(userId),
     getFeaturedSections(),
-    getPopularRoasteries(userId),
+    getPopularRoasteries(),
   ])
 
   return (


### PR DESCRIPTION
## 변경 사항
- `getPopularRoasteries()` 호출 시 `userId` 인자 제거
- 인기 섹션이 모든 유저에게 동일한 전체 기준 순위를 표시하도록 수정
- CF 폴백 추천(`getPopularFallback`)은 여전히 `userId` 필터 유지 (발견용 추천이므로 이미 평가한 것 제외가 맞음)

## 배경
기존 코드에서 `getPopularRoasteries(userId)`로 호출하면서 이미 평가한 로스터리가 인기 섹션에서 제외되고 있었음.
"실시간 인기 로스터리"는 객관적 순위이므로 유저 맞춤 필터가 적용되면 안 됨.

## 테스트 방법
- [ ] 홈 피드의 "실시간 인기 로스터리" 섹션에서 내가 이미 평가한 로스터리도 정상 표시되는지 확인
- [ ] 평점 상위 로스터리 순서가 모든 유저에게 동일하게 보이는지 확인