### PR TITLE
fix: 모바일 지도 뷰 UI 버그 수정

### DIFF
--- a/src/app/(main)/roasteries/RoasteriesContent.tsx
+++ b/src/app/(main)/roasteries/RoasteriesContent.tsx
@@ -159,6 +159,7 @@ export async function RoasteriesContent({ params }: Props) {
         <Link
           href={mapUrl}
           className="lg:hidden fixed bottom-[calc(var(--bottom-tab-height)+env(safe-area-inset-bottom,0px)+20px)] right-page-edge z-50 flex items-center justify-center w-14 h-14 rounded-full bg-primary text-primary-foreground shadow-lg hover:bg-primary/90 transition-colors"
+          style={{ touchAction: 'manipulation' }}
           aria-label="지도로 보기"
         >
           <MapPin className="size-6" />

--- a/src/components/roastery/map/RoasteryMapView.tsx
+++ b/src/components/roastery/map/RoasteryMapView.tsx
@@ -143,7 +143,7 @@ function markerIcon(selected: boolean, hovered: boolean, primarySelected = false
   const size = primarySelected ? 32 : selected ? 24 : hovered ? 26 : 20
   const nv = window.naver!
   return {
-    content: `<div style="width:${size}px;height:${size}px;background:${selected ? '#fff' : '#1A1917'};border:${selected ? '2px solid #1A1917' : 'none'};border-radius:50%;box-shadow:0 2px 6px rgba(0,0,0,0.3);cursor:pointer;font-size:${Math.round(size * 0.55)}px;line-height:${size}px;text-align:center;overflow:hidden;">☕️</div>`,
+    content: `<div style="width:${size}px;height:${size}px;background:${selected ? '#fff' : '#1A1917'};border:${selected ? '2px solid #1A1917' : 'none'};border-radius:50%;box-shadow:0 2px 6px rgba(0,0,0,0.3);cursor:pointer;font-size:${Math.round(size * 0.55)}px;display:flex;align-items:center;justify-content:center;overflow:hidden;">☕️</div>`,
     size: new nv.maps.Size(size, size),
     anchor: new nv.maps.Point(size / 2, size / 2),
   }


### PR DESCRIPTION
## 변경 사항
- 지도 마커 커피 이모지 중앙 정렬 수정: `line-height` + `text-align` → flexbox(`align-items`/`justify-content`)
- 지도 전환 FAB 터치 인식 개선: `touch-action: manipulation` 추가로 iOS 300ms 더블탭 지연 제거

## 테스트 방법
- [x] 모바일에서 지도 뷰 진입 후 마커의 ☕️ 이모지가 원 중앙에 표시되는지 확인
- [x] 모바일 로스터리 목록에서 지도 전환 FAB을 싱글탭으로 즉시 인식되는지 확인