### PR TITLE
fix: 지도 선택 상태 버그 3종 수정

### DIFF
--- a/src/components/roastery/FilterPanel.tsx
+++ b/src/components/roastery/FilterPanel.tsx
@@ -42,6 +42,7 @@ export function FilterPanel({ filter, sort, isLoggedIn, variant = 'default' }: F
 
   function buildParams(updates: Partial<FilterParams>): string {
     const params = new URLSearchParams(searchParams.toString())
+    params.delete('id')
     const next = { ...filter, ...updates }
 
     if (next.q) params.set('q', next.q)

--- a/src/components/roastery/map/RoasteryMapLayout.tsx
+++ b/src/components/roastery/map/RoasteryMapLayout.tsx
@@ -219,10 +219,10 @@ export function RoasteryMapLayout({
     setPrevRoasteriesKey(roasteriesKey)
     setCarouselIndex(0)
     setCarouselDismissed(false)
-    setSnapId(undefined)
   }
   if (prevRoasteriesSetKey !== roasteriesSetKey) {
     setPrevRoasteriesSetKey(roasteriesSetKey)
+    setSnapId(undefined)
     if (nearbyMode) {
       setNearbyMode(false)
       setNearbyLocations([])

--- a/src/components/roastery/map/RoasteryMapLayout.tsx
+++ b/src/components/roastery/map/RoasteryMapLayout.tsx
@@ -219,6 +219,7 @@ export function RoasteryMapLayout({
     setPrevRoasteriesKey(roasteriesKey)
     setCarouselIndex(0)
     setCarouselDismissed(false)
+    setSnapId(undefined)
   }
   if (prevRoasteriesSetKey !== roasteriesSetKey) {
     setPrevRoasteriesSetKey(roasteriesSetKey)
@@ -314,8 +315,9 @@ export function RoasteryMapLayout({
       setNearbyIndex(idx)
       setNearbySelectedId(roasteryId)
       zoomRef.current?.panTo(item.location.lat!, item.location.lng!, 15)
+      router.push(buildUrl(roasteryId), { scroll: false })
     },
-    [nearbyLocations]
+    [nearbyLocations, router, buildUrl]
   )
 
   const handleTouchStart = useCallback((e: TouchEvent<HTMLDivElement>) => {


### PR DESCRIPTION
## 변경 사항
- 필터/검색 변경 시 `?id=` URL 파라미터 자동 제거 → stale 상세 패널 해제 (`FilterPanel.buildParams`)
- 필터 변경 시 모바일 스냅 카드 초기화 (결과 집합 변경 시에만, 정렬 변경에는 유지)
- 데스크탑 내 주변 모드에서 카드 클릭 시 상세 패널 오픈 (`handleNearbyCardClick`에 `router.push` 추가)

## 테스트 방법
- [x] 지도 뷰에서 마커 클릭 → 패널 오픈 → 검색어 입력 → 상세 패널이 닫힌다
- [x] 모바일 비필터 지도에서 마커 클릭 → 스냅 카드 표시 → 필터 적용 → 필터 해제 → 스냅 카드가 재등장하지 않는다
- [x] 모바일 지도에서 마커 클릭 → 스냅 카드 표시 → 정렬 변경 → 스냅 카드가 유지된다
- [x] 데스크탑 내 주변 모드에서 사이드바 카드 클릭 → 상세 패널이 오픈된다