### PR TITLE
fix: Roastery 모델 locations 필드 중복 제거

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -65,7 +65,6 @@ model Roastery {
   ratings               Rating[]
   recommendations       Recommendation[]
   channels              RoasteryChannel[]
-  locations             RoasteryLocation[]
   tags                  RoasteryTag[]
 
   @@index([priceRange])


### PR DESCRIPTION
## 변경 사항
- `prisma/schema.prisma` Roastery 모델에 `locations RoasteryLocation[]` 이중 정의 제거
- #194, #195 동시 머지 과정에서 발생한 충돌로 인한 오류

## 원인
PR #194와 #195가 각각 독립적으로 동일 필드를 추가하여 머지 후 중복 발생 → 운영 빌드 실패

## 테스트 방법
- [ ] `pnpm prisma generate` 정상 완료 확인
- [ ] Vercel 배포 성공 확인