### PR TITLE
feat: 지도 뷰 검색 결과 없을 때 빈 상태 표시 개선

### DIFF
--- a/src/app/(main)/roasteries/RoasteriesContent.tsx
+++ b/src/app/(main)/roasteries/RoasteriesContent.tsx
@@ -97,7 +97,7 @@ export async function RoasteriesContent({ params }: Props) {
 
   const pageHeader = <RoasteryPageHeader filter={filter} sort={sort} isLoggedIn={!!userId} />
 
-  if (isMapView && mapRoasteries.length > 0) {
+  if (isMapView) {
     return (
       <div className="flex flex-col lg:h-[calc(100vh-var(--header-height))] lg:overflow-hidden">
         <RoasteriesViewTracker view="map" />

--- a/src/components/roastery/map/RoasteryMapLayout.tsx
+++ b/src/components/roastery/map/RoasteryMapLayout.tsx
@@ -384,6 +384,13 @@ export function RoasteryMapLayout({
                   </motion.div>
                 ))}
               </motion.div>
+            ) : roasteries.length === 0 ? (
+              <div className="py-12 flex flex-col items-center gap-2 text-center">
+                <p className="text-sm font-medium">찾는 로스터리가 없어요</p>
+                <p className="text-xs text-muted-foreground">
+                  필터를 조정하거나 검색어를 바꿔보세요.
+                </p>
+              </div>
             ) : (
               <RoasteryGrid
                 roasteries={roasteries}


### PR DESCRIPTION
## 변경 사항
- 지도 뷰(`?view=map`)에서 검색 결과가 0개여도 지도를 유지하도록 수정
- 데스크탑 왼쪽 패널 리스트 영역에 결과 없을 때 빈 상태 UI 추가 ("찾는 로스터리가 없어요")

## 테스트 방법
- [x] 지도 뷰(`/roasteries?view=map`)에서 검색어나 필터를 적용해 결과가 0개가 되도록 설정
- [x] 데스크탑에서 왼쪽 패널에 "찾는 로스터리가 없어요" 메시지가 표시되고 오른쪽 지도는 유지되는지 확인
- [x] 내 주변 모드에서 결과 없을 때 기존 동작(주변 10km 내 매장이 없어요) 정상 작동 확인