### PR TITLE
feat: 로스터리 지도 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,5 +48,8 @@ next-env.d.ts
 # claude code
 .claude/
 
+# 지오코딩 작업 파일 (DB 시딩 완료 후 불필요)
+roastery-geocode*.json
+
 
 /tmp

--- a/next.config.ts
+++ b/next.config.ts
@@ -35,7 +35,7 @@ const securityHeaders = [
       // 미지정 리소스는 동일 출처만 허용
       "default-src 'self'",
       // Next.js App Router는 인라인 스크립트·eval 필요 (hydration, turbopack)
-      "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://oapi.map.naver.com https://va.vercel-scripts.com",
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://oapi.map.naver.com http://oapi.map.naver.com http://nrbe.map.naver.net https://va.vercel-scripts.com",
       // Tailwind CSS 등 CSS-in-JS는 인라인 스타일 필요
       "style-src 'self' 'unsafe-inline'",
       // 소셜 로그인 프로필 이미지 및 Vercel Blob 이미지 허용
@@ -46,7 +46,7 @@ const securityHeaders = [
         'https://phinf.pstatic.net https://ssl.pstatic.net',
         'https://*.public.blob.vercel-storage.com',
         // Naver Maps 타일/리소스 이미지
-        'https://map.pstatic.net https://*.map.naver.com http://static.naver.net https://static.naver.net',
+        'https://map.pstatic.net https://*.pstatic.net https://*.map.naver.com http://static.naver.net https://static.naver.net',
       ].join(' '),
       // 웹폰트는 동일 출처만
       "font-src 'self'",

--- a/next.config.ts
+++ b/next.config.ts
@@ -46,7 +46,7 @@ const securityHeaders = [
         'https://phinf.pstatic.net https://ssl.pstatic.net',
         'https://*.public.blob.vercel-storage.com',
         // Naver Maps 타일/리소스 이미지
-        'https://map.pstatic.net https://*.pstatic.net https://*.map.naver.com http://static.naver.net https://static.naver.net',
+        'https://map.pstatic.net https://*.pstatic.net https://*.map.naver.com http://static.naver.net https://static.naver.net http://*.map.naver.net https://*.map.naver.net',
       ].join(' '),
       // 웹폰트는 동일 출처만
       "font-src 'self'",

--- a/next.config.ts
+++ b/next.config.ts
@@ -51,7 +51,7 @@ const securityHeaders = [
       // 웹폰트는 동일 출처만
       "font-src 'self'",
       // Sentry 에러 전송, Axiom 로그 전송 허용
-      "connect-src 'self' https://*.ingest.sentry.io https://*.ingest.us.sentry.io https://api.axiom.co https://*.google-analytics.com https://analytics.google.com https://www.googletagmanager.com https://vitals.vercel-insights.com",
+      "connect-src 'self' https://*.ingest.sentry.io https://*.ingest.us.sentry.io https://api.axiom.co https://*.google-analytics.com https://analytics.google.com https://www.googletagmanager.com https://vitals.vercel-insights.com https://*.navercorp.com https://oapi.map.naver.com",
       // iframe으로 이 페이지를 삽입하는 것 자체를 차단 (X-Frame-Options 보완)
       "frame-ancestors 'none'",
       // <base> 태그 출처 제한 (base href 하이재킹 방지)

--- a/next.config.ts
+++ b/next.config.ts
@@ -35,7 +35,7 @@ const securityHeaders = [
       // 미지정 리소스는 동일 출처만 허용
       "default-src 'self'",
       // Next.js App Router는 인라인 스크립트·eval 필요 (hydration, turbopack)
-      "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://oapi.map.naver.com",
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://oapi.map.naver.com https://va.vercel-scripts.com",
       // Tailwind CSS 등 CSS-in-JS는 인라인 스타일 필요
       "style-src 'self' 'unsafe-inline'",
       // 소셜 로그인 프로필 이미지 및 Vercel Blob 이미지 허용

--- a/next.config.ts
+++ b/next.config.ts
@@ -51,7 +51,7 @@ const securityHeaders = [
       // 웹폰트는 동일 출처만
       "font-src 'self'",
       // Sentry 에러 전송, Axiom 로그 전송 허용
-      "connect-src 'self' https://*.ingest.sentry.io https://*.ingest.us.sentry.io https://api.axiom.co https://*.google-analytics.com https://analytics.google.com https://www.googletagmanager.com https://vitals.vercel-insights.com https://*.navercorp.com https://oapi.map.naver.com",
+      "connect-src 'self' https://*.ingest.sentry.io https://*.ingest.us.sentry.io https://api.axiom.co https://*.google-analytics.com https://analytics.google.com https://www.googletagmanager.com https://vitals.vercel-insights.com https://*.navercorp.com https://oapi.map.naver.com http://oapi.map.naver.com",
       // iframe으로 이 페이지를 삽입하는 것 자체를 차단 (X-Frame-Options 보완)
       "frame-ancestors 'none'",
       // <base> 태그 출처 제한 (base href 하이재킹 방지)

--- a/next.config.ts
+++ b/next.config.ts
@@ -45,8 +45,8 @@ const securityHeaders = [
         'https://k.kakaocdn.net http://k.kakaocdn.net https://img1.kakaocdn.net http://img1.kakaocdn.net',
         'https://phinf.pstatic.net https://ssl.pstatic.net',
         'https://*.public.blob.vercel-storage.com',
-        // Naver Maps 타일 이미지
-        'https://map.pstatic.net https://*.map.naver.com',
+        // Naver Maps 타일/리소스 이미지
+        'https://map.pstatic.net https://*.map.naver.com http://static.naver.net https://static.naver.net',
       ].join(' '),
       // 웹폰트는 동일 출처만
       "font-src 'self'",

--- a/next.config.ts
+++ b/next.config.ts
@@ -35,7 +35,7 @@ const securityHeaders = [
       // 미지정 리소스는 동일 출처만 허용
       "default-src 'self'",
       // Next.js App Router는 인라인 스크립트·eval 필요 (hydration, turbopack)
-      "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com",
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://oapi.map.naver.com",
       // Tailwind CSS 등 CSS-in-JS는 인라인 스타일 필요
       "style-src 'self' 'unsafe-inline'",
       // 소셜 로그인 프로필 이미지 및 Vercel Blob 이미지 허용
@@ -45,6 +45,8 @@ const securityHeaders = [
         'https://k.kakaocdn.net http://k.kakaocdn.net https://img1.kakaocdn.net http://img1.kakaocdn.net',
         'https://phinf.pstatic.net https://ssl.pstatic.net',
         'https://*.public.blob.vercel-storage.com',
+        // Naver Maps 타일 이미지
+        'https://map.pstatic.net https://*.map.naver.com',
       ].join(' '),
       // 웹폰트는 동일 출처만
       "font-src 'self'",

--- a/next.config.ts
+++ b/next.config.ts
@@ -23,9 +23,9 @@ const securityHeaders = [
   // 미적용 시: URL에 포함된 사용자 식별 정보(쿼리스트링 등)가 외부로 유출 가능
   { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
 
-  // 브라우저 기능 접근 제한: 카메라·마이크·위치 정보 API 사용 차단
+  // 브라우저 기능 접근 제한: 카메라·마이크 차단, 위치는 자사 페이지만 허용 (GPS 기능)
   // 미적용 시: 공급망 공격(악성 npm 패키지 등)으로 사용자 기기 접근 가능
-  { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
+  { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=(self)' },
 
   // CSP: 허용된 리소스 출처만 로드·실행 가능하도록 화이트리스트 지정
   // 미적용 시: XSS 공격 성공 시 악성 스크립트가 자유롭게 실행되고 데이터 외부 전송 가능
@@ -35,21 +35,24 @@ const securityHeaders = [
       // 미지정 리소스는 동일 출처만 허용
       "default-src 'self'",
       // Next.js App Router는 인라인 스크립트·eval 필요 (hydration, turbopack)
-      "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com",
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://oapi.map.naver.com http://oapi.map.naver.com http://nrbe.map.naver.net https://va.vercel-scripts.com",
       // Tailwind CSS 등 CSS-in-JS는 인라인 스타일 필요
       "style-src 'self' 'unsafe-inline'",
       // 소셜 로그인 프로필 이미지 및 Vercel Blob 이미지 허용
       [
         "img-src 'self' data: blob:",
+        'https://www.googletagmanager.com',
         'https://lh3.googleusercontent.com',
         'https://k.kakaocdn.net http://k.kakaocdn.net https://img1.kakaocdn.net http://img1.kakaocdn.net',
         'https://phinf.pstatic.net https://ssl.pstatic.net',
         'https://*.public.blob.vercel-storage.com',
+        // Naver Maps 타일/리소스 이미지
+        'https://map.pstatic.net https://*.pstatic.net https://*.map.naver.com http://static.naver.net https://static.naver.net http://*.map.naver.net https://*.map.naver.net',
       ].join(' '),
       // 웹폰트는 동일 출처만
       "font-src 'self'",
       // Sentry 에러 전송, Axiom 로그 전송 허용
-      "connect-src 'self' https://*.ingest.sentry.io https://*.ingest.us.sentry.io https://api.axiom.co https://*.google-analytics.com https://analytics.google.com https://www.googletagmanager.com https://vitals.vercel-insights.com",
+      "connect-src 'self' https://*.ingest.sentry.io https://*.ingest.us.sentry.io https://api.axiom.co https://*.google-analytics.com https://analytics.google.com https://www.googletagmanager.com https://vitals.vercel-insights.com https://*.navercorp.com https://oapi.map.naver.com http://oapi.map.naver.com",
       // iframe으로 이 페이지를 삽입하는 것 자체를 차단 (X-Frame-Options 보완)
       "frame-ancestors 'none'",
       // <base> 태그 출처 제한 (base href 하이재킹 방지)

--- a/prisma/migrations/20260506055839_add_roastery_location/migration.sql
+++ b/prisma/migrations/20260506055839_add_roastery_location/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "RoasteryLocation" (
+    "id" TEXT NOT NULL,
+    "roasteryId" TEXT NOT NULL,
+    "address" TEXT NOT NULL,
+    "lat" DOUBLE PRECISION,
+    "lng" DOUBLE PRECISION,
+    "isPrimary" BOOLEAN NOT NULL DEFAULT false,
+
+    CONSTRAINT "RoasteryLocation_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "RoasteryLocation_roasteryId_idx" ON "RoasteryLocation"("roasteryId");
+
+-- AddForeignKey
+ALTER TABLE "RoasteryLocation" ADD CONSTRAINT "RoasteryLocation_roasteryId_fkey" FOREIGN KEY ("roasteryId") REFERENCES "Roastery"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -61,6 +61,7 @@ model Roastery {
   beans                 Bean[]
   bookmarks             Bookmark[]
   featuredIn            FeaturedSectionRoastery[]
+  locations             RoasteryLocation[]
   ratings               Rating[]
   recommendations       Recommendation[]
   channels              RoasteryChannel[]
@@ -70,6 +71,18 @@ model Roastery {
   @@index([decaf])
   @@index([name])
   @@index([deletedAt])
+}
+
+model RoasteryLocation {
+  id         String   @id @default(cuid())
+  roasteryId String
+  address    String
+  lat        Float?
+  lng        Float?
+  isPrimary  Boolean  @default(false)
+  roastery   Roastery @relation(fields: [roasteryId], references: [id], onDelete: Cascade)
+
+  @@index([roasteryId])
 }
 
 model Tag {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -13,7 +13,7 @@ type PriceMap = Partial<Record<ChannelKey, string>>
 
 interface SeedEntry {
   n: string // name
-  r: string // region
+  r: string | string[] // region (single or multiple)
   a?: string // address
   un?: number // isOnboardingCandidate (0|1)
   ns?: string // naver smartstore URL
@@ -29,7 +29,7 @@ interface SeedEntry {
 const SEED_DATA: SeedEntry[] = [
   {
     n: '프릳츠 커피 컴퍼니',
-    r: '서울',
+    r: ['서울', '제주'],
     a: '마포구 도화동 179-9',
     un: 0,
     w: 'https://fritz.co.kr',
@@ -70,7 +70,7 @@ const SEED_DATA: SeedEntry[] = [
   },
   {
     n: '빈브라더스',
-    r: '서울',
+    r: ['서울', '경기'],
     a: '마포구 토정로 35-1',
     un: 1,
     ns: 'https://smartstore.naver.com/beanbrothers',
@@ -99,7 +99,7 @@ const SEED_DATA: SeedEntry[] = [
   },
   {
     n: '나무사이로',
-    r: '서울',
+    r: ['서울', '경기'],
     a: '종로구 사직로8길 21',
     un: 0,
     w: 'https://namusairo.com',
@@ -113,7 +113,7 @@ const SEED_DATA: SeedEntry[] = [
   },
   {
     n: '알레그리아',
-    r: '경기',
+    r: ['경기', '서울'],
     a: '성남시 분당구 판교역로 230',
     un: 0,
     ns: 'https://smartstore.naver.com/alegriacoffee',
@@ -141,7 +141,7 @@ const SEED_DATA: SeedEntry[] = [
   },
   {
     n: '펠트커피',
-    r: '서울',
+    r: ['서울', '경기'],
     a: '마포구 서강로11길 23',
     un: 1,
     ns: 'https://smartstore.naver.com/feltcoffee',
@@ -222,7 +222,7 @@ const SEED_DATA: SeedEntry[] = [
   },
   {
     n: '억셉트 커피',
-    r: '경기',
+    r: ['서울', '경기'],
     a: '군포시 당정로 28번길 17',
     un: 0,
     ns: 'https://smartstore.naver.com/acceptcoffee',
@@ -305,7 +305,7 @@ const SEED_DATA: SeedEntry[] = [
   },
   {
     n: '필아웃',
-    r: '경기',
+    r: ['경기', '서울'],
     a: '성남시 분당구 벌말로 30번길 12',
     un: 0,
     ns: 'https://smartstore.naver.com/filloutcoffee',
@@ -337,7 +337,7 @@ const SEED_DATA: SeedEntry[] = [
   },
   {
     n: '인크 커피',
-    r: '서울',
+    r: ['서울', '경기'],
     a: '금천구 가산디지털2로 127-20',
     un: 0,
     ns: 'https://smartstore.naver.com/inccoffee',
@@ -507,7 +507,7 @@ const SEED_DATA: SeedEntry[] = [
   },
   {
     n: '유동 커피',
-    r: '제주',
+    r: ['제주', '부산', '경북'],
     a: '제주 서귀포 태평로 406',
     un: 0,
     ns: 'https://smartstore.naver.com/youdongcoffeeshop',
@@ -532,7 +532,7 @@ const SEED_DATA: SeedEntry[] = [
   },
   {
     n: '클라리멘토',
-    r: '경기',
+    r: ['서울', '경기'],
     a: '고양 덕양구 권율대로 420',
     un: 1,
     ns: 'https://smartstore.naver.com/clarimento',
@@ -579,7 +579,7 @@ const SEED_DATA: SeedEntry[] = [
   },
   {
     n: '블랙업커피',
-    r: '부산',
+    r: ['부산', '경남'],
     a: '부산진구 서전로10번길 41',
     un: 1,
     ns: 'https://smartstore.naver.com/blackup_coffee',
@@ -635,7 +635,7 @@ const SEED_DATA: SeedEntry[] = [
   },
   {
     n: '커넥츠 커피',
-    r: '서울',
+    r: ['서울', '경기'],
     a: '마포구 성지길 60',
     un: 1,
     ns: 'https://smartstore.naver.com/connectscoffee',
@@ -728,7 +728,7 @@ const SEED_DATA: SeedEntry[] = [
   },
   {
     n: '비브레이브',
-    r: '제주',
+    r: ['제주', '충남'],
     a: '제주 서귀포 서호중로 85',
     un: 1,
     ns: 'https://smartstore.naver.com/bebravejeju',
@@ -806,7 +806,7 @@ const SEED_DATA: SeedEntry[] = [
   },
   {
     n: '해월커피',
-    r: '경기',
+    r: ['인천', '경기'],
     a: '경기 광주 남구로길 9',
     un: 1,
     ns: 'https://smartstore.naver.com/haewolcoffee',
@@ -917,7 +917,7 @@ const SEED_DATA: SeedEntry[] = [
   },
   {
     n: '커피명가',
-    r: '대구',
+    r: ['경북', '서울'],
     a: '경북 경산시 임당로 40',
     un: 0,
     ns: 'https://smartstore.naver.com/coffeemyungga',
@@ -929,7 +929,7 @@ const SEED_DATA: SeedEntry[] = [
   },
   {
     n: '1LL 커피',
-    r: '대구',
+    r: ['대구', '서울', '경기', '경북'],
     a: '수성구 달구벌대로496길 21',
     un: 0,
     ns: 'https://smartstore.naver.com/1llcoffee',
@@ -1098,7 +1098,7 @@ async function main() {
 
     // 지역 + 특성 태그 처리
     const tagIds = await upsertTags(
-      [entry.r],
+      Array.isArray(entry.r) ? entry.r : [entry.r],
       (entry.tags ?? []).map((t) => t.trim()).filter(Boolean)
     )
 

--- a/scripts/seed-locations.ts
+++ b/scripts/seed-locations.ts
@@ -1,0 +1,82 @@
+/**
+ * roastery-geocode-corrected.json → RoasteryLocation 테이블 시딩
+ * 사용: tsx scripts/seed-locations.ts
+ */
+import dotenv from 'dotenv'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+import pg from 'pg'
+import { randomUUID } from 'crypto'
+
+dotenv.config({ path: '.env.local' })
+
+const { Pool } = pg
+
+interface LocationEntry {
+  address: string
+  lat: number
+  lng: number
+  isPrimary: boolean
+}
+
+interface RoasteryEntry {
+  name: string
+  locations: LocationEntry[]
+}
+
+async function main() {
+  const pool = new Pool({ connectionString: process.env.DIRECT_URL || process.env.DATABASE_URL })
+
+  const raw = readFileSync(join(process.cwd(), 'roastery-geocode-corrected.json'), 'utf-8')
+  const entries: RoasteryEntry[] = JSON.parse(raw)
+
+  let inserted = 0
+  let skipped = 0
+  let notFound = 0
+
+  for (const entry of entries) {
+    // DB에서 이름으로 roasteryId 조회 (삭제/숨김 제외)
+    const res = await pool.query<{ id: string }>(
+      `SELECT id FROM "Roastery" WHERE name = $1 AND "deletedAt" IS NULL AND hidden = false LIMIT 1`,
+      [entry.name]
+    )
+
+    if (res.rowCount === 0) {
+      console.warn(`[NOT FOUND] ${entry.name}`)
+      notFound++
+      continue
+    }
+
+    const roasteryId = res.rows[0].id
+
+    // 이미 location이 있으면 스킵 (중복 방지)
+    const existing = await pool.query(
+      `SELECT COUNT(*) FROM "RoasteryLocation" WHERE "roasteryId" = $1`,
+      [roasteryId]
+    )
+    if (parseInt(existing.rows[0].count) > 0) {
+      console.log(`[SKIP] ${entry.name} — 이미 location 존재`)
+      skipped++
+      continue
+    }
+
+    for (const loc of entry.locations) {
+      await pool.query(
+        `INSERT INTO "RoasteryLocation" (id, "roasteryId", address, lat, lng, "isPrimary")
+         VALUES ($1, $2, $3, $4, $5, $6)`,
+        [randomUUID(), roasteryId, loc.address, loc.lat, loc.lng, loc.isPrimary]
+      )
+      inserted++
+    }
+
+    console.log(`[OK] ${entry.name} — ${entry.locations.length}개 위치 추가`)
+  }
+
+  await pool.end()
+  console.log(`\n완료: 추가 ${inserted}개, 스킵 ${skipped}개, 미발견 ${notFound}개`)
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -16,10 +16,10 @@ export default async function MainLayout({ children }: { children: React.ReactNo
   }
 
   return (
-    <div className="flex min-h-screen flex-col bg-bg">
+    <div className="flex h-[100svh] flex-col bg-bg">
       <Navigation />
       {/* 모바일: BottomTab 높이(64px)만큼 하단 패딩 */}
-      <main className="flex-1 pb-[calc(4rem+env(safe-area-inset-bottom,0px))] lg:pb-0">
+      <main className="flex-1 overflow-y-auto pb-[calc(var(--bottom-tab-height)+env(safe-area-inset-bottom,0px))] lg:pb-0">
         <PageTransition>{children}</PageTransition>
       </main>
     </div>

--- a/src/app/(main)/roasteries/RoasteriesContent.tsx
+++ b/src/app/(main)/roasteries/RoasteriesContent.tsx
@@ -1,0 +1,169 @@
+import { Suspense } from 'react'
+import Link from 'next/link'
+import { MapPin, List } from 'lucide-react'
+import { auth } from '@/lib/auth'
+import { getRoasteries, getRoasteryById } from '@/lib/queries/roastery'
+import { getUserRating, getRatingCount, getRoasteryRatings } from '@/lib/queries/rating'
+import { getBookmarkStatus } from '@/lib/queries/bookmark'
+import { RequestRoasteryButton } from '@/components/roastery/RequestRoasteryButton'
+import { RoasteryPageHeader } from '@/components/roastery/RoasteryPageHeader'
+import { RoasteryGrid } from '@/components/roastery/RoasteryGrid'
+import { RoasteryMapLayout } from '@/components/roastery/map/RoasteryMapLayout'
+import { RoasteriesViewTracker } from '@/components/roastery/RoasteriesViewTracker'
+import { toArray } from '@/lib/utils'
+import { PRICE_OPTIONS } from '@/types/roastery'
+import type { SortOption, FilterParams, PriceRange } from '@/types/roastery'
+import type { SelectedRoasteryData } from '@/components/roastery/map/RoasteryMapLayout'
+
+interface Props {
+  params: { [key: string]: string | string[] | undefined }
+}
+
+export async function RoasteriesContent({ params }: Props) {
+  const session = await auth()
+  const userId = session?.user?.id
+
+  const isMapView = params.view === 'map'
+  const sort: SortOption = params.sort === 'name' ? 'name' : 'popular'
+  const selectedId = isMapView && typeof params.id === 'string' ? params.id : undefined
+
+  const filter: FilterParams = {
+    q: typeof params.q === 'string' ? params.q.trim() : '',
+    price: toArray(params.price).filter((v): v is PriceRange =>
+      PRICE_OPTIONS.includes(v as PriceRange)
+    ),
+    decaf: params.decaf === '1',
+    regions: toArray(params.region),
+    tags: toArray(params.tag),
+    rated: params.rated === '1',
+  }
+
+  const filterParams = new URLSearchParams()
+  if (filter.q) filterParams.set('q', filter.q)
+  filter.price.forEach((v) => filterParams.append('price', v))
+  if (filter.decaf) filterParams.set('decaf', '1')
+  filter.regions.forEach((v) => filterParams.append('region', v))
+  filter.tags.forEach((v) => filterParams.append('tag', v))
+  if (filter.rated) filterParams.set('rated', '1')
+  if (sort !== 'popular') filterParams.set('sort', sort)
+
+  const isFiltered = !!(
+    filter.q ||
+    filter.price.length > 0 ||
+    filter.decaf ||
+    filter.regions.length > 0 ||
+    filter.tags.length > 0 ||
+    filter.rated
+  )
+
+  const mapUrlParams = new URLSearchParams(filterParams)
+  mapUrlParams.set('view', 'map')
+  const mapUrl = `/roasteries?${mapUrlParams.toString()}`
+  const listUrl = filterParams.toString() ? `/roasteries?${filterParams.toString()}` : '/roasteries'
+
+  const [roasteries, selectedRoastery, ratingCount] = await Promise.all([
+    getRoasteries(sort, filter, userId),
+    selectedId ? getRoasteryById(selectedId) : null,
+    isMapView && userId && selectedId ? getRatingCount(userId) : 0,
+  ])
+
+  const mapRoasteries = isMapView
+    ? roasteries.filter((r) => r.locations.some((l) => l.address))
+    : roasteries
+
+  let selectedDetail: SelectedRoasteryData | null = null
+  if (selectedRoastery) {
+    const initialSort = userId && ratingCount >= 3 ? 'SIMILAR' : 'HIGH'
+    const [userRating, isBookmarked, ratingsResult] = await Promise.all([
+      userId ? getUserRating(userId, selectedRoastery.id) : null,
+      userId ? getBookmarkStatus(userId, selectedRoastery.id) : false,
+      getRoasteryRatings({
+        roasteryId: selectedRoastery.id,
+        sort: initialSort,
+        currentUserId: userId,
+      }),
+    ])
+    selectedDetail = {
+      roastery: selectedRoastery,
+      isBookmarked,
+      userRating: userRating
+        ? { score: userRating.score, comment: userRating.comment ?? undefined }
+        : undefined,
+      initialRatings: ratingsResult.items,
+      initialNextCursor: ratingsResult.nextCursor,
+      initialSort,
+    }
+  }
+
+  const pageHeader = <RoasteryPageHeader filter={filter} sort={sort} isLoggedIn={!!userId} />
+
+  if (isMapView && mapRoasteries.length > 0) {
+    return (
+      <div className="flex flex-col lg:h-[calc(100vh-var(--header-height))] lg:overflow-hidden">
+        <RoasteriesViewTracker view="map" />
+        <div className="lg:flex-1 lg:min-h-0 lg:flex lg:flex-col">
+          <Suspense fallback={null}>
+            <RoasteryMapLayout
+              roasteries={mapRoasteries}
+              selectedDetail={selectedDetail}
+              isLoggedIn={!!userId}
+              activeRegions={filter.regions}
+              isFiltered={isFiltered}
+              mobileHeader={pageHeader}
+              listUrl={listUrl}
+              filter={filter}
+              sort={sort}
+            />
+          </Suspense>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="page-wrapper flex flex-col gap-6 py-8">
+      <RoasteriesViewTracker view={isMapView ? 'map' : 'list'} />
+      {pageHeader}
+
+      {mapRoasteries.length === 0 ? (
+        <div className="py-20 flex flex-col items-center gap-3 text-center">
+          <p className="text-base font-medium">조건에 맞는 로스터리가 없어요.</p>
+          <p className="text-sm text-muted-foreground">필터를 조정하거나 검색어를 바꿔보세요.</p>
+          <RequestRoasteryButton />
+        </div>
+      ) : (
+        <>
+          <div className="flex items-center justify-between">
+            <span className="text-sm text-muted-foreground">{roasteries.length}개 로스터리</span>
+            <div className="hidden lg:flex items-center gap-0.5 rounded-lg bg-muted p-0.5">
+              <span className="flex items-center justify-center w-7 h-6 rounded-md bg-background shadow-sm text-foreground">
+                <List className="size-3.5" />
+              </span>
+              <Link
+                href={mapUrl}
+                className="flex items-center justify-center w-7 h-6 rounded-md text-muted-foreground hover:text-foreground transition-colors"
+                aria-label="지도로 보기"
+              >
+                <MapPin className="size-3.5" />
+              </Link>
+            </div>
+          </div>
+          <RoasteryGrid roasteries={roasteries} activeRegions={filter.regions} />
+          <div className="flex justify-center pt-4 pb-2">
+            <RequestRoasteryButton />
+          </div>
+        </>
+      )}
+
+      {!isMapView && (
+        <Link
+          href={mapUrl}
+          className="lg:hidden fixed bottom-[calc(var(--bottom-tab-height)+env(safe-area-inset-bottom,0px)+20px)] right-page-edge z-50 flex items-center justify-center w-14 h-14 rounded-full bg-primary text-primary-foreground shadow-lg hover:bg-primary/90 transition-colors"
+          aria-label="지도로 보기"
+        >
+          <MapPin className="size-6" />
+        </Link>
+      )}
+    </div>
+  )
+}

--- a/src/app/(main)/roasteries/page.tsx
+++ b/src/app/(main)/roasteries/page.tsx
@@ -9,13 +9,16 @@ export const metadata: Metadata = {
     canonical: '/roasteries',
   },
 }
-import { getRoasteries } from '@/lib/queries/roastery'
-import { RoasteryGrid } from '@/components/roastery/RoasteryGrid'
+import { getRoasteries, getRoasteryById } from '@/lib/queries/roastery'
+import { getUserRating, getRatingCount, getRoasteryRatings } from '@/lib/queries/rating'
+import { getBookmarkStatus } from '@/lib/queries/bookmark'
 import { FilterPanel } from '@/components/roastery/FilterPanel'
 import { RequestRoasteryButton } from '@/components/roastery/RequestRoasteryButton'
+import { RoasteryMapLayout } from '@/components/roastery/map/RoasteryMapLayout'
 import { toArray } from '@/lib/utils'
 import { PRICE_OPTIONS } from '@/types/roastery'
 import type { SortOption, FilterParams, PriceRange } from '@/types/roastery'
+import type { SelectedRoasteryData } from '@/components/roastery/map/RoasteryMapLayout'
 
 interface RoasteriesPageProps {
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>
@@ -26,6 +29,7 @@ export default async function RoasteriesPage({ searchParams }: RoasteriesPagePro
   const userId = session?.user?.id
 
   const sort: SortOption = params.sort === 'name' ? 'name' : 'popular'
+  const selectedId = typeof params.id === 'string' ? params.id : undefined
 
   const filter: FilterParams = {
     q: typeof params.q === 'string' ? params.q.trim() : '',
@@ -38,7 +42,37 @@ export default async function RoasteriesPage({ searchParams }: RoasteriesPagePro
     rated: params.rated === '1',
   }
 
-  const roasteries = await getRoasteries(sort, filter, userId)
+  // 목록 + 상세 병렬 fetch
+  const [roasteries, selectedRoastery, ratingCount] = await Promise.all([
+    getRoasteries(sort, filter, userId),
+    selectedId ? getRoasteryById(selectedId) : null,
+    userId && selectedId ? getRatingCount(userId) : 0,
+  ])
+
+  // 선택된 로스터리 상세 데이터
+  let selectedDetail: SelectedRoasteryData | null = null
+  if (selectedRoastery) {
+    const initialSort = userId && ratingCount >= 3 ? 'SIMILAR' : 'HIGH'
+    const [userRating, isBookmarked, ratingsResult] = await Promise.all([
+      userId ? getUserRating(userId, selectedRoastery.id) : null,
+      userId ? getBookmarkStatus(userId, selectedRoastery.id) : false,
+      getRoasteryRatings({
+        roasteryId: selectedRoastery.id,
+        sort: initialSort,
+        currentUserId: userId,
+      }),
+    ])
+    selectedDetail = {
+      roastery: selectedRoastery,
+      isBookmarked,
+      userRating: userRating
+        ? { score: userRating.score, comment: userRating.comment ?? undefined }
+        : undefined,
+      initialRatings: ratingsResult.items,
+      initialNextCursor: ratingsResult.nextCursor,
+      initialSort,
+    }
+  }
 
   return (
     <div className="page-wrapper py-8 flex flex-col gap-6">
@@ -56,7 +90,14 @@ export default async function RoasteriesPage({ searchParams }: RoasteriesPagePro
         </div>
       ) : (
         <>
-          <RoasteryGrid roasteries={roasteries} activeRegions={filter.regions} />
+          <Suspense fallback={null}>
+            <RoasteryMapLayout
+              roasteries={roasteries}
+              selectedDetail={selectedDetail}
+              isLoggedIn={!!userId}
+              activeRegions={filter.regions}
+            />
+          </Suspense>
           <div className="flex justify-center pt-4 pb-2">
             <RequestRoasteryButton />
           </div>

--- a/src/app/(main)/roasteries/page.tsx
+++ b/src/app/(main)/roasteries/page.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from 'next'
 import { Suspense } from 'react'
+import Link from 'next/link'
+import { MapPin } from 'lucide-react'
 import { auth } from '@/lib/auth'
 
 export const metadata: Metadata = {
@@ -14,6 +16,7 @@ import { getUserRating, getRatingCount, getRoasteryRatings } from '@/lib/queries
 import { getBookmarkStatus } from '@/lib/queries/bookmark'
 import { FilterPanel } from '@/components/roastery/FilterPanel'
 import { RequestRoasteryButton } from '@/components/roastery/RequestRoasteryButton'
+import { RoasteryGrid } from '@/components/roastery/RoasteryGrid'
 import { RoasteryMapLayout } from '@/components/roastery/map/RoasteryMapLayout'
 import { toArray } from '@/lib/utils'
 import { PRICE_OPTIONS } from '@/types/roastery'
@@ -28,8 +31,9 @@ export default async function RoasteriesPage({ searchParams }: RoasteriesPagePro
   const [params, session] = await Promise.all([searchParams, auth()])
   const userId = session?.user?.id
 
+  const isMapView = params.view === 'map'
   const sort: SortOption = params.sort === 'name' ? 'name' : 'popular'
-  const selectedId = typeof params.id === 'string' ? params.id : undefined
+  const selectedId = isMapView && typeof params.id === 'string' ? params.id : undefined
 
   const filter: FilterParams = {
     q: typeof params.q === 'string' ? params.q.trim() : '',
@@ -42,11 +46,26 @@ export default async function RoasteriesPage({ searchParams }: RoasteriesPagePro
     rated: params.rated === '1',
   }
 
-  // 목록 + 상세 병렬 fetch
+  // 필터 파라미터만 담은 URLSearchParams (view, id 제외)
+  const filterParams = new URLSearchParams()
+  if (filter.q) filterParams.set('q', filter.q)
+  filter.price.forEach((v) => filterParams.append('price', v))
+  if (filter.decaf) filterParams.set('decaf', '1')
+  filter.regions.forEach((v) => filterParams.append('region', v))
+  filter.tags.forEach((v) => filterParams.append('tag', v))
+  if (filter.rated) filterParams.set('rated', '1')
+  if (sort !== 'popular') filterParams.set('sort', sort)
+
+  const mapUrlParams = new URLSearchParams(filterParams)
+  mapUrlParams.set('view', 'map')
+  const mapUrl = `/roasteries?${mapUrlParams.toString()}`
+  const listUrl = filterParams.toString() ? `/roasteries?${filterParams.toString()}` : '/roasteries'
+
+  // 목록 + 지도 뷰에서만 상세 fetch
   const [roasteries, selectedRoastery, ratingCount] = await Promise.all([
     getRoasteries(sort, filter, userId),
     selectedId ? getRoasteryById(selectedId) : null,
-    userId && selectedId ? getRatingCount(userId) : 0,
+    isMapView && userId && selectedId ? getRatingCount(userId) : 0,
   ])
 
   // 선택된 로스터리 상세 데이터
@@ -88,16 +107,29 @@ export default async function RoasteriesPage({ searchParams }: RoasteriesPagePro
           <p className="text-sm text-muted-foreground">필터를 조정하거나 검색어를 바꿔보세요.</p>
           <RequestRoasteryButton />
         </div>
+      ) : isMapView ? (
+        <Suspense fallback={null}>
+          <RoasteryMapLayout
+            roasteries={roasteries}
+            selectedDetail={selectedDetail}
+            isLoggedIn={!!userId}
+            activeRegions={filter.regions}
+            listUrl={listUrl}
+          />
+        </Suspense>
       ) : (
         <>
-          <Suspense fallback={null}>
-            <RoasteryMapLayout
-              roasteries={roasteries}
-              selectedDetail={selectedDetail}
-              isLoggedIn={!!userId}
-              activeRegions={filter.regions}
-            />
-          </Suspense>
+          <div className="flex items-center justify-between">
+            <span className="text-sm text-muted-foreground">{roasteries.length}개 로스터리</span>
+            <Link
+              href={mapUrl}
+              className="flex items-center gap-1.5 text-sm border rounded-md px-3 py-1.5 hover:bg-muted transition-colors"
+            >
+              <MapPin className="size-4" />
+              지도로 보기
+            </Link>
+          </div>
+          <RoasteryGrid roasteries={roasteries} activeRegions={filter.regions} />
           <div className="flex justify-center pt-4 pb-2">
             <RequestRoasteryButton />
           </div>

--- a/src/app/(main)/roasteries/page.tsx
+++ b/src/app/(main)/roasteries/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import { Suspense } from 'react'
-import { auth } from '@/lib/auth'
+import { Skeleton } from '@/components/ui/skeleton'
+import { RoasteriesContent } from './RoasteriesContent'
 
 export const metadata: Metadata = {
   title: '로스터리',
@@ -9,59 +10,79 @@ export const metadata: Metadata = {
     canonical: '/roasteries',
   },
 }
-import { getRoasteries } from '@/lib/queries/roastery'
-import { RoasteryGrid } from '@/components/roastery/RoasteryGrid'
-import { FilterPanel } from '@/components/roastery/FilterPanel'
-import { RequestRoasteryButton } from '@/components/roastery/RequestRoasteryButton'
-import { toArray } from '@/lib/utils'
-import { PRICE_OPTIONS } from '@/types/roastery'
-import type { SortOption, FilterParams, PriceRange } from '@/types/roastery'
+
+function ListViewSkeleton() {
+  return (
+    <div className="page-wrapper py-8 flex flex-col gap-6">
+      <Skeleton className="h-7 w-24" />
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+        {Array.from({ length: 8 }).map((_, i) => (
+          <div key={i} className="flex flex-row items-start gap-3 rounded-xl p-2">
+            <Skeleton className="size-16 rounded-lg shrink-0" />
+            <div className="flex flex-col justify-between h-16 min-w-0 flex-1">
+              <Skeleton className="h-4 w-3/4" />
+              <Skeleton className="h-3 w-1/2" />
+              <Skeleton className="h-3 w-1/3" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function MapViewSkeleton() {
+  return (
+    <div className="page-wrapper flex flex-col lg:py-8">
+      {/* 헤더 스켈레톤 */}
+      <div className="pt-8 pb-3 flex flex-col gap-4 border-b lg:border-none lg:pb-6">
+        <div className="flex items-center justify-between">
+          <Skeleton className="h-7 w-20" />
+          {/* 데스크탑: 뷰 토글 버튼 */}
+          <div className="hidden lg:flex gap-2">
+            <Skeleton className="h-8 w-20 rounded-md" />
+            <Skeleton className="h-8 w-20 rounded-md" />
+          </div>
+        </div>
+        {/* 모바일: 검색 + 필터 버튼 */}
+        <div className="flex gap-2 lg:hidden">
+          <Skeleton className="h-9 flex-1 rounded-md" />
+          <Skeleton className="h-9 w-20 rounded-md" />
+        </div>
+        {/* 데스크탑: pill 필터 */}
+        <div className="hidden lg:flex gap-2">
+          <Skeleton className="h-9 w-56 rounded-full" />
+          <Skeleton className="h-9 w-20 rounded-full" />
+          <Skeleton className="h-9 w-24 rounded-full" />
+          <Skeleton className="h-9 w-20 rounded-full" />
+        </div>
+      </div>
+      {/* 지도 플레이스홀더 */}
+      <Skeleton
+        style={{
+          borderRadius: 0,
+          height:
+            'calc(100svh - var(--bottom-tab-height) - env(safe-area-inset-bottom, 0px) - 8rem)',
+          width: 'calc(100% + 2 * var(--page-padding))',
+          marginLeft: 'calc(-1 * var(--page-padding))',
+          marginRight: 'calc(-1 * var(--page-padding))',
+        }}
+      />
+    </div>
+  )
+}
 
 interface RoasteriesPageProps {
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>
 }
 
 export default async function RoasteriesPage({ searchParams }: RoasteriesPageProps) {
-  const [params, session] = await Promise.all([searchParams, auth()])
-  const userId = session?.user?.id
-
-  const sort: SortOption = params.sort === 'name' ? 'name' : 'popular'
-
-  const filter: FilterParams = {
-    q: typeof params.q === 'string' ? params.q.trim() : '',
-    price: toArray(params.price).filter((v): v is PriceRange =>
-      PRICE_OPTIONS.includes(v as PriceRange)
-    ),
-    decaf: params.decaf === '1',
-    regions: toArray(params.region),
-    tags: toArray(params.tag),
-    rated: params.rated === '1',
-  }
-
-  const roasteries = await getRoasteries(sort, filter, userId)
+  const params = await searchParams
+  const isMapView = params.view === 'map'
 
   return (
-    <div className="page-wrapper py-8 flex flex-col gap-6">
-      <h1 className="text-xl font-semibold">로스터리</h1>
-
-      <Suspense fallback={null}>
-        <FilterPanel filter={filter} sort={sort} isLoggedIn={!!userId} />
-      </Suspense>
-
-      {roasteries.length === 0 ? (
-        <div className="py-20 flex flex-col items-center gap-3 text-center">
-          <p className="text-base font-medium">조건에 맞는 로스터리가 없어요.</p>
-          <p className="text-sm text-muted-foreground">필터를 조정하거나 검색어를 바꿔보세요.</p>
-          <RequestRoasteryButton />
-        </div>
-      ) : (
-        <>
-          <RoasteryGrid roasteries={roasteries} activeRegions={filter.regions} />
-          <div className="flex justify-center pt-4 pb-2">
-            <RequestRoasteryButton />
-          </div>
-        </>
-      )}
-    </div>
+    <Suspense fallback={isMapView ? <MapViewSkeleton /> : <ListViewSkeleton />}>
+      <RoasteriesContent params={params} />
+    </Suspense>
   )
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -143,6 +143,10 @@
   /* 컨테이너 */
   --container-max: 1440px;
 
+  /* 네비게이션 높이 */
+  --header-height: 3.5rem;   /* 데스크탑 헤더 (h-14) */
+  --bottom-tab-height: 4rem; /* 모바일 하단 탭 (h-16) */
+
   /* 브레이크포인트 */
   --breakpoint-sm: 640px;   /* 모바일 large */
   --breakpoint-md: 768px;   /* 태블릿 */
@@ -197,6 +201,28 @@ body {
   overflow-x: clip; /* edge-to-edge 스크롤 섹션의 가로 스크롤바 방지 */
 }
 
+/* ── 스크롤바 스타일링 ── */
+/* webkit: 4px 오버레이 스크롤바 (공간 미차지) */
+::-webkit-scrollbar {
+  width: 4px;
+}
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+::-webkit-scrollbar-thumb {
+  background: color-mix(in oklch, var(--foreground) 20%, transparent);
+  border-radius: 2px;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: color-mix(in oklch, var(--foreground) 35%, transparent);
+}
+
+/* Firefox: 얇은 스크롤바 */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: color-mix(in oklch, var(--foreground) 20%, transparent) transparent;
+}
+
 /* ── 페이지 컨테이너 ── */
 /* 사용법: <div className="page-wrapper"> */
 :root {
@@ -217,6 +243,11 @@ body {
     max-width: var(--container-max);
     margin-inline: auto;
     padding-inline: var(--page-padding);
+  }
+
+  /* fixed 요소를 page-wrapper 콘텐츠 오른쪽 끝에 맞춤 (padding + auto margin 동시 반영) */
+  .right-page-edge {
+    right: max(var(--page-padding), calc((100vw - 1440px) / 2 + var(--page-padding)));
   }
 }
 
@@ -253,6 +284,11 @@ body {
   --sidebar-accent-foreground:             oklch(0.985 0 0);
   --sidebar-border:             oklch(1 0 0 / 10%);
   --sidebar-ring:             oklch(0.556 0 0);
+}
+
+@keyframes pulse-ring {
+  0% { transform: scale(0.6); opacity: 0.8; }
+  100% { transform: scale(1.8); opacity: 0; }
 }
 
 @layer base {

--- a/src/components/layout/BottomTab.tsx
+++ b/src/components/layout/BottomTab.tsx
@@ -7,23 +7,27 @@ import { Home, Coffee, LayoutList, User, Settings } from 'lucide-react'
 import { motion } from 'framer-motion'
 import { cn } from '@/lib/utils'
 import { SPRING_SNAPPY, TAP_SCALE } from '@/lib/motion'
-
-const authTabs = [
-  { href: '/', label: '홈', Icon: Home },
-  { href: '/roasteries', label: '로스터리', Icon: Coffee },
-  { href: '/activity', label: '내 활동', Icon: LayoutList },
-  { href: '/profile', label: '프로필', Icon: User },
-]
-
-const guestTabs = [
-  { href: '/', label: '홈', Icon: Home },
-  { href: '/roasteries', label: '로스터리', Icon: Coffee },
-  { href: '/settings', label: '설정', Icon: Settings },
-]
+import { getRoasteriesView } from '@/lib/roasteriesState'
 
 export function BottomTab({ className }: { className?: string }) {
   const pathname = usePathname()
   const { data: session } = useSession()
+
+  const roasteriesHref = getRoasteriesView() === 'map' ? '/roasteries?view=map' : '/roasteries'
+
+  const authTabs = [
+    { key: '/', href: '/', label: '홈', Icon: Home },
+    { key: '/roasteries', href: roasteriesHref, label: '로스터리', Icon: Coffee },
+    { key: '/activity', href: '/activity', label: '내 활동', Icon: LayoutList },
+    { key: '/profile', href: '/profile', label: '프로필', Icon: User },
+  ]
+
+  const guestTabs = [
+    { key: '/', href: '/', label: '홈', Icon: Home },
+    { key: '/roasteries', href: roasteriesHref, label: '로스터리', Icon: Coffee },
+    { key: '/settings', href: '/settings', label: '설정', Icon: Settings },
+  ]
+
   const tabs = session?.user ? authTabs : guestTabs
 
   return (
@@ -35,10 +39,10 @@ export function BottomTab({ className }: { className?: string }) {
       )}
     >
       <ul className="flex h-16 w-full">
-        {tabs.map(({ href, label, Icon }) => {
-          const isActive = href === '/' ? pathname === '/' : pathname.startsWith(href)
+        {tabs.map(({ key, href, label, Icon }) => {
+          const isActive = key === '/' ? pathname === '/' : pathname.startsWith(key)
           return (
-            <li key={href} className="relative flex flex-1 items-center justify-center">
+            <li key={key} className="relative flex flex-1 items-center justify-center">
               {/* layoutId로 활성 탭 이동 시 인디케이터가 spring으로 슬라이드 */}
               {isActive && (
                 <motion.div

--- a/src/components/roastery/FilterPanel.tsx
+++ b/src/components/roastery/FilterPanel.tsx
@@ -14,11 +14,12 @@ interface FilterPanelProps {
   filter: FilterParams
   sort: SortOption
   isLoggedIn: boolean
+  variant?: 'default' | 'map-search' | 'map-pills'
 }
 
 type PillId = 'price' | 'region' | 'tag'
 
-export function FilterPanel({ filter, sort, isLoggedIn }: FilterPanelProps) {
+export function FilterPanel({ filter, sort, isLoggedIn, variant = 'default' }: FilterPanelProps) {
   const router = useRouter()
   const pathname = usePathname()
   const searchParams = useSearchParams()
@@ -102,6 +103,111 @@ export function FilterPanel({ filter, sort, isLoggedIn }: FilterPanelProps) {
     filter.regions.length > 0 ||
     filter.tags.length > 0 ||
     filter.rated
+
+  if (variant === 'map-search') {
+    return (
+      <div
+        className={`flex items-center gap-2${isPending ? ' opacity-60 pointer-events-none' : ''}`}
+      >
+        <input
+          type="search"
+          placeholder="로스터리 이름 검색..."
+          value={inputValue}
+          onChange={(e) => setInputValue(e.target.value)}
+          onFocus={() => {
+            isFocusedRef.current = true
+          }}
+          onBlur={() => {
+            isFocusedRef.current = false
+          }}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && !e.nativeEvent.isComposing) navigate({ q: inputValue.trim() })
+          }}
+          className="min-w-0 flex-1 rounded-md border border-border bg-background px-3 py-1.5 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+          aria-label="로스터리 이름 검색"
+        />
+        <SortSelector sort={sort} />
+      </div>
+    )
+  }
+
+  if (variant === 'map-pills') {
+    return (
+      <div
+        className={`flex items-center gap-2 flex-wrap${isPending ? ' opacity-60 pointer-events-none' : ''}`}
+      >
+        <FilterPill
+          id="price"
+          label="가격대"
+          count={filter.price.length}
+          open={openPill === 'price'}
+          onToggle={() => setOpenPill(openPill === 'price' ? null : 'price')}
+          onClose={() => setOpenPill(null)}
+          shadow
+        >
+          <PriceGroup selected={filter.price} onToggle={togglePrice} />
+        </FilterPill>
+
+        <button
+          onClick={() => navigate({ decaf: !filter.decaf })}
+          className={`inline-flex cursor-pointer items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm transition-colors shadow-md ${
+            filter.decaf
+              ? 'border-foreground bg-foreground text-background'
+              : 'border-border bg-background hover:border-foreground/40'
+          }`}
+        >
+          디카페인
+        </button>
+
+        <FilterPill
+          id="region"
+          label="지역"
+          count={filter.regions.length}
+          open={openPill === 'region'}
+          onToggle={() => setOpenPill(openPill === 'region' ? null : 'region')}
+          onClose={() => setOpenPill(null)}
+          shadow
+        >
+          <RegionGroup selected={filter.regions} onToggle={toggleRegion} />
+        </FilterPill>
+
+        <FilterPill
+          id="tag"
+          label="태그"
+          count={filter.tags.length}
+          open={openPill === 'tag'}
+          onToggle={() => setOpenPill(openPill === 'tag' ? null : 'tag')}
+          onClose={() => setOpenPill(null)}
+          shadow
+        >
+          <TagGroup selected={filter.tags} onToggle={toggleTag} />
+        </FilterPill>
+
+        {isLoggedIn && (
+          <button
+            onClick={() => navigate({ rated: !filter.rated })}
+            className={`inline-flex cursor-pointer items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm transition-colors shadow-md ${
+              filter.rated
+                ? 'border-foreground bg-foreground text-background'
+                : 'border-border bg-background hover:border-foreground/40'
+            }`}
+          >
+            내가 평가한
+          </button>
+        )}
+
+        {isFiltered && (
+          <button
+            onClick={reset}
+            className="inline-flex cursor-pointer items-center gap-1.5 rounded-full border border-border bg-background px-3 py-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <RotateCcw className="h-3.5 w-3.5" />
+            초기화
+          </button>
+        )}
+      </div>
+    )
+  }
 
   return (
     <div className={isPending ? 'opacity-60 pointer-events-none' : ''}>
@@ -203,7 +309,7 @@ export function FilterPanel({ filter, sort, isLoggedIn }: FilterPanelProps) {
           className={`inline-flex cursor-pointer items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm transition-colors ${
             filter.decaf
               ? 'border-foreground bg-foreground text-background'
-              : 'border-border hover:border-foreground/40'
+              : 'border-border bg-background hover:border-foreground/40'
           }`}
         >
           디카페인
@@ -237,7 +343,7 @@ export function FilterPanel({ filter, sort, isLoggedIn }: FilterPanelProps) {
             className={`inline-flex cursor-pointer items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm transition-colors ${
               filter.rated
                 ? 'border-foreground bg-foreground text-background'
-                : 'border-border hover:border-foreground/40'
+                : 'border-border bg-background hover:border-foreground/40'
             }`}
           >
             내가 평가한
@@ -270,6 +376,7 @@ function FilterPill({
   open,
   onToggle,
   onClose,
+  shadow = false,
   children,
 }: {
   id?: PillId
@@ -278,6 +385,7 @@ function FilterPill({
   open: boolean
   onToggle: () => void
   onClose: () => void
+  shadow?: boolean
   children: React.ReactNode
 }) {
   const ref = useRef<HTMLDivElement>(null)
@@ -295,10 +403,10 @@ function FilterPill({
     <div ref={ref} className="relative">
       <button
         onClick={onToggle}
-        className={`inline-flex cursor-pointer items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm transition-colors ${
+        className={`inline-flex cursor-pointer items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm transition-colors ${shadow ? 'shadow-md' : ''} ${
           count > 0
             ? 'border-foreground bg-foreground text-background'
-            : 'border-border hover:border-foreground/40'
+            : 'border-border bg-background hover:border-foreground/40'
         }`}
       >
         {label}

--- a/src/components/roastery/RoasteriesViewTracker.tsx
+++ b/src/components/roastery/RoasteriesViewTracker.tsx
@@ -1,0 +1,11 @@
+'use client'
+
+import { useEffect } from 'react'
+import { setRoasteriesView } from '@/lib/roasteriesState'
+
+export function RoasteriesViewTracker({ view }: { view: 'list' | 'map' }) {
+  useEffect(() => {
+    setRoasteriesView(view)
+  }, [view])
+  return null
+}

--- a/src/components/roastery/RoasteryCard.test.tsx
+++ b/src/components/roastery/RoasteryCard.test.tsx
@@ -32,6 +32,7 @@ function makeRoastery(overrides: Partial<RoasteryWithStats> = {}): RoasteryWithS
     name: '테스트 로스터리',
     description: null,
     tags: [],
+    locations: [],
     priceRange: 'MID',
     decaf: false,
     imageUrl: null,

--- a/src/components/roastery/RoasteryCard.tsx
+++ b/src/components/roastery/RoasteryCard.tsx
@@ -15,6 +15,7 @@ interface RoasteryCardProps {
   priority?: boolean
   activeRegions?: string[]
   variant?: 'portrait' | 'landscape'
+  onCardClick?: (id: string) => void
 }
 
 function CoffeePlaceholder({ size }: { size: number }) {
@@ -46,6 +47,7 @@ export function RoasteryCard({
   priority = false,
   activeRegions,
   variant = 'portrait',
+  onCardClick,
 }: RoasteryCardProps) {
   const regions = getRegions(roastery.tags)
   const charTags = getCharacteristicTags(roastery.tags)
@@ -55,6 +57,14 @@ export function RoasteryCard({
       <Link
         href={`/roasteries/${roastery.id}`}
         className="block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-xl"
+        onClick={
+          onCardClick
+            ? (e) => {
+                e.preventDefault()
+                onCardClick(roastery.id)
+              }
+            : undefined
+        }
       >
         <motion.div
           className="group flex flex-row items-start gap-3 rounded-xl p-2 hover:bg-muted/50 transition-colors"
@@ -106,6 +116,14 @@ export function RoasteryCard({
     <Link
       href={`/roasteries/${roastery.id}`}
       className="block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-xl"
+      onClick={
+        onCardClick
+          ? (e) => {
+              e.preventDefault()
+              onCardClick(roastery.id)
+            }
+          : undefined
+      }
     >
       <motion.div
         className="group flex flex-col gap-2"

--- a/src/components/roastery/RoasteryCard.tsx
+++ b/src/components/roastery/RoasteryCard.tsx
@@ -9,12 +9,16 @@ import { RatingDisplay } from './RatingDisplay'
 import type { RoasteryWithStats } from '@/types/roastery'
 import { PRICE_RANGE_LABELS, getRegions, getCharacteristicTags } from '@/types/roastery'
 import { SPRING_SNAPPY, TAP_SCALE } from '@/lib/motion'
+import { formatDistance } from '@/lib/geo'
 
 interface RoasteryCardProps {
   roastery: RoasteryWithStats
   priority?: boolean
   activeRegions?: string[]
   variant?: 'portrait' | 'landscape'
+  onCardClick?: (id: string) => void
+  nearbyAddress?: string
+  nearbyDistance?: number
 }
 
 function CoffeePlaceholder({ size }: { size: number }) {
@@ -46,6 +50,9 @@ export function RoasteryCard({
   priority = false,
   activeRegions,
   variant = 'portrait',
+  onCardClick,
+  nearbyAddress,
+  nearbyDistance,
 }: RoasteryCardProps) {
   const regions = getRegions(roastery.tags)
   const charTags = getCharacteristicTags(roastery.tags)
@@ -55,6 +62,14 @@ export function RoasteryCard({
       <Link
         href={`/roasteries/${roastery.id}`}
         className="block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-xl"
+        onClick={
+          onCardClick
+            ? (e) => {
+                e.preventDefault()
+                onCardClick(roastery.id)
+              }
+            : undefined
+        }
       >
         <motion.div
           className="group flex flex-row items-start gap-3 rounded-xl p-2 hover:bg-muted/50 transition-colors"
@@ -76,14 +91,27 @@ export function RoasteryCard({
               <CoffeePlaceholder size={24} />
             )}
           </div>
-          <div className="flex flex-col justify-between h-16 min-w-0">
-            <p className="font-medium text-sm leading-tight line-clamp-1">{roastery.name}</p>
-            <p className="text-xs text-muted-foreground line-clamp-1">
-              {regions.length > 0 && (
-                <RegionDisplay regions={regions} activeRegions={activeRegions} />
+          <div className="flex flex-col justify-between h-16 min-w-0 flex-1">
+            <div className="flex items-center justify-between gap-2">
+              <p className="font-medium text-sm leading-tight line-clamp-1">{roastery.name}</p>
+              {nearbyDistance != null && (
+                <span className="text-xs text-primary font-medium shrink-0">
+                  {formatDistance(nearbyDistance)}
+                </span>
               )}
-              {regions.length > 0 && ' · '}
-              {PRICE_RANGE_LABELS[roastery.priceRange]}
+            </div>
+            <p className="text-xs text-muted-foreground line-clamp-1">
+              {nearbyAddress != null ? (
+                nearbyAddress
+              ) : (
+                <>
+                  {regions.length > 0 && (
+                    <RegionDisplay regions={regions} activeRegions={activeRegions} />
+                  )}
+                  {regions.length > 0 && ' · '}
+                  {PRICE_RANGE_LABELS[roastery.priceRange]}
+                </>
+              )}
             </p>
             <div className="flex items-center gap-1.5 flex-wrap">
               <span className="text-xs">
@@ -106,6 +134,14 @@ export function RoasteryCard({
     <Link
       href={`/roasteries/${roastery.id}`}
       className="block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-xl"
+      onClick={
+        onCardClick
+          ? (e) => {
+              e.preventDefault()
+              onCardClick(roastery.id)
+            }
+          : undefined
+      }
     >
       <motion.div
         className="group flex flex-col gap-2"

--- a/src/components/roastery/RoasteryDetail.tsx
+++ b/src/components/roastery/RoasteryDetail.tsx
@@ -92,8 +92,8 @@ export function RoasteryDetail({
         {/* 지역 + 주소 */}
         <div className="flex flex-col gap-0.5">
           {regions.length > 0 && <p className="text-sm text-muted-foreground">{regions[0]}</p>}
-          {roastery.address && (
-            <p className="text-xs text-muted-foreground/70">{roastery.address}</p>
+          {roastery.locations[0]?.address && (
+            <p className="text-xs text-muted-foreground/70">{roastery.locations[0].address}</p>
           )}
         </div>
 

--- a/src/components/roastery/RoasteryDetail.tsx
+++ b/src/components/roastery/RoasteryDetail.tsx
@@ -18,6 +18,7 @@ interface RoasteryDetailProps {
   initialRatings: RatingListItem[]
   initialNextCursor: string | null
   initialSort: RatingSortOption
+  hideBackButton?: boolean
 }
 
 export function RoasteryDetail({
@@ -28,13 +29,14 @@ export function RoasteryDetail({
   initialRatings,
   initialNextCursor,
   initialSort,
+  hideBackButton = false,
 }: RoasteryDetailProps) {
   const regions = getRegions(roastery.tags)
   const charTags = getCharacteristicTags(roastery.tags)
 
   return (
     <div className="flex flex-col gap-8">
-      <BackButton />
+      {!hideBackButton && <BackButton />}
 
       {/* 기본 정보 */}
       <div className="flex flex-col gap-2">

--- a/src/components/roastery/RoasteryDetail.tsx
+++ b/src/components/roastery/RoasteryDetail.tsx
@@ -8,6 +8,7 @@ import { BookmarkButton } from '@/components/bookmark/BookmarkButton'
 import { RatingList } from '@/components/rating/RatingList'
 import type { RoasteryDetail as RoasteryDetailType } from '@/types/roastery'
 import { PRICE_RANGE_LABELS, getRegions, getCharacteristicTags } from '@/types/roastery'
+import { RoasteryLocationSection } from './RoasteryLocationSection'
 import type { RatingListItem, RatingSortOption } from '@/types/rating'
 
 interface RoasteryDetailProps {
@@ -18,6 +19,7 @@ interface RoasteryDetailProps {
   initialRatings: RatingListItem[]
   initialNextCursor: string | null
   initialSort: RatingSortOption
+  hideBackButton?: boolean
 }
 
 export function RoasteryDetail({
@@ -28,13 +30,17 @@ export function RoasteryDetail({
   initialRatings,
   initialNextCursor,
   initialSort,
+  hideBackButton = false,
 }: RoasteryDetailProps) {
   const regions = getRegions(roastery.tags)
   const charTags = getCharacteristicTags(roastery.tags)
+  const primaryLocation =
+    roastery.locations.find((l) => l.isPrimary) ?? roastery.locations[0] ?? null
+  const otherLocations = roastery.locations.filter((l) => l !== primaryLocation)
 
   return (
     <div className="flex flex-col gap-8">
-      <BackButton />
+      {!hideBackButton && <BackButton />}
 
       {/* 기본 정보 */}
       <div className="flex flex-col gap-2">
@@ -91,10 +97,14 @@ export function RoasteryDetail({
 
         {/* 지역 + 주소 */}
         <div className="flex flex-col gap-0.5">
-          {regions.length > 0 && <p className="text-sm text-muted-foreground">{regions[0]}</p>}
-          {roastery.address && (
-            <p className="text-xs text-muted-foreground/70">{roastery.address}</p>
+          {regions.length > 0 && (
+            <p className="text-sm text-muted-foreground">{regions.join(' · ')}</p>
           )}
+          <RoasteryLocationSection
+            primaryLocation={primaryLocation}
+            otherLocations={otherLocations}
+            roasteryId={roastery.id}
+          />
         </div>
 
         {/* 설명 */}

--- a/src/components/roastery/RoasteryGrid.tsx
+++ b/src/components/roastery/RoasteryGrid.tsx
@@ -8,15 +8,27 @@ import { staggerContainerVariants, fadeUpVariants } from '@/lib/motion'
 interface RoasteryGridProps {
   roasteries: RoasteryWithStats[]
   activeRegions?: string[]
+  variant?: 'portrait' | 'landscape'
+  onCardClick?: (id: string) => void
 }
 
-export function RoasteryGrid({ roasteries, activeRegions }: RoasteryGridProps) {
+export function RoasteryGrid({
+  roasteries,
+  activeRegions,
+  variant = 'landscape',
+  onCardClick,
+}: RoasteryGridProps) {
+  const gridClass =
+    variant === 'portrait'
+      ? 'grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5'
+      : 'grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4'
+
   return (
     <motion.div
       variants={staggerContainerVariants}
       initial="hidden"
       animate="visible"
-      className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
+      className={gridClass}
     >
       {roasteries.map((roastery, i) => (
         <motion.div key={roastery.id} variants={fadeUpVariants}>
@@ -24,7 +36,8 @@ export function RoasteryGrid({ roasteries, activeRegions }: RoasteryGridProps) {
             roastery={roastery}
             priority={i < 4}
             activeRegions={activeRegions}
-            variant="landscape"
+            variant={variant}
+            onCardClick={onCardClick}
           />
         </motion.div>
       ))}

--- a/src/components/roastery/RoasteryGrid.tsx
+++ b/src/components/roastery/RoasteryGrid.tsx
@@ -8,15 +8,30 @@ import { staggerContainerVariants, fadeUpVariants } from '@/lib/motion'
 interface RoasteryGridProps {
   roasteries: RoasteryWithStats[]
   activeRegions?: string[]
+  variant?: 'portrait' | 'landscape'
+  onCardClick?: (id: string) => void
+  singleCol?: boolean
 }
 
-export function RoasteryGrid({ roasteries, activeRegions }: RoasteryGridProps) {
+export function RoasteryGrid({
+  roasteries,
+  activeRegions,
+  variant = 'landscape',
+  onCardClick,
+  singleCol,
+}: RoasteryGridProps) {
+  const gridClass = singleCol
+    ? 'grid grid-cols-1 gap-4'
+    : variant === 'portrait'
+      ? 'grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5'
+      : 'grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4'
+
   return (
     <motion.div
       variants={staggerContainerVariants}
       initial="hidden"
       animate="visible"
-      className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
+      className={gridClass}
     >
       {roasteries.map((roastery, i) => (
         <motion.div key={roastery.id} variants={fadeUpVariants}>
@@ -24,7 +39,8 @@ export function RoasteryGrid({ roasteries, activeRegions }: RoasteryGridProps) {
             roastery={roastery}
             priority={i < 4}
             activeRegions={activeRegions}
-            variant="landscape"
+            variant={variant}
+            onCardClick={onCardClick}
           />
         </motion.div>
       ))}

--- a/src/components/roastery/RoasteryLocationSection.tsx
+++ b/src/components/roastery/RoasteryLocationSection.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { ChevronDown, ChevronUp, MapPin } from 'lucide-react'
+import type { LocationItem } from '@/types/roastery'
+
+interface Props {
+  primaryLocation: LocationItem | null
+  otherLocations: LocationItem[]
+  roasteryId: string
+}
+
+export function RoasteryLocationSection({ primaryLocation, otherLocations, roasteryId }: Props) {
+  const [expanded, setExpanded] = useState(false)
+
+  const hasAddress = primaryLocation?.address || otherLocations.some((l) => l.address)
+  const hasMap = primaryLocation?.lat != null && primaryLocation?.lng != null
+
+  if (!hasAddress && !hasMap) return null
+
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex items-center gap-1.5 flex-wrap min-w-0">
+          {primaryLocation?.address && (
+            <p className="text-xs text-muted-foreground/70">{primaryLocation.address}</p>
+          )}
+          {otherLocations.length > 0 && (
+            <button
+              onClick={() => setExpanded((v) => !v)}
+              className="flex items-center gap-0.5 text-xs text-muted-foreground hover:text-foreground transition-colors shrink-0"
+            >
+              외 {otherLocations.length}개
+              {expanded ? <ChevronUp className="size-3" /> : <ChevronDown className="size-3" />}
+            </button>
+          )}
+        </div>
+        {hasMap && (
+          <Link
+            href={`/roasteries?view=map&id=${roasteryId}`}
+            className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors shrink-0"
+          >
+            <MapPin className="size-3.5" />
+            지도 보기
+          </Link>
+        )}
+      </div>
+
+      {expanded && (
+        <div className="flex flex-col gap-0.5 pt-0.5">
+          {otherLocations
+            .filter((l) => l.address)
+            .map((loc) => (
+              <p key={loc.id} className="text-xs text-muted-foreground/70">
+                {loc.address}
+              </p>
+            ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/roastery/RoasteryLocationSection.tsx
+++ b/src/components/roastery/RoasteryLocationSection.tsx
@@ -15,7 +15,9 @@ export function RoasteryLocationSection({ primaryLocation, otherLocations, roast
   const [expanded, setExpanded] = useState(false)
 
   const hasAddress = primaryLocation?.address || otherLocations.some((l) => l.address)
-  const hasMap = primaryLocation?.lat != null && primaryLocation?.lng != null
+  const hasMap =
+    (primaryLocation?.lat != null && primaryLocation?.lng != null) ||
+    otherLocations.some((l) => l.lat != null && l.lng != null)
 
   if (!hasAddress && !hasMap) return null
 

--- a/src/components/roastery/RoasteryPageHeader.tsx
+++ b/src/components/roastery/RoasteryPageHeader.tsx
@@ -1,0 +1,20 @@
+import { Suspense } from 'react'
+import { FilterPanel } from './FilterPanel'
+import type { FilterParams, SortOption } from '@/types/roastery'
+
+interface Props {
+  filter: FilterParams
+  sort: SortOption
+  isLoggedIn: boolean
+}
+
+export function RoasteryPageHeader({ filter, sort, isLoggedIn }: Props) {
+  return (
+    <div className="flex flex-col gap-4">
+      <h1 className="text-xl font-semibold">로스터리</h1>
+      <Suspense fallback={null}>
+        <FilterPanel filter={filter} sort={sort} isLoggedIn={isLoggedIn} />
+      </Suspense>
+    </div>
+  )
+}

--- a/src/components/roastery/map/RoasteryMapLayout.tsx
+++ b/src/components/roastery/map/RoasteryMapLayout.tsx
@@ -35,6 +35,7 @@ interface Props {
   selectedDetail: SelectedRoasteryData | null
   isLoggedIn: boolean
   activeRegions: string[]
+  listUrl: string
 }
 
 // ─── Component ───────────────────────────────────────────────────────────────
@@ -44,6 +45,7 @@ export function RoasteryMapLayout({
   selectedDetail,
   isLoggedIn,
   activeRegions,
+  listUrl,
 }: Props) {
   const router = useRouter()
   const searchParams = useSearchParams()
@@ -165,6 +167,13 @@ export function RoasteryMapLayout({
               <>
                 {/* List panel header */}
                 <div className="flex items-center justify-between px-4 py-3 border-b shrink-0">
+                  <Link
+                    href={listUrl}
+                    className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
+                  >
+                    <ChevronLeft className="size-4" />
+                    목록으로
+                  </Link>
                   <span className="text-sm text-muted-foreground">
                     {roasteries.length}개 로스터리
                   </span>
@@ -213,6 +222,15 @@ export function RoasteryMapLayout({
   // ─── Mobile Layout ───────────────────────────────────────────────────────────
   return (
     <div className="flex flex-col">
+      {/* Back to list */}
+      <Link
+        href={listUrl}
+        className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors mb-3 self-start"
+      >
+        <ChevronLeft className="size-4" />
+        목록으로
+      </Link>
+
       {/* View toggle */}
       <div className="flex rounded-lg border overflow-hidden self-center mb-4">
         <button

--- a/src/components/roastery/map/RoasteryMapLayout.tsx
+++ b/src/components/roastery/map/RoasteryMapLayout.tsx
@@ -1,0 +1,261 @@
+'use client'
+
+import { useState, useMemo, useCallback } from 'react'
+import dynamic from 'next/dynamic'
+import Link from 'next/link'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { X, List, MapPin, ChevronLeft, ChevronRight, ArrowUpRight } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { RoasteryGrid } from '@/components/roastery/RoasteryGrid'
+import { RoasteryDetail } from '@/components/roastery/RoasteryDetail'
+import { useMediaQuery } from '@/hooks/useMediaQuery'
+import type { RoasteryWithStats, RoasteryDetail as RoasteryDetailType } from '@/types/roastery'
+import type { RatingListItem, RatingSortOption } from '@/types/rating'
+import type { MapMarkerData } from './RoasteryMapView'
+
+// Naver Map을 SSR 없이 로드
+const RoasteryMapView = dynamic(
+  () => import('./RoasteryMapView').then((m) => ({ default: m.RoasteryMapView })),
+  { ssr: false }
+)
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface SelectedRoasteryData {
+  roastery: RoasteryDetailType
+  isBookmarked: boolean
+  userRating?: { score: number; comment?: string }
+  initialRatings: RatingListItem[]
+  initialNextCursor: string | null
+  initialSort: RatingSortOption
+}
+
+interface Props {
+  roasteries: RoasteryWithStats[]
+  selectedDetail: SelectedRoasteryData | null
+  isLoggedIn: boolean
+  activeRegions: string[]
+}
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export function RoasteryMapLayout({
+  roasteries,
+  selectedDetail,
+  isLoggedIn,
+  activeRegions,
+}: Props) {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const isDesktop = useMediaQuery('(min-width: 768px)')
+
+  const [hoveredId, setHoveredId] = useState<string | undefined>()
+  const [panelOpen, setPanelOpen] = useState(true)
+  const [mobileView, setMobileView] = useState<'list' | 'map'>('list')
+  const [snapId, setSnapId] = useState<string | undefined>() // mobile map marker tap
+
+  const selectedId = selectedDetail?.roastery.id
+
+  // Extract markers from roasteries (locations with valid coordinates)
+  const markers = useMemo<MapMarkerData[]>(() => {
+    const result: MapMarkerData[] = []
+    for (const r of roasteries) {
+      for (const loc of r.locations) {
+        if (loc.lat !== null && loc.lng !== null) {
+          result.push({
+            roasteryId: r.id,
+            roasteryName: r.name,
+            lat: loc.lat,
+            lng: loc.lng,
+            isPrimary: loc.isPrimary,
+          })
+        }
+      }
+    }
+    return result
+  }, [roasteries])
+
+  const snapRoastery = useMemo(
+    () => (snapId ? roasteries.find((r) => r.id === snapId) : undefined),
+    [snapId, roasteries]
+  )
+
+  // URL helpers
+  const buildUrl = useCallback(
+    (id: string | null) => {
+      const p = new URLSearchParams(searchParams.toString())
+      if (id) p.set('id', id)
+      else p.delete('id')
+      return `/roasteries?${p.toString()}`
+    },
+    [searchParams]
+  )
+
+  const selectRoastery = useCallback(
+    (roasteryId: string) => {
+      if (isDesktop) {
+        setPanelOpen(true)
+        router.push(buildUrl(roasteryId), { scroll: false })
+      } else {
+        // mobile map: show snap card
+        setSnapId(roasteryId)
+      }
+    },
+    [isDesktop, router, buildUrl]
+  )
+
+  const clearSelection = useCallback(() => {
+    router.push(buildUrl(null), { scroll: false })
+    setSnapId(undefined)
+  }, [router, buildUrl])
+
+  const handleCardClick = useCallback(
+    (roasteryId: string) => {
+      if (isDesktop) {
+        setPanelOpen(true)
+        router.push(buildUrl(roasteryId), { scroll: false })
+      }
+      // mobile list: navigate to detail page directly
+    },
+    [isDesktop, router, buildUrl]
+  )
+
+  // ─── Desktop Layout ─────────────────────────────────────────────────────────
+  if (isDesktop) {
+    return (
+      <div className="flex gap-0 h-[calc(100vh-120px)] min-h-[500px]">
+        {/* Left panel */}
+        {panelOpen && (
+          <div className="w-[360px] xl:w-[420px] shrink-0 flex flex-col border-r overflow-hidden">
+            {selectedDetail ? (
+              <>
+                {/* Detail panel header */}
+                <div className="flex items-center justify-between px-4 py-3 border-b shrink-0">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="gap-1 text-muted-foreground"
+                    onClick={clearSelection}
+                  >
+                    <ChevronLeft className="size-4" />
+                    목록
+                  </Button>
+                  <Link href={`/roasteries/${selectedDetail.roastery.id}`}>
+                    <Button variant="outline" size="sm" className="gap-1">
+                      자세히 보기
+                      <ArrowUpRight className="size-3.5" />
+                    </Button>
+                  </Link>
+                </div>
+                {/* Detail content */}
+                <div className="flex-1 overflow-y-auto p-4">
+                  <RoasteryDetail
+                    roastery={selectedDetail.roastery}
+                    isLoggedIn={isLoggedIn}
+                    userRating={selectedDetail.userRating}
+                    isBookmarked={selectedDetail.isBookmarked}
+                    initialRatings={selectedDetail.initialRatings}
+                    initialNextCursor={selectedDetail.initialNextCursor}
+                    initialSort={selectedDetail.initialSort}
+                    hideBackButton
+                  />
+                </div>
+              </>
+            ) : (
+              <>
+                {/* List panel header */}
+                <div className="flex items-center justify-between px-4 py-3 border-b shrink-0">
+                  <span className="text-sm text-muted-foreground">
+                    {roasteries.length}개 로스터리
+                  </span>
+                </div>
+                {/* List content */}
+                <div className="flex-1 overflow-y-auto">
+                  <RoasteryGrid
+                    roasteries={roasteries}
+                    activeRegions={activeRegions}
+                    variant="landscape"
+                    onCardClick={handleCardClick}
+                  />
+                </div>
+              </>
+            )}
+          </div>
+        )}
+
+        {/* Panel toggle button */}
+        <button
+          onClick={() => setPanelOpen((v) => !v)}
+          className="relative z-10 flex items-center justify-center w-6 bg-background border-y border-r hover:bg-muted transition-colors shrink-0"
+          aria-label={panelOpen ? '목록 닫기' : '목록 열기'}
+        >
+          {panelOpen ? (
+            <ChevronLeft className="size-3.5 text-muted-foreground" />
+          ) : (
+            <ChevronRight className="size-3.5 text-muted-foreground" />
+          )}
+        </button>
+
+        {/* Map */}
+        <div className="flex-1 relative">
+          <RoasteryMapView
+            markers={markers}
+            selectedId={selectedId}
+            hoveredId={hoveredId}
+            onMarkerClick={selectRoastery}
+            onMarkerHover={setHoveredId}
+          />
+        </div>
+      </div>
+    )
+  }
+
+  // ─── Mobile Layout ───────────────────────────────────────────────────────────
+  return (
+    <div className="flex flex-col">
+      {/* View toggle */}
+      <div className="flex rounded-lg border overflow-hidden self-center mb-4">
+        <button
+          onClick={() => setMobileView('list')}
+          className={`flex items-center gap-1.5 px-4 py-2 text-sm font-medium transition-colors ${mobileView === 'list' ? 'bg-primary text-primary-foreground' : 'bg-background text-muted-foreground hover:bg-muted'}`}
+        >
+          <List className="size-4" />
+          목록
+        </button>
+        <button
+          onClick={() => setMobileView('map')}
+          className={`flex items-center gap-1.5 px-4 py-2 text-sm font-medium transition-colors ${mobileView === 'map' ? 'bg-primary text-primary-foreground' : 'bg-background text-muted-foreground hover:bg-muted'}`}
+        >
+          <MapPin className="size-4" />
+          지도
+        </button>
+      </div>
+
+      {mobileView === 'list' ? (
+        <RoasteryGrid roasteries={roasteries} activeRegions={activeRegions} />
+      ) : (
+        <div className="relative" style={{ height: 'calc(100vh - 260px)', minHeight: 400 }}>
+          <RoasteryMapView markers={markers} selectedId={snapId} onMarkerClick={selectRoastery} />
+
+          {/* Snap card */}
+          {snapRoastery && (
+            <div className="absolute bottom-4 left-4 right-4 bg-background rounded-xl shadow-lg border p-4">
+              <button
+                className="absolute top-2 right-2 text-muted-foreground hover:text-foreground"
+                onClick={() => setSnapId(undefined)}
+              >
+                <X className="size-4" />
+              </button>
+              <Link href={`/roasteries/${snapRoastery.id}`} className="flex flex-col gap-1">
+                <p className="font-medium text-sm pr-6">{snapRoastery.name}</p>
+                <p className="text-xs text-muted-foreground">
+                  {snapRoastery.locations[0]?.address ?? ''}
+                </p>
+              </Link>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/roastery/map/RoasteryMapLayout.tsx
+++ b/src/components/roastery/map/RoasteryMapLayout.tsx
@@ -1,0 +1,745 @@
+'use client'
+
+import {
+  useState,
+  useMemo,
+  useCallback,
+  useRef,
+  useEffect,
+  type ReactNode,
+  type TouchEvent,
+} from 'react'
+import dynamic from 'next/dynamic'
+import Link from 'next/link'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { AnimatePresence, motion } from 'framer-motion'
+import { X, List, MapPin, ChevronLeft, ChevronRight, Plus, Minus, LocateFixed } from 'lucide-react'
+import { toast } from 'sonner'
+import { RoasteryGrid } from '@/components/roastery/RoasteryGrid'
+import { RoasteryCard } from '@/components/roastery/RoasteryCard'
+import { RoasteryDetail } from '@/components/roastery/RoasteryDetail'
+import { FilterPanel } from '@/components/roastery/FilterPanel'
+import { useMediaQuery } from '@/hooks/useMediaQuery'
+import { getNearbyLocations, formatDistance } from '@/lib/geo'
+import type { NearbyLocation } from '@/lib/geo'
+import type {
+  RoasteryWithStats,
+  RoasteryDetail as RoasteryDetailType,
+  FilterParams,
+  SortOption,
+} from '@/types/roastery'
+import type { RatingListItem, RatingSortOption } from '@/types/rating'
+import type { MapMarkerData, ZoomHandle } from './RoasteryMapView'
+import { staggerContainerVariants, fadeUpVariants } from '@/lib/motion'
+
+// Naver Map을 SSR 없이 로드
+const RoasteryMapView = dynamic(
+  () => import('./RoasteryMapView').then((m) => ({ default: m.RoasteryMapView })),
+  { ssr: false }
+)
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface SelectedRoasteryData {
+  roastery: RoasteryDetailType
+  isBookmarked: boolean
+  userRating?: { score: number; comment?: string }
+  initialRatings: RatingListItem[]
+  initialNextCursor: string | null
+  initialSort: RatingSortOption
+}
+
+interface Props {
+  roasteries: RoasteryWithStats[]
+  selectedDetail: SelectedRoasteryData | null
+  isLoggedIn: boolean
+  activeRegions: string[]
+  isFiltered: boolean
+  mobileHeader?: ReactNode
+  listUrl: string
+  filter: FilterParams
+  sort: SortOption
+}
+
+// ─── Session-level card position memory ──────────────────────────────────────
+
+let savedCarouselIndex = 0
+let savedSnapId: string | undefined = undefined
+let savedNearbyMode = false
+let savedNearbyLocations: NearbyLocation[] = []
+let savedNearbyIndex = 0
+let savedNearbySelectedId: string | undefined = undefined
+let savedUserLocation: { lat: number; lng: number } | null = null
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export function RoasteryMapLayout({
+  roasteries,
+  selectedDetail,
+  isLoggedIn,
+  activeRegions,
+  isFiltered,
+  mobileHeader,
+  listUrl,
+  filter,
+  sort,
+}: Props) {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const isDesktop = useMediaQuery('(min-width: 1024px)')
+  const isXL = useMediaQuery('(min-width: 1280px)')
+  const overlayWidthPx = isXL ? 400 : 360
+
+  const [hoveredId, setHoveredId] = useState<string | undefined>()
+  const [snapId, setSnapId] = useState<string | undefined>(
+    selectedDetail?.roastery.id ?? savedSnapId
+  )
+  const [carouselIndex, setCarouselIndex] = useState(savedCarouselIndex)
+  const [nearbyMode, setNearbyMode] = useState(savedNearbyMode)
+  const [nearbyLocations, setNearbyLocations] = useState<NearbyLocation[]>(savedNearbyLocations)
+  const [nearbyIndex, setNearbyIndex] = useState(savedNearbyIndex)
+  const [nearbySelectedId, setNearbySelectedId] = useState<string | undefined>(
+    savedNearbySelectedId
+  )
+  const [carouselDismissed, setCarouselDismissed] = useState(false)
+  const [userLocation, setUserLocation] = useState<{ lat: number; lng: number } | null>(
+    savedUserLocation
+  )
+  const [isGpsLoading, setIsGpsLoading] = useState(false)
+  const [clickedAddress, setClickedAddress] = useState<string | null>(null)
+  const touchStartX = useRef(0)
+  const zoomRef = useRef<ZoomHandle | null>(null)
+  const handleMapReady = useCallback((handle: ZoomHandle) => {
+    zoomRef.current = handle
+  }, [])
+
+  const handleGpsClick = useCallback(() => {
+    if (nearbyMode) {
+      setNearbyMode(false)
+      setNearbyLocations([])
+      setNearbyIndex(0)
+      setNearbySelectedId(undefined)
+      setUserLocation(null)
+      return
+    }
+    if (!navigator.geolocation) return
+    setIsGpsLoading(true)
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        const { latitude: lat, longitude: lng } = pos.coords
+        const nearby = getNearbyLocations(roasteries, lat, lng)
+        setUserLocation({ lat, lng })
+        setNearbyLocations(nearby)
+        setNearbyIndex(0)
+        setNearbySelectedId(nearby[0]?.roastery.id)
+        setNearbyMode(true)
+        zoomRef.current?.panTo(lat, lng, 14)
+        zoomRef.current?.skipNextFlyTo()
+        setIsGpsLoading(false)
+      },
+      (err) => {
+        setIsGpsLoading(false)
+        if (err.code === err.PERMISSION_DENIED) {
+          toast.error('위치 권한이 필요해요', {
+            description: '브라우저 설정에서 위치 접근을 허용해주세요.',
+          })
+        } else {
+          toast.error('위치를 가져올 수 없어요', { description: '잠시 후 다시 시도해주세요.' })
+        }
+      }
+    )
+  }, [nearbyMode, roasteries])
+
+  useEffect(() => {
+    savedCarouselIndex = carouselIndex
+  }, [carouselIndex])
+  useEffect(() => {
+    savedSnapId = snapId
+  }, [snapId])
+  useEffect(() => {
+    savedNearbyMode = nearbyMode
+  }, [nearbyMode])
+  useEffect(() => {
+    savedNearbyLocations = nearbyLocations
+  }, [nearbyLocations])
+  useEffect(() => {
+    savedNearbyIndex = nearbyIndex
+  }, [nearbyIndex])
+  useEffect(() => {
+    savedNearbySelectedId = nearbySelectedId
+  }, [nearbySelectedId])
+  useEffect(() => {
+    savedUserLocation = userLocation
+  }, [userLocation])
+
+  const selectedId = selectedDetail?.roastery.id
+
+  const markers = useMemo<MapMarkerData[]>(() => {
+    const result: MapMarkerData[] = []
+    for (const r of roasteries) {
+      for (const loc of r.locations) {
+        if (loc.lat !== null && loc.lng !== null) {
+          result.push({
+            roasteryId: r.id,
+            roasteryName: r.name,
+            lat: loc.lat,
+            lng: loc.lng,
+            isPrimary: loc.isPrimary,
+            address: loc.address,
+          })
+        }
+      }
+    }
+    return result
+  }, [roasteries])
+
+  const nearbyMarkers = useMemo<MapMarkerData[]>(
+    () =>
+      nearbyLocations.map((item) => ({
+        roasteryId: item.roastery.id,
+        roasteryName: item.roastery.name,
+        lat: item.location.lat!,
+        lng: item.location.lng!,
+        isPrimary: item.location.isPrimary,
+        address: item.location.address,
+      })),
+    [nearbyLocations]
+  )
+
+  // 필터 결과가 바뀌면 캐러셀 인덱스 초기화 (React 공식 파생 상태 패턴)
+  const roasteriesKey = useMemo(() => roasteries.map((r) => r.id).join(','), [roasteries])
+  const [prevRoasteriesKey, setPrevRoasteriesKey] = useState(roasteriesKey)
+  if (prevRoasteriesKey !== roasteriesKey) {
+    setPrevRoasteriesKey(roasteriesKey)
+    setCarouselIndex(0)
+    setCarouselDismissed(false)
+  }
+
+  const snapRoastery = useMemo(
+    () => (snapId ? roasteries.find((r) => r.id === snapId) : undefined),
+    [snapId, roasteries]
+  )
+
+  const carouselRoastery = isFiltered ? (roasteries[carouselIndex] ?? null) : null
+
+  // 모바일에서 지도에 넘기는 selectedId (nearby: 카드 스와이프 시에만 fly-to)
+  const mobileSelectedId = nearbyMode
+    ? nearbySelectedId
+    : isFiltered
+      ? carouselDismissed
+        ? undefined
+        : carouselRoastery?.id
+      : snapId
+
+  const buildUrl = useCallback(
+    (id: string | null) => {
+      const p = new URLSearchParams(searchParams.toString())
+      if (id) p.set('id', id)
+      else p.delete('id')
+      return `/roasteries?${p.toString()}`
+    },
+    [searchParams]
+  )
+
+  const selectRoastery = useCallback(
+    (roasteryId: string, lat: number, lng: number) => {
+      // 클릭한 마커의 주소 추적 (스냅 카드용)
+      const clicked = markers.find(
+        (m) => m.roasteryId === roasteryId && m.lat === lat && m.lng === lng
+      )
+      setClickedAddress(clicked?.address ?? null)
+
+      if (isDesktop) {
+        if (nearbyMode) {
+          setNearbySelectedId(roasteryId)
+          const idx = nearbyLocations.findIndex((item) => item.roastery.id === roasteryId)
+          if (idx !== -1) setNearbyIndex(idx)
+        }
+        router.push(buildUrl(roasteryId), { scroll: false })
+      } else if (nearbyMode) {
+        router.push(`/roasteries/${roasteryId}`)
+      } else if (isFiltered) {
+        const idx = roasteries.findIndex((r) => r.id === roasteryId)
+        if (idx !== -1) {
+          setCarouselIndex(idx)
+          setCarouselDismissed(false)
+        }
+      } else {
+        setSnapId(roasteryId)
+      }
+    },
+    [isDesktop, nearbyMode, nearbyLocations, isFiltered, roasteries, markers, router, buildUrl]
+  )
+
+  const clearSelection = useCallback(() => {
+    router.push(buildUrl(null), { scroll: false })
+    setSnapId(undefined)
+    setNearbySelectedId(undefined)
+  }, [router, buildUrl])
+
+  const handleCardClick = useCallback(
+    (roasteryId: string) => {
+      if (isDesktop && !nearbyMode) {
+        zoomRef.current?.clearSelection()
+        router.push(buildUrl(roasteryId), { scroll: false })
+      }
+    },
+    [isDesktop, nearbyMode, router, buildUrl]
+  )
+
+  const handleNearbyCardClick = useCallback(
+    (roasteryId: string, lat: number, lng: number) => {
+      const idx = nearbyLocations.findIndex(
+        (item) =>
+          item.roastery.id === roasteryId && item.location.lat === lat && item.location.lng === lng
+      )
+      if (idx === -1) return
+      const item = nearbyLocations[idx]!
+      setNearbyIndex(idx)
+      setNearbySelectedId(roasteryId)
+      zoomRef.current?.panTo(item.location.lat!, item.location.lng!, 15)
+    },
+    [nearbyLocations]
+  )
+
+  const handleTouchStart = useCallback((e: TouchEvent<HTMLDivElement>) => {
+    touchStartX.current = e.touches[0].clientX
+  }, [])
+
+  const handleTouchEnd = useCallback(
+    (e: TouchEvent<HTMLDivElement>) => {
+      const delta = e.changedTouches[0].clientX - touchStartX.current
+      if (delta < -50 && carouselIndex < roasteries.length - 1) {
+        setCarouselIndex((i) => i + 1)
+      } else if (delta > 50 && carouselIndex > 0) {
+        setCarouselIndex((i) => i - 1)
+      }
+    },
+    [carouselIndex, roasteries.length]
+  )
+
+  // ─── Desktop Layout ─────────────────────────────────────────────────────────
+  if (isDesktop) {
+    return (
+      <div className="relative flex gap-0 h-full min-h-[500px]">
+        {/* Left panel — 항상 리스트 표시 */}
+        <div className="w-[360px] xl:w-[400px] shrink-0 flex flex-col border-r overflow-hidden">
+          {/* 검색 */}
+          <div className="shrink-0 px-4 py-4 border-b">
+            <FilterPanel filter={filter} sort={sort} isLoggedIn={isLoggedIn} variant="map-search" />
+          </div>
+          <div className="flex items-center justify-between px-4 py-3 border-b shrink-0">
+            {nearbyMode ? (
+              <span className="text-sm text-primary font-medium flex items-center gap-1">
+                <LocateFixed className="size-3" />내 주변 {nearbyLocations.length}개 매장
+              </span>
+            ) : (
+              <span className="text-sm text-muted-foreground">{roasteries.length}개 로스터리</span>
+            )}
+            <div className="flex items-center gap-0.5 rounded-lg bg-muted p-0.5">
+              <Link
+                href={listUrl}
+                className="flex items-center justify-center w-7 h-6 rounded-md text-muted-foreground hover:text-foreground transition-colors"
+                aria-label="목록으로 보기"
+              >
+                <List className="size-3.5" />
+              </Link>
+              <span className="flex items-center justify-center w-7 h-6 rounded-md bg-background shadow-sm text-foreground">
+                <MapPin className="size-3.5" />
+              </span>
+            </div>
+          </div>
+          <div className="flex-1 overflow-y-auto px-4 pt-2">
+            {nearbyMode && nearbyLocations.length === 0 ? (
+              <div className="py-12 flex flex-col items-center gap-2 text-center">
+                <p className="text-sm font-medium">주변 10km 내 매장이 없어요</p>
+                <p className="text-xs text-muted-foreground">다른 지역에서 다시 시도해보세요</p>
+              </div>
+            ) : nearbyMode ? (
+              <motion.div
+                variants={staggerContainerVariants}
+                initial="hidden"
+                animate="visible"
+                className="grid grid-cols-1 gap-4"
+              >
+                {nearbyLocations.map((item, i) => (
+                  <motion.div
+                    key={`${item.roastery.id}-${item.location.lat}-${item.location.lng}`}
+                    variants={fadeUpVariants}
+                  >
+                    <RoasteryCard
+                      roastery={item.roastery}
+                      priority={i < 4}
+                      variant="landscape"
+                      nearbyAddress={item.location.address ?? undefined}
+                      nearbyDistance={item.distance}
+                      onCardClick={() =>
+                        handleNearbyCardClick(
+                          item.roastery.id,
+                          item.location.lat!,
+                          item.location.lng!
+                        )
+                      }
+                    />
+                  </motion.div>
+                ))}
+              </motion.div>
+            ) : (
+              <RoasteryGrid
+                roasteries={roasteries}
+                activeRegions={activeRegions}
+                variant="landscape"
+                onCardClick={handleCardClick}
+                singleCol
+              />
+            )}
+          </div>
+        </div>
+
+        {/* Map */}
+        <div className="flex-1 relative">
+          <RoasteryMapView
+            markers={nearbyMode ? nearbyMarkers : markers}
+            selectedId={nearbyMode ? nearbySelectedId : selectedId}
+            primarySelectedId={selectedDetail?.roastery.id}
+            hoveredId={hoveredId}
+            onMarkerClick={selectRoastery}
+            onMarkerHover={setHoveredId}
+            onMapReady={handleMapReady}
+            showZoomControl={false}
+            userLocation={userLocation}
+            overlayWidth={selectedDetail ? overlayWidthPx : 0}
+          />
+          {/* 필터 칩 오버레이 */}
+          <div className="absolute top-4 left-4 right-14 z-10">
+            <div className="flex items-center gap-2 w-max">
+              <FilterPanel
+                filter={filter}
+                sort={sort}
+                isLoggedIn={isLoggedIn}
+                variant="map-pills"
+              />
+              <button
+                onClick={handleGpsClick}
+                disabled={isGpsLoading}
+                className={`inline-flex cursor-pointer items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm transition-colors shadow-md whitespace-nowrap disabled:opacity-50 ${
+                  nearbyMode
+                    ? 'border-foreground bg-foreground text-background'
+                    : 'border-border bg-background hover:border-foreground/40'
+                }`}
+              >
+                <LocateFixed className="size-3.5" />내 주변
+              </button>
+            </div>
+          </div>
+          {/* 줌 · GPS 버튼 */}
+          <div className="absolute top-4 right-4 z-10 flex flex-col items-center gap-2">
+            <div className="flex flex-col rounded-lg border bg-background shadow-md overflow-hidden">
+              <button
+                onClick={() => zoomRef.current?.zoomIn()}
+                className="flex items-center justify-center w-9 h-9 hover:bg-muted transition-colors"
+                aria-label="확대"
+              >
+                <Plus className="size-4" />
+              </button>
+              <div className="h-px bg-border" />
+              <button
+                onClick={() => zoomRef.current?.zoomOut()}
+                className="flex items-center justify-center w-9 h-9 hover:bg-muted transition-colors"
+                aria-label="축소"
+              >
+                <Minus className="size-4" />
+              </button>
+            </div>
+            <button
+              onClick={handleGpsClick}
+              disabled={isGpsLoading}
+              className={`flex items-center justify-center w-9 h-9 rounded-lg border shadow-md transition-colors disabled:opacity-50 ${nearbyMode ? 'bg-foreground text-background border-foreground hover:bg-foreground/90' : 'bg-background hover:bg-muted'}`}
+              aria-label="내 주변 로스터리"
+            >
+              <LocateFixed className="size-4" />
+            </button>
+          </div>
+
+          {/* nearby 모드: 결과 없음 */}
+
+          {/* 상세 패널 오버레이 */}
+          <AnimatePresence>
+            {selectedDetail && (
+              <motion.div
+                className="absolute top-[60px] bottom-3 left-3 w-[360px] xl:w-[400px] bg-background z-20 shadow-2xl rounded-xl flex flex-col overflow-hidden"
+                initial={{ x: -10, opacity: 0 }}
+                animate={{ x: 0, opacity: 1 }}
+                exit={{ x: -10, opacity: 0 }}
+                transition={{ duration: 0.18, ease: 'easeOut' }}
+              >
+                <div className="flex items-center justify-end px-3 py-2 shrink-0">
+                  <button
+                    onClick={clearSelection}
+                    className="flex items-center justify-center w-7 h-7 rounded-full hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+                    aria-label="닫기"
+                  >
+                    <X className="size-4" />
+                  </button>
+                </div>
+                <div className="flex-1 overflow-y-auto px-4 pb-4">
+                  <RoasteryDetail
+                    roastery={selectedDetail.roastery}
+                    isLoggedIn={isLoggedIn}
+                    userRating={selectedDetail.userRating}
+                    isBookmarked={selectedDetail.isBookmarked}
+                    initialRatings={selectedDetail.initialRatings}
+                    initialNextCursor={selectedDetail.initialNextCursor}
+                    initialSort={selectedDetail.initialSort}
+                    hideBackButton
+                  />
+                </div>
+              </motion.div>
+            )}
+          </AnimatePresence>
+        </div>
+      </div>
+    )
+  }
+
+  // ─── Mobile Layout ───────────────────────────────────────────────────────────
+  return (
+    <div
+      className="relative flex flex-col overflow-hidden"
+      style={{
+        height: 'calc(100svh - var(--bottom-tab-height) - env(safe-area-inset-bottom, 0px))',
+      }}
+    >
+      {/* 페이지 헤더 (h1 + 필터) */}
+      {mobileHeader && (
+        <div className="shrink-0 bg-background border-b pt-8 pb-3 px-[var(--page-padding)]">
+          {mobileHeader}
+        </div>
+      )}
+
+      {/* 지도 */}
+      <div className="flex-1 min-h-0 relative">
+        <RoasteryMapView
+          markers={nearbyMode ? nearbyMarkers : markers}
+          selectedId={mobileSelectedId}
+          primarySelectedId={mobileSelectedId}
+          onMarkerClick={selectRoastery}
+          showZoomControl={false}
+          onMapReady={handleMapReady}
+          userLocation={userLocation}
+        />
+        <div className="absolute top-4 right-4 z-10 flex flex-col items-center gap-2">
+          <div className="flex flex-col rounded-lg border bg-background shadow-md overflow-hidden">
+            <button
+              onClick={() => zoomRef.current?.zoomIn()}
+              className="flex items-center justify-center w-9 h-9 hover:bg-muted transition-colors"
+              aria-label="확대"
+            >
+              <Plus className="size-4" />
+            </button>
+            <div className="h-px bg-border" />
+            <button
+              onClick={() => zoomRef.current?.zoomOut()}
+              className="flex items-center justify-center w-9 h-9 hover:bg-muted transition-colors"
+              aria-label="축소"
+            >
+              <Minus className="size-4" />
+            </button>
+          </div>
+          <button
+            onClick={handleGpsClick}
+            disabled={isGpsLoading}
+            className={`flex items-center justify-center w-9 h-9 rounded-lg border shadow-md transition-colors disabled:opacity-50 ${nearbyMode ? 'bg-foreground text-background border-foreground hover:bg-foreground/90' : 'bg-background hover:bg-muted'}`}
+            aria-label="내 주변 로스터리"
+          >
+            <LocateFixed className="size-4" />
+          </button>
+        </div>
+      </div>
+
+      {/* FAB + 캐러셀 / 스냅 카드 */}
+      <div
+        className="absolute left-4 right-4 z-50 flex flex-col gap-4 items-end pointer-events-none"
+        style={{ bottom: '20px' }}
+      >
+        <Link
+          href={listUrl}
+          className="pointer-events-auto flex items-center justify-center w-14 h-14 rounded-full bg-primary text-primary-foreground shadow-lg hover:bg-primary/90 transition-colors"
+          aria-label="목록으로 보기"
+        >
+          <List className="size-5" />
+        </Link>
+
+        {/* 내 주변 모드: 결과 없음 */}
+        {nearbyMode && nearbyLocations.length === 0 && (
+          <div className="pointer-events-auto w-full bg-background rounded-2xl shadow-lg border px-4 py-4 flex items-center justify-between">
+            <p className="text-sm text-muted-foreground">주변 10km 내 매장이 없어요</p>
+            <button
+              onClick={() => {
+                setNearbyMode(false)
+                setUserLocation(null)
+              }}
+              className="text-muted-foreground hover:text-foreground"
+            >
+              <X className="size-4" />
+            </button>
+          </div>
+        )}
+
+        {/* 내 주변 모드: 캐러셀 카드 */}
+        {nearbyMode &&
+          nearbyLocations.length > 0 &&
+          (() => {
+            const item = nearbyLocations[nearbyIndex]
+            return item ? (
+              <div
+                className="pointer-events-auto relative w-full bg-background rounded-2xl shadow-lg border px-4 pt-5 pb-0"
+                onTouchStart={handleTouchStart}
+                onTouchEnd={(e) => {
+                  const delta = e.changedTouches[0].clientX - touchStartX.current
+                  if (delta < -50 && nearbyIndex < nearbyLocations.length - 1) {
+                    const next = nearbyIndex + 1
+                    const nextItem = nearbyLocations[next]!
+                    setNearbyIndex(next)
+                    setNearbySelectedId(nextItem.roastery.id)
+                    zoomRef.current?.panTo(nextItem.location.lat!, nextItem.location.lng!, 15)
+                  } else if (delta > 50 && nearbyIndex > 0) {
+                    const prev = nearbyIndex - 1
+                    const prevItem = nearbyLocations[prev]!
+                    setNearbyIndex(prev)
+                    setNearbySelectedId(prevItem.roastery.id)
+                    zoomRef.current?.panTo(prevItem.location.lat!, prevItem.location.lng!, 15)
+                  }
+                }}
+              >
+                <button
+                  className="absolute top-3 right-3 text-muted-foreground hover:text-foreground"
+                  onClick={() => {
+                    setNearbyMode(false)
+                    setNearbyLocations([])
+                    setNearbyIndex(0)
+                    setNearbySelectedId(undefined)
+                    setUserLocation(null)
+                  }}
+                >
+                  <X className="size-4" />
+                </button>
+                {nearbyIndex > 0 && (
+                  <button
+                    className="absolute left-0 top-1/2 -translate-x-1/2 -translate-y-1/2 flex items-center justify-center w-7 h-7 rounded-full bg-background border shadow-sm"
+                    onClick={() => {
+                      const prev = nearbyIndex - 1
+                      setNearbyIndex(prev)
+                      setNearbySelectedId(nearbyLocations[prev]?.roastery.id)
+                    }}
+                    aria-label="이전 매장"
+                  >
+                    <ChevronLeft className="size-3 text-muted-foreground" />
+                  </button>
+                )}
+                {nearbyIndex < nearbyLocations.length - 1 && (
+                  <button
+                    className="absolute right-0 top-1/2 translate-x-1/2 -translate-y-1/2 flex items-center justify-center w-7 h-7 rounded-full bg-background border shadow-sm"
+                    onClick={() => {
+                      const next = nearbyIndex + 1
+                      setNearbyIndex(next)
+                      setNearbySelectedId(nearbyLocations[next]?.roastery.id)
+                    }}
+                    aria-label="다음 매장"
+                  >
+                    <ChevronRight className="size-3 text-muted-foreground" />
+                  </button>
+                )}
+                <Link
+                  href={`/roasteries/${item.roastery.id}`}
+                  className="flex w-full flex-col gap-1 pr-6"
+                >
+                  <p className="font-medium text-base leading-tight">
+                    {item.roastery.name}
+                    <span className="ml-1.5 text-xs text-primary font-medium">
+                      {formatDistance(item.distance)}
+                    </span>
+                  </p>
+                  <p className="text-sm text-muted-foreground">{item.location.address}</p>
+                </Link>
+                <div className="flex h-4 items-center justify-center">
+                  {nearbyLocations.length > 1 && (
+                    <span className="text-xs text-muted-foreground">
+                      {nearbyIndex + 1} / {nearbyLocations.length}
+                    </span>
+                  )}
+                </div>
+              </div>
+            ) : null
+          })()}
+
+        {/* 필터 활성: 캐러셀 카드 */}
+        {!nearbyMode && isFiltered && carouselRoastery && !carouselDismissed && (
+          <div
+            className="pointer-events-auto relative w-full bg-background rounded-2xl shadow-lg border px-4 pt-4 pb-0"
+            onTouchStart={handleTouchStart}
+            onTouchEnd={handleTouchEnd}
+          >
+            <button
+              className="absolute top-4 right-4 text-muted-foreground hover:text-foreground"
+              onClick={() => setCarouselDismissed(true)}
+            >
+              <X className="size-4" />
+            </button>
+            {carouselIndex > 0 && (
+              <button
+                className="absolute left-0 top-1/2 -translate-x-1/2 -translate-y-1/2 flex items-center justify-center w-7 h-7 rounded-full bg-background border shadow-sm"
+                onClick={() => setCarouselIndex((i) => i - 1)}
+                aria-label="이전 로스터리"
+              >
+                <ChevronLeft className="size-3 text-muted-foreground" />
+              </button>
+            )}
+            {carouselIndex < roasteries.length - 1 && (
+              <button
+                className="absolute right-0 top-1/2 translate-x-1/2 -translate-y-1/2 flex items-center justify-center w-7 h-7 rounded-full bg-background border shadow-sm"
+                onClick={() => setCarouselIndex((i) => i + 1)}
+                aria-label="다음 로스터리"
+              >
+                <ChevronRight className="size-3 text-muted-foreground" />
+              </button>
+            )}
+            <div>
+              <Link href={`/roasteries/${carouselRoastery.id}`} className="flex flex-col gap-1">
+                <p className="font-medium text-base">{carouselRoastery.name}</p>
+                <p className="text-sm text-muted-foreground">
+                  {carouselRoastery.locations[0]?.address ?? ''}
+                </p>
+              </Link>
+            </div>
+            <div className="flex h-4 items-center justify-center">
+              {roasteries.length > 1 && (
+                <span className="text-xs text-muted-foreground">
+                  {carouselIndex + 1} / {roasteries.length}
+                </span>
+              )}
+            </div>
+          </div>
+        )}
+
+        {/* 필터 없음: 기존 스냅 카드 */}
+        {!nearbyMode && !isFiltered && snapRoastery && (
+          <div className="pointer-events-auto w-full bg-background rounded-2xl shadow-lg border p-4 relative">
+            <button
+              className="absolute top-4 right-4 text-muted-foreground hover:text-foreground"
+              onClick={() => setSnapId(undefined)}
+            >
+              <X className="size-4" />
+            </button>
+            <Link href={`/roasteries/${snapRoastery.id}`} className="flex flex-col gap-1">
+              <p className="font-medium text-base pr-6">{snapRoastery.name}</p>
+              <p className="text-sm text-muted-foreground">
+                {clickedAddress ?? snapRoastery.locations[0]?.address ?? ''}
+              </p>
+            </Link>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/roastery/map/RoasteryMapView.tsx
+++ b/src/components/roastery/map/RoasteryMapView.tsx
@@ -1,0 +1,188 @@
+'use client'
+
+import { useEffect, useRef, useCallback, useState } from 'react'
+import Script from 'next/script'
+
+// ─── Minimal Naver Maps type declarations ────────────────────────────────────
+
+type NaverLatLng = object
+type NaverSize = object
+type NaverPoint = object
+
+interface NaverMapInstance {
+  setCenter(latLng: NaverLatLng): void
+  setZoom(zoom: number, animate?: boolean): void
+  fitBounds(bounds: object, opts?: object): void
+  destroy(): void
+}
+
+interface NaverMarkerInstance {
+  setIcon(icon: object): void
+  setZIndex(z: number): void
+  setMap(map: NaverMapInstance | null): void
+  getPosition(): NaverLatLng
+}
+
+interface NaverMapsAPI {
+  Map: new (el: HTMLElement, opts: object) => NaverMapInstance
+  Marker: new (opts: object) => NaverMarkerInstance
+  LatLng: new (lat: number, lng: number) => NaverLatLng
+  LatLngBounds: new (
+    sw?: NaverLatLng,
+    ne?: NaverLatLng
+  ) => {
+    extend(latLng: NaverLatLng): void
+    isEmpty(): boolean
+  }
+  Size: new (w: number, h: number) => NaverSize
+  Point: new (x: number, y: number) => NaverPoint
+  Event: {
+    addListener(target: object, type: string, fn: (...args: unknown[]) => void): object
+  }
+}
+
+declare global {
+  interface Window {
+    naver?: { maps: NaverMapsAPI }
+  }
+}
+
+// ─── Props & marker data ─────────────────────────────────────────────────────
+
+export interface MapMarkerData {
+  roasteryId: string
+  roasteryName: string
+  lat: number
+  lng: number
+  isPrimary: boolean
+}
+
+interface Props {
+  markers: MapMarkerData[]
+  selectedId?: string
+  hoveredId?: string
+  onMarkerClick: (roasteryId: string) => void
+  onMarkerHover?: (roasteryId: string | undefined) => void
+}
+
+// ─── Marker icon helper ───────────────────────────────────────────────────────
+
+function markerIcon(selected: boolean, hovered: boolean) {
+  const size = selected ? 28 : hovered ? 24 : 20
+  const bg = selected ? '#2563eb' : hovered ? '#3b82f6' : '#4b5563'
+  const half = size / 2
+  const nv = window.naver!
+  return {
+    content: `<div style="width:${size}px;height:${size}px;background:${bg};border:2px solid #fff;border-radius:50%;box-shadow:0 2px 6px rgba(0,0,0,0.3);cursor:pointer;transition:width .15s,height .15s,background .15s;"></div>`,
+    size: new nv.maps.Size(size, size),
+    anchor: new nv.maps.Point(half, half),
+  }
+}
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+const NCPKEY = process.env.NEXT_PUBLIC_NAVER_MAP_CLIENT_ID!
+
+export function RoasteryMapView({
+  markers,
+  selectedId,
+  hoveredId,
+  onMarkerClick,
+  onMarkerHover,
+}: Props) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const mapRef = useRef<NaverMapInstance | null>(null)
+  const markerMapRef = useRef<Map<string, NaverMarkerInstance[]>>(new Map())
+  const [mapReady, setMapReady] = useState(false)
+
+  const initMap = useCallback(() => {
+    if (!containerRef.current || mapRef.current || !window.naver?.maps) return
+    const nv = window.naver.maps
+
+    const map = new nv.Map(containerRef.current, {
+      center: new nv.LatLng(37.5665, 126.978),
+      zoom: 11,
+      mapTypeControl: false,
+      scaleControl: false,
+      logoControl: false,
+      mapDataControl: false,
+      zoomControl: true,
+      zoomControlOptions: { position: 3 /* TOP_RIGHT */ },
+    })
+
+    mapRef.current = map
+    setMapReady(true)
+  }, [])
+
+  const handleScriptLoad = useCallback(() => {
+    initMap()
+  }, [initMap])
+
+  // Sync markers whenever data or selection changes
+  useEffect(() => {
+    if (!mapReady || !mapRef.current || !window.naver?.maps) return
+    const nv = window.naver.maps
+    const map = mapRef.current
+    const markerMap = markerMapRef.current
+
+    // Clear existing markers
+    for (const list of markerMap.values()) {
+      for (const m of list) m.setMap(null)
+    }
+    markerMap.clear()
+
+    // Add fresh markers
+    for (const data of markers) {
+      const isSelected = data.roasteryId === selectedId
+      const isHovered = data.roasteryId === hoveredId
+
+      const marker = new nv.Marker({
+        position: new nv.LatLng(data.lat, data.lng),
+        map,
+        icon: markerIcon(isSelected, isHovered),
+        title: data.roasteryName,
+        zIndex: isSelected ? 100 : isHovered ? 50 : 10,
+      })
+
+      nv.Event.addListener(marker, 'click', () => onMarkerClick(data.roasteryId))
+      if (onMarkerHover) {
+        nv.Event.addListener(marker, 'mouseover', () => onMarkerHover(data.roasteryId))
+        nv.Event.addListener(marker, 'mouseout', () => onMarkerHover(undefined))
+      }
+
+      const existing = markerMap.get(data.roasteryId) ?? []
+      existing.push(marker)
+      markerMap.set(data.roasteryId, existing)
+    }
+
+    // Fit bounds if no selection
+    if (!selectedId && markers.length > 0) {
+      const nv2 = window.naver.maps
+      const bounds = new nv2.LatLngBounds()
+      for (const m of markers) bounds.extend(new nv2.LatLng(m.lat, m.lng))
+      if (!bounds.isEmpty()) map.fitBounds(bounds, { top: 60, right: 20, bottom: 60, left: 20 })
+    }
+  }, [mapReady, markers, selectedId, hoveredId, onMarkerClick, onMarkerHover])
+
+  // Fly to selected marker
+  useEffect(() => {
+    if (!mapReady || !mapRef.current || !selectedId || !window.naver?.maps) return
+    const target =
+      markers.find((m) => m.roasteryId === selectedId && m.isPrimary) ??
+      markers.find((m) => m.roasteryId === selectedId)
+    if (!target) return
+    const nv = window.naver.maps
+    mapRef.current.setCenter(new nv.LatLng(target.lat, target.lng))
+  }, [mapReady, selectedId, markers])
+
+  return (
+    <>
+      <Script
+        src={`https://oapi.map.naver.com/openapi/v3/maps.js?ncpKeyId=${NCPKEY}`}
+        strategy="afterInteractive"
+        onLoad={handleScriptLoad}
+      />
+      <div ref={containerRef} className="w-full h-full" />
+    </>
+  )
+}

--- a/src/components/roastery/map/RoasteryMapView.tsx
+++ b/src/components/roastery/map/RoasteryMapView.tsx
@@ -32,7 +32,6 @@ interface NaverMapsAPI {
     ne?: NaverLatLng
   ) => {
     extend(latLng: NaverLatLng): void
-    isEmpty(): boolean
   }
   Size: new (w: number, h: number) => NaverSize
   Point: new (x: number, y: number) => NaverPoint
@@ -160,7 +159,7 @@ export function RoasteryMapView({
       const nv2 = window.naver.maps
       const bounds = new nv2.LatLngBounds()
       for (const m of markers) bounds.extend(new nv2.LatLng(m.lat, m.lng))
-      if (!bounds.isEmpty()) map.fitBounds(bounds, { top: 60, right: 20, bottom: 60, left: 20 })
+      map.fitBounds(bounds, { top: 60, right: 20, bottom: 60, left: 20 })
     }
   }, [mapReady, markers, selectedId, hoveredId, onMarkerClick, onMarkerHover])
 

--- a/src/components/roastery/map/RoasteryMapView.tsx
+++ b/src/components/roastery/map/RoasteryMapView.tsx
@@ -1,0 +1,410 @@
+'use client'
+
+import { useEffect, useRef, useCallback, useState } from 'react'
+import Script from 'next/script'
+
+// ─── Minimal Naver Maps type declarations ────────────────────────────────────
+
+type NaverLatLng = object
+type NaverSize = object
+type NaverPoint = object
+
+interface NaverMapInstance {
+  setCenter(latLng: NaverLatLng): void
+  setZoom(zoom: number, animate?: boolean): void
+  getZoom(): number
+  getCenter(): { lat(): number; lng(): number }
+  fitBounds(bounds: object, opts?: object): void
+  morph(latLng: NaverLatLng, zoom?: number): void
+  destroy(): void
+}
+
+interface NaverMarkerInstance {
+  setIcon(icon: object): void
+  setZIndex(z: number): void
+  setMap(map: NaverMapInstance | null): void
+  getPosition(): NaverLatLng
+}
+
+interface NaverMapsAPI {
+  Map: new (el: HTMLElement, opts: object) => NaverMapInstance
+  Marker: new (opts: object) => NaverMarkerInstance
+  LatLng: new (lat: number, lng: number) => NaverLatLng
+  LatLngBounds: new (
+    sw?: NaverLatLng,
+    ne?: NaverLatLng
+  ) => {
+    extend(latLng: NaverLatLng): void
+  }
+  Size: new (w: number, h: number) => NaverSize
+  Point: new (x: number, y: number) => NaverPoint
+  Event: {
+    addListener(target: object, type: string, fn: (...args: unknown[]) => void): object
+  }
+}
+
+declare global {
+  interface Window {
+    naver?: { maps: NaverMapsAPI }
+  }
+}
+
+// ─── Session-level map position memory ───────────────────────────────────────
+
+let savedMapView: { lat: number; lng: number; zoom: number } | null = null
+
+// ─── Props & marker data ─────────────────────────────────────────────────────
+
+export interface MapMarkerData {
+  roasteryId: string
+  roasteryName: string
+  lat: number
+  lng: number
+  isPrimary: boolean
+  address: string
+}
+
+export interface ZoomHandle {
+  zoomIn: () => void
+  zoomOut: () => void
+  panTo: (lat: number, lng: number, zoom?: number) => void
+  skipNextFlyTo: () => void
+  clearSelection: () => void
+}
+
+interface Props {
+  markers: MapMarkerData[]
+  selectedId?: string
+  primarySelectedId?: string
+  hoveredId?: string
+  onMarkerClick: (roasteryId: string, lat: number, lng: number) => void
+  onMarkerHover?: (roasteryId: string | undefined) => void
+  showZoomControl?: boolean
+  onMapReady?: (handle: ZoomHandle) => void
+  userLocation?: { lat: number; lng: number } | null
+  overlayWidth?: number
+}
+
+// ─── Fit-view helper (morph 애니메이션용 중심점·줌 계산) ────────────────────────
+
+const PAD = { top: 60, right: 20, bottom: 60, left: 20 }
+
+// overlayWidth: 지도 왼쪽을 가리는 패널 너비(px). 보이는 영역 중앙에 마커가 오도록 lng 오프셋 적용.
+function computeFitView(
+  markers: MapMarkerData[],
+  container: HTMLElement,
+  overlayWidth = 0
+): { lat: number; lng: number; zoom: number } {
+  const lats = markers.map((m) => m.lat)
+  const lngs = markers.map((m) => m.lng)
+  const maxLat = Math.max(...lats)
+  const maxLng = Math.max(...lngs)
+  const minLat = Math.min(...lats)
+  const minLng = Math.min(...lngs)
+  const centerLat = (maxLat + minLat) / 2
+  const centerLng = (maxLng + minLng) / 2
+
+  // 오버레이가 왼쪽을 overlayWidth px 가리므로 마커를 보이는 영역 중앙(화면 중앙 + overlayWidth/2)에 두려면
+  // 카메라 중심을 마커보다 서쪽(경도 -)으로 이동 → marker.lng - offset = cameraCenter.lng
+  const lngOffset = (z: number) => (overlayWidth / 2) * (360 / (256 * 2 ** z))
+
+  const leftPad = PAD.left + overlayWidth
+  const availW = container.clientWidth - leftPad - PAD.right
+  const availH = container.clientHeight - PAD.top - PAD.bottom
+
+  if (markers.length === 1) {
+    return { lat: centerLat, lng: centerLng - lngOffset(16), zoom: 16 }
+  }
+
+  if (availW <= 0 || availH <= 0) {
+    return { lat: centerLat, lng: centerLng - lngOffset(11), zoom: 11 }
+  }
+
+  const TILE = 256
+  const lngToX = (lng: number, z: number) => ((lng + 180) / 360) * TILE * 2 ** z
+  const latToY = (lat: number, z: number) => {
+    const sin = Math.sin((lat * Math.PI) / 180)
+    return (0.5 - Math.log((1 + sin) / (1 - sin)) / (4 * Math.PI)) * TILE * 2 ** z
+  }
+
+  for (let z = 21; z >= 1; z--) {
+    const dx = Math.abs(lngToX(maxLng, z) - lngToX(minLng, z))
+    const dy = Math.abs(latToY(maxLat, z) - latToY(minLat, z))
+    if (dx <= availW && dy <= availH)
+      return { lat: centerLat, lng: centerLng - lngOffset(z), zoom: z }
+  }
+
+  return { lat: centerLat, lng: centerLng - lngOffset(1), zoom: 1 }
+}
+
+// ─── Marker icon helper ───────────────────────────────────────────────────────
+
+function markerIcon(selected: boolean, hovered: boolean, primarySelected = false) {
+  const size = primarySelected ? 32 : selected ? 24 : hovered ? 26 : 20
+  const nv = window.naver!
+  return {
+    content: `<div style="width:${size}px;height:${size}px;background:${selected ? '#fff' : '#1A1917'};border:${selected ? '2px solid #1A1917' : 'none'};border-radius:50%;box-shadow:0 2px 6px rgba(0,0,0,0.3);cursor:pointer;font-size:${Math.round(size * 0.55)}px;line-height:${size}px;text-align:center;overflow:hidden;">☕️</div>`,
+    size: new nv.maps.Size(size, size),
+    anchor: new nv.maps.Point(size / 2, size / 2),
+  }
+}
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+const NCPKEY = process.env.NEXT_PUBLIC_NAVER_MAP_CLIENT_ID!
+
+export function RoasteryMapView({
+  markers,
+  selectedId,
+  primarySelectedId,
+  hoveredId,
+  onMarkerClick,
+  onMarkerHover,
+  showZoomControl = true,
+  onMapReady,
+  userLocation,
+  overlayWidth = 0,
+}: Props) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const mapRef = useRef<NaverMapInstance | null>(null)
+  const showZoomControlRef = useRef(showZoomControl)
+  const onMapReadyRef = useRef(onMapReady)
+  const userLocationMarkerRef = useRef<NaverMarkerInstance | null>(null)
+  useEffect(() => {
+    onMapReadyRef.current = onMapReady
+  }, [onMapReady])
+  const markerMapRef = useRef<Map<string, NaverMarkerInstance[]>>(new Map())
+  const clickedPosRef = useRef<{ lat: number; lng: number } | null>(null)
+  const markersKeyRef = useRef<string>('')
+  const justFitBoundsRef = useRef(false)
+  const prevSelectedIdRef = useRef<string | undefined>(undefined)
+  const restoredFromSavedRef = useRef(!!savedMapView)
+  const [selection, setSelection] = useState<{
+    roasteryId: string
+    lat: number
+    lng: number
+  } | null>(null)
+  const clearSelectionRef = useRef<() => void>(() => setSelection(null))
+  const [mapReady, setMapReady] = useState(false)
+
+  const initMap = useCallback(() => {
+    if (!containerRef.current || mapRef.current || !window.naver?.maps) return
+    const nv = window.naver.maps
+
+    const initialCenter = savedMapView
+      ? new nv.LatLng(savedMapView.lat, savedMapView.lng)
+      : new nv.LatLng(37.5665, 126.978)
+    const initialZoom = savedMapView?.zoom ?? 11
+
+    const map = new nv.Map(containerRef.current, {
+      center: initialCenter,
+      zoom: initialZoom,
+      mapTypeControl: false,
+      scaleControl: false,
+      logoControl: false,
+      mapDataControl: false,
+      zoomControl: showZoomControlRef.current,
+      zoomControlOptions: { position: 3 /* TOP_RIGHT */ },
+    })
+
+    nv.Event.addListener(map, 'idle', () => {
+      const center = map.getCenter()
+      savedMapView = { lat: center.lat(), lng: center.lng(), zoom: map.getZoom() }
+    })
+
+    mapRef.current = map
+    onMapReadyRef.current?.({
+      zoomIn: () => map.setZoom(map.getZoom() + 1, true),
+      zoomOut: () => map.setZoom(map.getZoom() - 1, true),
+      panTo: (lat: number, lng: number, zoom?: number) => {
+        const latLng = new nv.LatLng(lat, lng)
+        if (zoom !== undefined) map.morph(latLng, zoom)
+        else map.setCenter(latLng)
+      },
+      skipNextFlyTo: () => {
+        justFitBoundsRef.current = true
+      },
+      clearSelection: () => clearSelectionRef.current(),
+    })
+    setMapReady(true)
+  }, [])
+
+  const handleScriptLoad = useCallback(() => {
+    initMap()
+  }, [initMap])
+
+  // Sync markers whenever data or selection changes
+  useEffect(() => {
+    if (!mapReady || !mapRef.current || !window.naver?.maps) return
+    const nv = window.naver.maps
+    const map = mapRef.current
+    const markerMap = markerMapRef.current
+
+    // Clear existing markers
+    for (const list of markerMap.values()) {
+      for (const m of list) m.setMap(null)
+    }
+    markerMap.clear()
+
+    // Add fresh markers
+    for (const data of markers) {
+      const isSelected = data.roasteryId === selectedId
+      // 사용자가 이 로스터리의 특정 마커를 클릭한 적이 있으면 true
+      const hasExplicitSelection = selection?.roasteryId === selectedId
+      const isPrimarySelected =
+        isSelected &&
+        (hasExplicitSelection
+          ? data.lat === selection!.lat && data.lng === selection!.lng
+          : primarySelectedId !== undefined
+            ? data.roasteryId === primarySelectedId
+            : data.isPrimary)
+      const isHovered = data.roasteryId === hoveredId
+
+      // 마커 클릭 전(초기): 로스터리 마커 전체 selected 스타일
+      // 마커 클릭 후: 클릭한 마커만 selected, 나머지는 일반 스타일
+      const isVisuallySelected = hasExplicitSelection ? isPrimarySelected : isSelected
+
+      const marker = new nv.Marker({
+        position: new nv.LatLng(data.lat, data.lng),
+        map,
+        icon: markerIcon(isVisuallySelected, isHovered, isPrimarySelected),
+        title: data.roasteryName,
+        zIndex: isPrimarySelected ? 100 : isSelected ? 60 : isHovered ? 50 : 10,
+      })
+
+      nv.Event.addListener(marker, 'click', () => {
+        clickedPosRef.current = { lat: data.lat, lng: data.lng }
+        setSelection({ roasteryId: data.roasteryId, lat: data.lat, lng: data.lng })
+        onMarkerClick(data.roasteryId, data.lat, data.lng)
+      })
+      if (onMarkerHover) {
+        nv.Event.addListener(marker, 'mouseover', () => onMarkerHover(data.roasteryId))
+        nv.Event.addListener(marker, 'mouseout', () => onMarkerHover(undefined))
+      }
+
+      const existing = markerMap.get(data.roasteryId) ?? []
+      existing.push(marker)
+      markerMap.set(data.roasteryId, existing)
+    }
+
+    // 마커 셋이 바뀔 때마다 morph로 부드럽게 이동 — selectedId 유무와 무관하게 실행
+    if (markers.length > 0 && containerRef.current) {
+      const key = markers.map((m) => `${m.roasteryId}:${m.lat}:${m.lng}`).join('|')
+      if (restoredFromSavedRef.current) {
+        // 저장된 위치로 복원된 첫 마운트: fitBounds 스킵, key만 초기화
+        // selectedId가 있으면 fly-to가 해당 마커로 이동할 수 있도록 justFitBounds 설정 안 함
+        markersKeyRef.current = key
+        restoredFromSavedRef.current = false
+        if (!selectedId) {
+          justFitBoundsRef.current = true
+        }
+      } else if (key !== markersKeyRef.current) {
+        const selectedMarkers = selectedId ? markers.filter((m) => m.roasteryId === selectedId) : []
+        const fitMarkers = selectedMarkers.length > 0 ? selectedMarkers : markers
+        const fitOverlay = selectedMarkers.length > 0 ? overlayWidth : 0
+        const { lat, lng, zoom } = computeFitView(fitMarkers, containerRef.current, fitOverlay)
+        map.morph(new nv.LatLng(lat, lng), zoom)
+        markersKeyRef.current = key
+        justFitBoundsRef.current = true
+      }
+    }
+  }, [
+    mapReady,
+    markers,
+    selectedId,
+    primarySelectedId,
+    selection,
+    hoveredId,
+    onMarkerClick,
+    onMarkerHover,
+    overlayWidth,
+  ])
+
+  // Fly to selected marker
+  useEffect(() => {
+    // fitBounds가 막 실행됐으면 fly 건너뜀 — selectedId 유무와 무관하게 먼저 소비
+    if (justFitBoundsRef.current) {
+      justFitBoundsRef.current = false
+      prevSelectedIdRef.current = selectedId
+      return
+    }
+    if (!selectedId) {
+      prevSelectedIdRef.current = undefined
+      return
+    }
+    if (!mapReady || !mapRef.current || !window.naver?.maps) return
+    if (!containerRef.current) return
+    const nv = window.naver.maps
+
+    const pos = clickedPosRef.current
+    clickedPosRef.current = null
+
+    const selectedIdChanged = prevSelectedIdRef.current !== selectedId
+
+    const roasteryMarkers = markers.filter((m) => m.roasteryId === selectedId)
+    if (roasteryMarkers.length === 0) return
+
+    prevSelectedIdRef.current = selectedId
+
+    if (pos) {
+      // 지도 마커 클릭: 클릭한 마커 위치로 fly (오버레이 오프셋 적용)
+      const currentZoom = mapRef.current.getZoom()
+      const targetZoom = currentZoom < 16 ? 16 : currentZoom
+      const lngOffset = (overlayWidth / 2) * (360 / (256 * 2 ** targetZoom))
+      mapRef.current.morph(new nv.LatLng(pos.lat, pos.lng - lngOffset), targetZoom)
+    } else if (selectedIdChanged) {
+      // 리스트 클릭 또는 URL 진입: 해당 로스터리 모든 마커 fit bounds (오버레이 오프셋 적용)
+      const { lat, lng, zoom } = computeFitView(roasteryMarkers, containerRef.current, overlayWidth)
+      mapRef.current.morph(new nv.LatLng(lat, lng), zoom)
+    }
+    // selection/overlayWidth 변경에 의한 재실행은 아무것도 하지 않음
+  }, [mapReady, selectedId, selection, markers, overlayWidth])
+
+  // User location marker (blue dot)
+  useEffect(() => {
+    if (!mapReady || !mapRef.current || !window.naver?.maps) return
+    const nv = window.naver.maps
+    const map = mapRef.current
+
+    if (!userLocation) {
+      userLocationMarkerRef.current?.setMap(null)
+      userLocationMarkerRef.current = null
+      return
+    }
+
+    const icon = {
+      content: `<div style="position:relative;width:20px;height:20px;display:flex;align-items:center;justify-content:center">
+        <div style="position:absolute;inset:-8px;border-radius:50%;background:rgba(59,130,246,0.15);animation:pulse-ring 2s ease-out infinite"></div>
+        <div style="width:14px;height:14px;border-radius:50%;background:#3b82f6;border:2.5px solid #fff;box-shadow:0 1px 4px rgba(0,0,0,0.25);flex-shrink:0"></div>
+      </div>`,
+      size: new nv.Size(20, 20),
+      anchor: new nv.Point(10, 10),
+    }
+
+    if (userLocationMarkerRef.current) {
+      userLocationMarkerRef.current.setIcon(icon)
+      ;(
+        userLocationMarkerRef.current as NaverMarkerInstance & { setPosition(p: NaverLatLng): void }
+      ).setPosition(new nv.LatLng(userLocation.lat, userLocation.lng))
+    } else {
+      userLocationMarkerRef.current = new nv.Marker({
+        position: new nv.LatLng(userLocation.lat, userLocation.lng),
+        map,
+        icon,
+        zIndex: 200,
+      })
+    }
+  }, [mapReady, userLocation])
+
+  return (
+    <>
+      <Script
+        src={`https://oapi.map.naver.com/openapi/v3/maps.js?ncpKeyId=${NCPKEY}`}
+        strategy="afterInteractive"
+        onLoad={handleScriptLoad}
+        onReady={handleScriptLoad}
+      />
+      <div ref={containerRef} className="w-full h-full" />
+    </>
+  )
+}

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -1,0 +1,15 @@
+'use client'
+
+import { useSyncExternalStore } from 'react'
+
+export function useMediaQuery(query: string): boolean {
+  return useSyncExternalStore(
+    (callback) => {
+      const mql = window.matchMedia(query)
+      mql.addEventListener('change', callback)
+      return () => mql.removeEventListener('change', callback)
+    },
+    () => window.matchMedia(query).matches,
+    () => false // server snapshot
+  )
+}

--- a/src/lib/geo.ts
+++ b/src/lib/geo.ts
@@ -1,0 +1,47 @@
+import type { RoasteryWithStats, LocationItem } from '@/types/roastery'
+
+export interface NearbyLocation {
+  roastery: RoasteryWithStats
+  location: LocationItem
+  distance: number
+}
+
+const R = 6371 // km
+
+export function haversineDistance(lat1: number, lng1: number, lat2: number, lng2: number): number {
+  const dLat = ((lat2 - lat1) * Math.PI) / 180
+  const dLng = ((lng2 - lng1) * Math.PI) / 180
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos((lat1 * Math.PI) / 180) * Math.cos((lat2 * Math.PI) / 180) * Math.sin(dLng / 2) ** 2
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a))
+}
+
+export function getNearbyLocations(
+  roasteries: RoasteryWithStats[],
+  userLat: number,
+  userLng: number,
+  maxKm = 10,
+  maxCount = 10
+): NearbyLocation[] {
+  const closest = new Map<string, NearbyLocation>()
+
+  for (const r of roasteries) {
+    for (const loc of r.locations) {
+      if (loc.lat === null || loc.lng === null) continue
+      const distance = haversineDistance(userLat, userLng, loc.lat, loc.lng)
+      if (distance > maxKm) continue
+      const prev = closest.get(r.id)
+      if (!prev || distance < prev.distance) {
+        closest.set(r.id, { roastery: r, location: loc, distance })
+      }
+    }
+  }
+
+  return [...closest.values()].sort((a, b) => a.distance - b.distance).slice(0, maxCount)
+}
+
+export function formatDistance(km: number): string {
+  if (km < 1) return `${Math.round(km * 1000)}m`
+  return `${km.toFixed(1)}km`
+}

--- a/src/lib/queries/bookmark.ts
+++ b/src/lib/queries/bookmark.ts
@@ -63,6 +63,7 @@ export async function getBookmarks(
     roastery: {
       ...b.roastery,
       tags: flattenTags(b.roastery.tags),
+      locations: [],
       ratingCount: b.roastery._count.ratings,
       avgRating: avgMap.get(b.roasteryId) ?? null,
     },

--- a/src/lib/queries/recommendation.ts
+++ b/src/lib/queries/recommendation.ts
@@ -58,6 +58,7 @@ export async function getPopularRoasteries(
     .map((r) => ({
       ...r,
       tags: flattenTags(r.tags),
+      locations: [] as never[],
       ratingCount: r._count.ratings,
       avgRating: avgMap.get(r.id) ?? null,
     }))
@@ -125,6 +126,7 @@ export async function getFeaturedSections(): Promise<FeaturedSectionData[]> {
     roasteries: s.roasteries.map(({ roastery: r }) => ({
       ...r,
       tags: flattenTags(r.tags),
+      locations: [] as never[],
       ratingCount: r._count.ratings,
       avgRating: avgMap.get(r.id) ?? null,
     })),
@@ -182,6 +184,7 @@ export async function getStoredRecommendations(userId: string): Promise<StoredRe
     roastery: {
       ...rec.roastery,
       tags: flattenTags(rec.roastery.tags),
+      locations: [] as never[],
       ratingCount: rec.roastery._count.ratings,
       avgRating: avgMap.get(rec.roasteryId) ?? null,
     },

--- a/src/lib/queries/roastery.ts
+++ b/src/lib/queries/roastery.ts
@@ -6,6 +6,7 @@ import type {
   RoasteryDetail,
   FilterParams,
   ChannelWithPrice,
+  LocationItem,
 } from '@/types/roastery'
 import { flattenTags } from '@/types/roastery'
 
@@ -24,6 +25,11 @@ const TAG_SELECT = {
     tag: { select: { id: true, name: true, category: true } },
   },
 } as const
+
+const LOCATION_SELECT = {
+  select: { id: true, address: true, lat: true, lng: true, isPrimary: true },
+  orderBy: [{ isPrimary: 'desc' as const }, { id: 'asc' as const }],
+}
 
 export async function getRoasteries(
   sort: SortOption = 'popular',
@@ -61,6 +67,7 @@ export async function getRoasteries(
         name: true,
         description: true,
         tags: TAG_SELECT,
+        locations: LOCATION_SELECT,
         priceRange: true,
         decaf: true,
         imageUrl: true,
@@ -81,6 +88,7 @@ export async function getRoasteries(
   const result = roasteries.map((r) => ({
     ...r,
     tags: flattenTags(r.tags),
+    locations: r.locations as LocationItem[],
     ratingCount: r._count.ratings,
     avgRating: avgMap.get(r.id) ?? null,
   }))
@@ -135,9 +143,9 @@ export async function getRoasteryById(id: string): Promise<RoasteryDetail | null
         id: true,
         name: true,
         description: true,
-        address: true,
         closedAt: true,
         tags: TAG_SELECT,
+        locations: LOCATION_SELECT,
         priceRange: true,
         decaf: true,
         imageUrl: true,
@@ -225,6 +233,7 @@ export async function getRoasteryById(id: string): Promise<RoasteryDetail | null
     ...roastery,
     closedAt: roastery.closedAt,
     tags: flattenTags(roastery.tags),
+    locations: roastery.locations as LocationItem[],
     ratingCount: roastery._count.ratings,
     avgRating: avgRating._avg.score ?? null,
     channels: baseChannels,

--- a/src/lib/roasteriesState.ts
+++ b/src/lib/roasteriesState.ts
@@ -1,0 +1,6 @@
+let savedView: 'list' | 'map' = 'list'
+
+export const getRoasteriesView = () => savedView
+export const setRoasteriesView = (v: 'list' | 'map') => {
+  savedView = v
+}

--- a/src/types/roastery.ts
+++ b/src/types/roastery.ts
@@ -18,6 +18,14 @@ export function flattenTags(
     .map(({ isPrimary, tag }) => ({ ...tag, isPrimary }))
 }
 
+export interface LocationItem {
+  id: string
+  address: string
+  lat: number | null
+  lng: number | null
+  isPrimary: boolean
+}
+
 export interface RoasteryWithStats {
   id: string
   name: string
@@ -29,6 +37,7 @@ export interface RoasteryWithStats {
   website: string | null // deprecated — 채널 마이그레이션 완료 후 제거
   avgRating: number | null
   ratingCount: number
+  locations: LocationItem[]
 }
 
 /** 채널 정의 상수 — 어드민 UI 등에서 재사용 */
@@ -71,7 +80,6 @@ export interface BeanWithDetails {
 }
 
 export interface RoasteryDetail extends RoasteryWithStats {
-  address: string | null
   closedAt: Date | null
   beans: BeanWithDetails[]
   channels: ChannelWithPrice[] // 원두 미선택 시 또는 가격 없는 로스터리의 기본 채널 목록


### PR DESCRIPTION
## 변경 사항

- **DB**: `RoasteryLocation` 테이블 추가 (1:N with Roastery) — address, lat, lng, isPrimary 필드
- **데이터**: 86개 로스터리, 163개 위치 데이터 geocoding 완료 (Naver Local Search API 활용)
- **타입/쿼리**: `LocationItem` 인터페이스 추가, `RoasteryWithStats`/`RoasteryDetail`에 `locations` 필드, `getRoasteries`/`getRoasteryById` 업데이트
- **지도 레이아웃**:
  - 데스크탑(≥768px): 왼쪽 목록/상세 패널 + 오른쪽 Naver Map 동시 표시, 패널 열기/닫기 토글
  - 모바일(<768px): 목록↔지도 뷰 토글, 지도 마커 탭 시 하단 스냅 카드
  - URL 기반 상태: `/roasteries?id=xxx` 로 선택된 로스터리 딥링크 지원
  - 카드 클릭 → 패널 내 상세 표시 + "자세히 보기" 버튼으로 전체 상세 페이지 이동
  - 마커 호버 → 마커 하이라이트, 마커 클릭 → 패널 열기 + 지도 fly-to

## 테스트 방법

- [x] `/roasteries` 접속 — 지도와 목록 패널이 나란히 표시됨
- [x] 목록에서 카드 클릭 → 패널이 상세 뷰로 전환, 지도가 해당 위치로 이동
- [x] "목록" 버튼 클릭 → 패널이 목록으로 돌아옴
- [x] 패널 옆의 `‹` / `›` 버튼으로 패널 열기/닫기
- [ ] 지도 마커 클릭 → 패널 열리고 해당 로스터리 상세 표시
- [x] 모바일 환경(또는 창 768px 미만): "목록" / "지도" 토글 버튼 표시
- [ ] 모바일 지도에서 마커 탭 → 하단 스냅 카드 표시, 탭 → 상세 페이지 이동