### PR TITLE
fix: GPS 내 주변 모드 활성 중 검색/필터 변경 시 자동 해제

### DIFF
--- a/src/components/roastery/map/RoasteryMapLayout.tsx
+++ b/src/components/roastery/map/RoasteryMapLayout.tsx
@@ -209,10 +209,19 @@ export function RoasteryMapLayout({
   // 필터 결과가 바뀌면 캐러셀 인덱스 초기화 (React 공식 파생 상태 패턴)
   const roasteriesKey = useMemo(() => roasteries.map((r) => r.id).join(','), [roasteries])
   const [prevRoasteriesKey, setPrevRoasteriesKey] = useState(roasteriesKey)
+  // 정렬 순서에 무관한 결과 집합 키 — 정렬만 바뀐 경우는 nearby 해제 대상이 아님
+  const roasteriesSetKey = useMemo(
+    () => [...roasteries.map((r) => r.id)].sort().join(','),
+    [roasteries]
+  )
+  const [prevRoasteriesSetKey, setPrevRoasteriesSetKey] = useState(roasteriesSetKey)
   if (prevRoasteriesKey !== roasteriesKey) {
     setPrevRoasteriesKey(roasteriesKey)
     setCarouselIndex(0)
     setCarouselDismissed(false)
+  }
+  if (prevRoasteriesSetKey !== roasteriesSetKey) {
+    setPrevRoasteriesSetKey(roasteriesSetKey)
     if (nearbyMode) {
       setNearbyMode(false)
       setNearbyLocations([])

--- a/src/components/roastery/map/RoasteryMapLayout.tsx
+++ b/src/components/roastery/map/RoasteryMapLayout.tsx
@@ -213,6 +213,13 @@ export function RoasteryMapLayout({
     setPrevRoasteriesKey(roasteriesKey)
     setCarouselIndex(0)
     setCarouselDismissed(false)
+    if (nearbyMode) {
+      setNearbyMode(false)
+      setNearbyLocations([])
+      setNearbyIndex(0)
+      setNearbySelectedId(undefined)
+      setUserLocation(null)
+    }
   }
 
   const snapRoastery = useMemo(


### PR DESCRIPTION
## 변경 사항
- GPS 내 주변 모드가 활성화된 상태에서 검색어나 필터를 변경하면 nearbyMode가 자동으로 해제됨
- `roasteriesSetKey`(정렬 순서 무관 집합 키)를 별도 도입해 정렬만 바꿀 때는 nearbyMode가 해제되지 않음 (Codex 지적 반영)
- 기존 캐러셀 인덱스 초기화와 동일한 React 파생 상태 패턴으로 통합

**수정 전 문제**: GPS 클릭 후 검색을 해도 지도·사이드바가 변하지 않는 silent failure 발생 — nearbyLocations가 GPS 클릭 시점의 스냅샷으로 고정되어 이후 검색 결과를 무시함

## 테스트 방법
- [x] 지도 뷰에서 GPS(내 주변) 버튼 클릭 → 주변 로스터리 표시 확인
- [x] 주변 모드 활성 상태에서 검색창에 텍스트 입력 → nearbyMode 자동 해제, 검색 결과로 지도·리스트 갱신 확인
- [x] 주변 모드 활성 상태에서 지역/가격 필터 변경 → nearbyMode 자동 해제 확인
- [x] 주변 모드 활성 상태에서 정렬(인기순↔이름순)만 변경 → nearbyMode가 해제되지 않음 확인