### PR TITLE
feat: 어드민 로스터리 지점 관리 기능 추가

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,9 @@
 {
+  "permissions": {
+    "allow": [
+      "Bash(python3 scripts/location_add.py*)"
+    ]
+  },
   "hooks": {
     "Stop": [
       {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -65,6 +65,7 @@ model Roastery {
   ratings               Rating[]
   recommendations       Recommendation[]
   channels              RoasteryChannel[]
+  locations             RoasteryLocation[]
   tags                  RoasteryTag[]
 
   @@index([priceRange])

--- a/src/actions/admin.ts
+++ b/src/actions/admin.ts
@@ -955,7 +955,12 @@ export async function geocodeAddress(
       },
     })
     if (!res.ok) {
-      return { success: false, error: '지오코딩 요청 실패', code: 'EXTERNAL_ERROR' }
+      const body = await res.text().catch(() => '')
+      return {
+        success: false,
+        error: `지오코딩 요청 실패 (${res.status}): ${body.slice(0, 200)}`,
+        code: 'EXTERNAL_ERROR',
+      }
     }
     const data = (await res.json()) as {
       status: string

--- a/src/actions/admin.ts
+++ b/src/actions/admin.ts
@@ -947,11 +947,12 @@ export async function geocodeAddress(
   }
 
   try {
-    const url = `https://naveropenapi.apigw.ntruss.com/map-geocode/v2/geocode?query=${encodeURIComponent(address.trim())}`
+    const url = `https://maps.apigw.ntruss.com/map-geocode/v2/geocode?query=${encodeURIComponent(address.trim())}`
     const res = await fetch(url, {
       headers: {
-        'X-NCP-APIGW-API-KEY-ID': clientId,
-        'X-NCP-APIGW-API-KEY': clientSecret,
+        'x-ncp-apigw-api-key-id': clientId,
+        'x-ncp-apigw-api-key': clientSecret,
+        Accept: 'application/json',
       },
     })
     if (!res.ok) {

--- a/src/actions/admin.ts
+++ b/src/actions/admin.ts
@@ -783,3 +783,193 @@ export async function reorderSections(orderedIds: string[]): Promise<ActionResul
     return { success: false, error: '순서 저장 중 오류가 발생했습니다', code: 'DB_ERROR' }
   }
 }
+
+// ── 지점(RoasteryLocation) 관리 ──────────────────────────
+
+export interface LocationInput {
+  address: string
+  lat: number | null
+  lng: number | null
+  isPrimary: boolean
+}
+
+export type AdminLocation = {
+  id: string
+  address: string
+  lat: number | null
+  lng: number | null
+  isPrimary: boolean
+}
+
+export async function getAdminRoasteryLocations(roasteryId: string): Promise<AdminLocation[]> {
+  const check = await requireAdmin()
+  if ('error' in check) redirect('/')
+
+  return prisma.roasteryLocation.findMany({
+    where: { roasteryId },
+    select: { id: true, address: true, lat: true, lng: true, isPrimary: true },
+    orderBy: [{ isPrimary: 'desc' }, { id: 'asc' }],
+  })
+}
+
+export async function createLocation(
+  roasteryId: string,
+  input: LocationInput
+): Promise<ActionResult<AdminLocation>> {
+  const check = await requireAdmin()
+  if ('error' in check) return { success: false, error: check.error, code: check.code }
+
+  if (!input.address.trim()) {
+    return { success: false, error: '주소는 필수입니다', code: 'VALIDATION' }
+  }
+
+  try {
+    if (input.isPrimary) {
+      await prisma.roasteryLocation.updateMany({
+        where: { roasteryId },
+        data: { isPrimary: false },
+      })
+    }
+
+    const loc = await prisma.roasteryLocation.create({
+      data: {
+        roasteryId,
+        address: input.address.trim(),
+        lat: input.lat,
+        lng: input.lng,
+        isPrimary: input.isPrimary,
+      },
+      select: { id: true, address: true, lat: true, lng: true, isPrimary: true },
+    })
+
+    revalidatePath(`/admin/roasteries/${roasteryId}`)
+    revalidatePath(`/roasteries/${roasteryId}`)
+    return { success: true, data: loc }
+  } catch {
+    return { success: false, error: '저장 중 오류가 발생했습니다', code: 'DB_ERROR' }
+  }
+}
+
+export async function updateLocation(
+  id: string,
+  roasteryId: string,
+  input: LocationInput
+): Promise<ActionResult<AdminLocation>> {
+  const check = await requireAdmin()
+  if ('error' in check) return { success: false, error: check.error, code: check.code }
+
+  if (!input.address.trim()) {
+    return { success: false, error: '주소는 필수입니다', code: 'VALIDATION' }
+  }
+
+  try {
+    if (input.isPrimary) {
+      await prisma.roasteryLocation.updateMany({
+        where: { roasteryId, NOT: { id } },
+        data: { isPrimary: false },
+      })
+    }
+
+    const loc = await prisma.roasteryLocation.update({
+      where: { id },
+      data: {
+        address: input.address.trim(),
+        lat: input.lat,
+        lng: input.lng,
+        isPrimary: input.isPrimary,
+      },
+      select: { id: true, address: true, lat: true, lng: true, isPrimary: true },
+    })
+
+    revalidatePath(`/admin/roasteries/${roasteryId}`)
+    revalidatePath(`/roasteries/${roasteryId}`)
+    return { success: true, data: loc }
+  } catch {
+    return { success: false, error: '저장 중 오류가 발생했습니다', code: 'DB_ERROR' }
+  }
+}
+
+export async function deleteLocation(id: string, roasteryId: string): Promise<ActionResult<void>> {
+  const check = await requireAdmin()
+  if ('error' in check) return { success: false, error: check.error, code: check.code }
+
+  try {
+    await prisma.roasteryLocation.delete({ where: { id } })
+    revalidatePath(`/admin/roasteries/${roasteryId}`)
+    revalidatePath(`/roasteries/${roasteryId}`)
+    return { success: true, data: undefined }
+  } catch {
+    return { success: false, error: '삭제 중 오류가 발생했습니다', code: 'DB_ERROR' }
+  }
+}
+
+export async function setPrimaryLocation(
+  id: string,
+  roasteryId: string
+): Promise<ActionResult<void>> {
+  const check = await requireAdmin()
+  if ('error' in check) return { success: false, error: check.error, code: check.code }
+
+  try {
+    await prisma.$transaction([
+      prisma.roasteryLocation.updateMany({
+        where: { roasteryId },
+        data: { isPrimary: false },
+      }),
+      prisma.roasteryLocation.update({
+        where: { id },
+        data: { isPrimary: true },
+      }),
+    ])
+
+    revalidatePath(`/admin/roasteries/${roasteryId}`)
+    revalidatePath(`/roasteries/${roasteryId}`)
+    return { success: true, data: undefined }
+  } catch {
+    return { success: false, error: '저장 중 오류가 발생했습니다', code: 'DB_ERROR' }
+  }
+}
+
+export async function geocodeAddress(
+  address: string
+): Promise<ActionResult<{ lat: number; lng: number }>> {
+  const check = await requireAdmin()
+  if ('error' in check) return { success: false, error: check.error, code: check.code }
+
+  if (!address.trim()) {
+    return { success: false, error: '주소를 입력해주세요', code: 'VALIDATION' }
+  }
+
+  const clientId = process.env.NAVER_MAP_CLIENT_ID
+  const clientSecret = process.env.NAVER_MAP_CLIENT_SECRET
+  if (!clientId || !clientSecret) {
+    return { success: false, error: '지오코딩 API 키가 설정되지 않았습니다', code: 'CONFIG_ERROR' }
+  }
+
+  try {
+    const url = `https://naveropenapi.apigw.ntruss.com/map-geocode/v2/geocode?query=${encodeURIComponent(address.trim())}`
+    const res = await fetch(url, {
+      headers: {
+        'X-NCP-APIGW-API-KEY-ID': clientId,
+        'X-NCP-APIGW-API-KEY': clientSecret,
+      },
+    })
+    if (!res.ok) {
+      return { success: false, error: '지오코딩 요청 실패', code: 'EXTERNAL_ERROR' }
+    }
+    const data = (await res.json()) as {
+      status: string
+      addresses: { x: string; y: string }[]
+    }
+    if (!data.addresses || data.addresses.length === 0) {
+      return { success: false, error: '주소를 찾을 수 없습니다', code: 'NOT_FOUND' }
+    }
+    const first = data.addresses[0]
+    return {
+      success: true,
+      data: { lng: parseFloat(first.x), lat: parseFloat(first.y) },
+    }
+  } catch {
+    return { success: false, error: '지오코딩 중 오류가 발생했습니다', code: 'EXTERNAL_ERROR' }
+  }
+}

--- a/src/app/admin/roasteries/[id]/page.tsx
+++ b/src/app/admin/roasteries/[id]/page.tsx
@@ -1,9 +1,10 @@
 import Link from 'next/link'
 import { notFound, redirect } from 'next/navigation'
 import { auth } from '@/lib/auth'
-import { getAdminRoastery, getAdminRoasteryBeans } from '@/actions/admin'
+import { getAdminRoastery, getAdminRoasteryBeans, getAdminRoasteryLocations } from '@/actions/admin'
 import { RoasteryStatusButtons } from '@/components/admin/RoasteryStatusButtons'
 import { BeanStatusButton } from '@/components/admin/BeanStatusButton'
+import { LocationSection } from '@/components/admin/LocationSection'
 
 const PRICE_RANGE_LABEL: Record<string, string> = {
   LOW: '2만원 미만',
@@ -28,7 +29,11 @@ export default async function RoasteryDetailPage({ params }: Props) {
   if (session?.user?.role !== 'ADMIN') redirect('/')
 
   const { id } = await params
-  const [roastery, beans] = await Promise.all([getAdminRoastery(id), getAdminRoasteryBeans(id)])
+  const [roastery, beans, locations] = await Promise.all([
+    getAdminRoastery(id),
+    getAdminRoasteryBeans(id),
+    getAdminRoasteryLocations(id),
+  ])
   if (!roastery) notFound()
 
   const primaryRegion = roastery.tags.find((t) => t.category === 'REGION')?.name ?? '—'
@@ -192,6 +197,9 @@ export default async function RoasteryDetailPage({ params }: Props) {
           </div>
         )}
       </div>
+
+      {/* 지점 목록 */}
+      <LocationSection roasteryId={id} initialLocations={locations} />
     </div>
   )
 }

--- a/src/components/admin/LocationSection.tsx
+++ b/src/components/admin/LocationSection.tsx
@@ -72,10 +72,11 @@ export function LocationSection({ roasteryId, initialLocations }: Props) {
         setGeocodeError(result.error)
         return
       }
+      const { lat, lng } = result.data!
       setForm((f) => ({
         ...f,
-        lat: String(result.data.lat),
-        lng: String(result.data.lng),
+        lat: String(lat),
+        lng: String(lng),
       }))
     })
   }
@@ -96,10 +97,11 @@ export function LocationSection({ roasteryId, initialLocations }: Props) {
           setError(result.error)
           return
         }
+        const saved = result.data!
         setLocations((prev) => {
           const updated = prev.map((l) => {
             if (input.isPrimary && l.id !== editingId) return { ...l, isPrimary: false }
-            if (l.id === editingId) return result.data
+            if (l.id === editingId) return saved
             return l
           })
           return sortLocations(updated)
@@ -111,10 +113,11 @@ export function LocationSection({ roasteryId, initialLocations }: Props) {
           setError(result.error)
           return
         }
+        const saved = result.data!
         setLocations((prev) => {
           const next = input.isPrimary
-            ? [...prev.map((l) => ({ ...l, isPrimary: false })), result.data]
-            : [...prev, result.data]
+            ? [...prev.map((l) => ({ ...l, isPrimary: false })), saved]
+            : [...prev, saved]
           return sortLocations(next)
         })
         setShowAddForm(false)

--- a/src/components/admin/LocationSection.tsx
+++ b/src/components/admin/LocationSection.tsx
@@ -1,0 +1,387 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import {
+  createLocation,
+  updateLocation,
+  deleteLocation,
+  setPrimaryLocation,
+  geocodeAddress,
+  type AdminLocation,
+  type LocationInput,
+} from '@/actions/admin'
+
+interface Props {
+  roasteryId: string
+  initialLocations: AdminLocation[]
+}
+
+interface FormState {
+  address: string
+  lat: string
+  lng: string
+  isPrimary: boolean
+}
+
+const emptyForm = (): FormState => ({ address: '', lat: '', lng: '', isPrimary: false })
+
+export function LocationSection({ roasteryId, initialLocations }: Props) {
+  const [locations, setLocations] = useState<AdminLocation[]>(initialLocations)
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [showAddForm, setShowAddForm] = useState(false)
+  const [form, setForm] = useState<FormState>(emptyForm())
+  const [error, setError] = useState<string | null>(null)
+  const [geocodeError, setGeocodeError] = useState<string | null>(null)
+  const [isPending, startTransition] = useTransition()
+  const [isGeocoding, startGeocodeTransition] = useTransition()
+
+  function handleEdit(loc: AdminLocation) {
+    setEditingId(loc.id)
+    setShowAddForm(false)
+    setForm({
+      address: loc.address,
+      lat: loc.lat != null ? String(loc.lat) : '',
+      lng: loc.lng != null ? String(loc.lng) : '',
+      isPrimary: loc.isPrimary,
+    })
+    setError(null)
+    setGeocodeError(null)
+  }
+
+  function handleAddNew() {
+    setEditingId(null)
+    setShowAddForm(true)
+    setForm(emptyForm())
+    setError(null)
+    setGeocodeError(null)
+  }
+
+  function handleCancel() {
+    setEditingId(null)
+    setShowAddForm(false)
+    setForm(emptyForm())
+    setError(null)
+    setGeocodeError(null)
+  }
+
+  function handleGeocode() {
+    setGeocodeError(null)
+    startGeocodeTransition(async () => {
+      const result = await geocodeAddress(form.address)
+      if (!result.success) {
+        setGeocodeError(result.error)
+        return
+      }
+      setForm((f) => ({
+        ...f,
+        lat: String(result.data.lat),
+        lng: String(result.data.lng),
+      }))
+    })
+  }
+
+  function handleSave() {
+    setError(null)
+    const input: LocationInput = {
+      address: form.address,
+      lat: form.lat !== '' ? parseFloat(form.lat) : null,
+      lng: form.lng !== '' ? parseFloat(form.lng) : null,
+      isPrimary: form.isPrimary,
+    }
+
+    startTransition(async () => {
+      if (editingId) {
+        const result = await updateLocation(editingId, roasteryId, input)
+        if (!result.success) {
+          setError(result.error)
+          return
+        }
+        setLocations((prev) => {
+          const updated = prev.map((l) => {
+            if (input.isPrimary && l.id !== editingId) return { ...l, isPrimary: false }
+            if (l.id === editingId) return result.data
+            return l
+          })
+          return sortLocations(updated)
+        })
+        setEditingId(null)
+      } else {
+        const result = await createLocation(roasteryId, input)
+        if (!result.success) {
+          setError(result.error)
+          return
+        }
+        setLocations((prev) => {
+          const next = input.isPrimary
+            ? [...prev.map((l) => ({ ...l, isPrimary: false })), result.data]
+            : [...prev, result.data]
+          return sortLocations(next)
+        })
+        setShowAddForm(false)
+      }
+      setForm(emptyForm())
+    })
+  }
+
+  function handleDelete(id: string) {
+    startTransition(async () => {
+      const result = await deleteLocation(id, roasteryId)
+      if (!result.success) {
+        setError(result.error)
+        return
+      }
+      setLocations((prev) => prev.filter((l) => l.id !== id))
+      if (editingId === id) setEditingId(null)
+    })
+  }
+
+  function handleSetPrimary(id: string) {
+    startTransition(async () => {
+      const result = await setPrimaryLocation(id, roasteryId)
+      if (!result.success) {
+        setError(result.error)
+        return
+      }
+      setLocations((prev) => sortLocations(prev.map((l) => ({ ...l, isPrimary: l.id === id }))))
+    })
+  }
+
+  return (
+    <div>
+      <div className="mb-4 flex items-center justify-between">
+        <h2 className="text-lg font-semibold text-text">지점 목록 ({locations.length})</h2>
+        {!showAddForm && editingId === null && (
+          <button
+            onClick={handleAddNew}
+            className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90 transition-opacity"
+          >
+            + 새 지점
+          </button>
+        )}
+      </div>
+
+      {error && <p className="mb-3 rounded-lg bg-red-50 px-3 py-2 text-sm text-red-600">{error}</p>}
+
+      {locations.length === 0 && !showAddForm ? (
+        <p className="text-sm text-text-sub">등록된 지점이 없습니다.</p>
+      ) : (
+        <div className="overflow-hidden rounded-xl border border-border">
+          <table className="w-full text-sm">
+            <thead className="bg-surface-sub">
+              <tr>
+                <th className="px-4 py-3 text-left font-medium text-text-sub">주소</th>
+                <th className="px-4 py-3 text-left font-medium text-text-sub">위도</th>
+                <th className="px-4 py-3 text-left font-medium text-text-sub">경도</th>
+                <th className="px-4 py-3 text-left font-medium text-text-sub">대표</th>
+                <th className="px-4 py-3 text-left font-medium text-text-sub"></th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border bg-surface">
+              {locations.map((loc) =>
+                editingId === loc.id ? (
+                  <tr key={loc.id} className="bg-surface-sub/50">
+                    <td colSpan={5} className="px-4 py-3">
+                      <InlineForm
+                        form={form}
+                        onChange={setForm}
+                        onSave={handleSave}
+                        onCancel={handleCancel}
+                        onGeocode={handleGeocode}
+                        isPending={isPending}
+                        isGeocoding={isGeocoding}
+                        geocodeError={geocodeError}
+                      />
+                    </td>
+                  </tr>
+                ) : (
+                  <tr key={loc.id} className="hover:bg-surface-sub transition-colors">
+                    <td className="px-4 py-3 text-text">{loc.address}</td>
+                    <td className="px-4 py-3 text-text-sub">{loc.lat ?? '—'}</td>
+                    <td className="px-4 py-3 text-text-sub">{loc.lng ?? '—'}</td>
+                    <td className="px-4 py-3">
+                      {loc.isPrimary ? (
+                        <span className="rounded px-1.5 py-0.5 text-xs bg-primary/10 text-primary font-medium">
+                          대표
+                        </span>
+                      ) : (
+                        <button
+                          onClick={() => handleSetPrimary(loc.id)}
+                          disabled={isPending}
+                          className="text-xs text-text-sub hover:text-text transition-colors disabled:opacity-40"
+                        >
+                          대표 설정
+                        </button>
+                      )}
+                    </td>
+                    <td className="px-4 py-3">
+                      <div className="flex items-center gap-2">
+                        <button
+                          onClick={() => handleEdit(loc)}
+                          disabled={isPending}
+                          className="text-xs text-text-sub hover:text-text transition-colors disabled:opacity-40"
+                        >
+                          수정
+                        </button>
+                        <button
+                          onClick={() => handleDelete(loc.id)}
+                          disabled={isPending}
+                          className="text-xs text-red-400 hover:text-red-600 transition-colors disabled:opacity-40"
+                        >
+                          삭제
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                )
+              )}
+
+              {showAddForm && (
+                <tr className="bg-surface-sub/50">
+                  <td colSpan={5} className="px-4 py-3">
+                    <InlineForm
+                      form={form}
+                      onChange={setForm}
+                      onSave={handleSave}
+                      onCancel={handleCancel}
+                      onGeocode={handleGeocode}
+                      isPending={isPending}
+                      isGeocoding={isGeocoding}
+                      geocodeError={geocodeError}
+                    />
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {showAddForm && locations.length === 0 && (
+        <div className="mt-3 overflow-hidden rounded-xl border border-border bg-surface">
+          <div className="px-4 py-3">
+            <InlineForm
+              form={form}
+              onChange={setForm}
+              onSave={handleSave}
+              onCancel={handleCancel}
+              onGeocode={handleGeocode}
+              isPending={isPending}
+              isGeocoding={isGeocoding}
+              geocodeError={geocodeError}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+interface InlineFormProps {
+  form: FormState
+  onChange: (f: FormState) => void
+  onSave: () => void
+  onCancel: () => void
+  onGeocode: () => void
+  isPending: boolean
+  isGeocoding: boolean
+  geocodeError: string | null
+}
+
+function InlineForm({
+  form,
+  onChange,
+  onSave,
+  onCancel,
+  onGeocode,
+  isPending,
+  isGeocoding,
+  geocodeError,
+}: InlineFormProps) {
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-col gap-1.5">
+        <label className="text-xs font-medium text-text-sub">주소</label>
+        <div className="flex gap-2">
+          <input
+            type="text"
+            value={form.address}
+            onChange={(e) => onChange({ ...form, address: e.target.value })}
+            placeholder="서울 마포구 합정동 ..."
+            className="flex-1 rounded-lg border border-border bg-surface px-3 py-2 text-sm text-text placeholder:text-text-sub/50 focus:outline-none focus:ring-2 focus:ring-primary/30"
+          />
+          <button
+            type="button"
+            onClick={onGeocode}
+            disabled={isGeocoding || !form.address.trim()}
+            className="shrink-0 rounded-lg border border-border px-3 py-2 text-xs text-text-sub hover:text-text transition-colors disabled:opacity-40"
+          >
+            {isGeocoding ? '조회 중...' : '좌표 자동 입력'}
+          </button>
+        </div>
+        {geocodeError && <p className="text-xs text-red-500">{geocodeError}</p>}
+      </div>
+
+      <div className="flex gap-3">
+        <div className="flex flex-col gap-1.5 flex-1">
+          <label className="text-xs font-medium text-text-sub">위도 (lat)</label>
+          <input
+            type="number"
+            step="any"
+            value={form.lat}
+            onChange={(e) => onChange({ ...form, lat: e.target.value })}
+            placeholder="37.5665"
+            className="rounded-lg border border-border bg-surface px-3 py-2 text-sm text-text placeholder:text-text-sub/50 focus:outline-none focus:ring-2 focus:ring-primary/30"
+          />
+        </div>
+        <div className="flex flex-col gap-1.5 flex-1">
+          <label className="text-xs font-medium text-text-sub">경도 (lng)</label>
+          <input
+            type="number"
+            step="any"
+            value={form.lng}
+            onChange={(e) => onChange({ ...form, lng: e.target.value })}
+            placeholder="126.9780"
+            className="rounded-lg border border-border bg-surface px-3 py-2 text-sm text-text placeholder:text-text-sub/50 focus:outline-none focus:ring-2 focus:ring-primary/30"
+          />
+        </div>
+      </div>
+
+      <label className="flex items-center gap-2 cursor-pointer">
+        <input
+          type="checkbox"
+          checked={form.isPrimary}
+          onChange={(e) => onChange({ ...form, isPrimary: e.target.checked })}
+          className="rounded border-border accent-primary"
+        />
+        <span className="text-xs text-text-sub">대표 지점으로 설정</span>
+      </label>
+
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={onSave}
+          disabled={isPending}
+          className="rounded-lg bg-primary px-4 py-2 text-xs font-medium text-primary-foreground hover:opacity-90 transition-opacity disabled:opacity-40"
+        >
+          {isPending ? '저장 중...' : '저장'}
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={isPending}
+          className="rounded-lg border border-border px-4 py-2 text-xs text-text-sub hover:text-text transition-colors disabled:opacity-40"
+        >
+          취소
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function sortLocations(locations: AdminLocation[]): AdminLocation[] {
+  return [...locations].sort((a, b) => {
+    if (a.isPrimary && !b.isPrimary) return -1
+    if (!a.isPrimary && b.isPrimary) return 1
+    return a.id.localeCompare(b.id)
+  })
+}

--- a/src/types/action.ts
+++ b/src/types/action.ts
@@ -11,4 +11,6 @@ export type ActionResult<T = void> =
         | 'NOT_FOUND'
         | 'UPLOAD_ERROR'
         | 'DUPLICATE'
+        | 'CONFIG_ERROR'
+        | 'EXTERNAL_ERROR'
     }


### PR DESCRIPTION
## 변경 사항
- RoasteryLocation CRUD Server Actions 추가 (create/update/delete/setPrimary/getAdminRoasteryLocations)
- 네이버 Geocoding API 연동: 주소 입력 후 "좌표 자동 입력" 버튼으로 lat/lng 자동 변환
- `LocationSection` 클라이언트 컴포넌트: 인라인 폼으로 지점 추가/수정/삭제, 대표 지점 설정
- `ActionResult` 타입에 `CONFIG_ERROR`, `EXTERNAL_ERROR` 코드 추가
- 어드민 로스터리 상세 페이지 (`/admin/roasteries/[id]`) 원두 목록 아래 지점 섹션 추가

## 테스트 방법
- [x] `/admin/roasteries/{id}` 페이지 접근 → 하단에 "지점 목록" 섹션이 보인다
- [x] "새 지점" 버튼 클릭 → 인라인 폼이 테이블 하단에 나타난다
- [x] 주소 입력 후 "좌표 자동 입력" 버튼 클릭 → 위도/경도 필드가 자동으로 채워진다
- [x] 저장 버튼 클릭 → 테이블에 새 지점이 추가된다
- [x] 기존 지점 "수정" 클릭 → 해당 행이 인라인 폼으로 전환된다
- [x] "대표 설정" 클릭 → 해당 지점이 대표로 변경되고 기존 대표는 해제된다
- [x] "삭제" 클릭 → 해당 지점이 목록에서 제거된다