### PR TITLE
feat: 지역 필터 선택지 DB 동적 조회

### DIFF
--- a/src/app/(main)/roasteries/RoasteriesContent.tsx
+++ b/src/app/(main)/roasteries/RoasteriesContent.tsx
@@ -2,7 +2,7 @@ import { Suspense } from 'react'
 import Link from 'next/link'
 import { MapPin, List } from 'lucide-react'
 import { auth } from '@/lib/auth'
-import { getRoasteries, getRoasteryById } from '@/lib/queries/roastery'
+import { getRoasteries, getRoasteryById, getRegionOptions } from '@/lib/queries/roastery'
 import { getUserRating, getRatingCount, getRoasteryRatings } from '@/lib/queries/rating'
 import { getBookmarkStatus } from '@/lib/queries/bookmark'
 import { RequestRoasteryButton } from '@/components/roastery/RequestRoasteryButton'
@@ -61,10 +61,11 @@ export async function RoasteriesContent({ params }: Props) {
   const mapUrl = `/roasteries?${mapUrlParams.toString()}`
   const listUrl = filterParams.toString() ? `/roasteries?${filterParams.toString()}` : '/roasteries'
 
-  const [roasteries, selectedRoastery, ratingCount] = await Promise.all([
+  const [roasteries, selectedRoastery, ratingCount, regionOptions] = await Promise.all([
     getRoasteries(sort, filter, userId),
     selectedId ? getRoasteryById(selectedId) : null,
     isMapView && userId && selectedId ? getRatingCount(userId) : 0,
+    getRegionOptions(),
   ])
 
   const mapRoasteries = isMapView
@@ -95,7 +96,9 @@ export async function RoasteriesContent({ params }: Props) {
     }
   }
 
-  const pageHeader = <RoasteryPageHeader filter={filter} sort={sort} isLoggedIn={!!userId} />
+  const pageHeader = (
+    <RoasteryPageHeader filter={filter} sort={sort} isLoggedIn={!!userId} regions={regionOptions} />
+  )
 
   if (isMapView) {
     return (
@@ -113,6 +116,7 @@ export async function RoasteriesContent({ params }: Props) {
               listUrl={listUrl}
               filter={filter}
               sort={sort}
+              regionOptions={regionOptions}
             />
           </Suspense>
         </div>

--- a/src/components/roastery/FilterPanel.tsx
+++ b/src/components/roastery/FilterPanel.tsx
@@ -6,7 +6,7 @@ import { SlidersHorizontal, RotateCcw, ChevronDown } from 'lucide-react'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Label } from '@/components/ui/label'
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet'
-import { PRICE_RANGE_LABELS, PRICE_OPTIONS, REGIONS, CHARACTERISTIC_TAGS } from '@/types/roastery'
+import { PRICE_RANGE_LABELS, PRICE_OPTIONS, CHARACTERISTIC_TAGS } from '@/types/roastery'
 import type { FilterParams, PriceRange, SortOption } from '@/types/roastery'
 import { SortSelector } from './SortSelector'
 
@@ -15,11 +15,18 @@ interface FilterPanelProps {
   sort: SortOption
   isLoggedIn: boolean
   variant?: 'default' | 'map-search' | 'map-pills'
+  regions?: string[]
 }
 
 type PillId = 'price' | 'region' | 'tag'
 
-export function FilterPanel({ filter, sort, isLoggedIn, variant = 'default' }: FilterPanelProps) {
+export function FilterPanel({
+  filter,
+  sort,
+  isLoggedIn,
+  variant = 'default',
+  regions = [],
+}: FilterPanelProps) {
   const router = useRouter()
   const pathname = usePathname()
   const searchParams = useSearchParams()
@@ -169,7 +176,7 @@ export function FilterPanel({ filter, sort, isLoggedIn, variant = 'default' }: F
           onClose={() => setOpenPill(null)}
           shadow
         >
-          <RegionGroup selected={filter.regions} onToggle={toggleRegion} />
+          <RegionGroup regions={regions} selected={filter.regions} onToggle={toggleRegion} />
         </FilterPill>
 
         <FilterPill
@@ -251,7 +258,7 @@ export function FilterPanel({ filter, sort, isLoggedIn, variant = 'default' }: F
                 checked={filter.decaf}
                 onToggle={() => navigate({ decaf: !filter.decaf })}
               />
-              <RegionGroup selected={filter.regions} onToggle={toggleRegion} />
+              <RegionGroup regions={regions} selected={filter.regions} onToggle={toggleRegion} />
               <TagGroup selected={filter.tags} onToggle={toggleTag} />
               {isLoggedIn && (
                 <RatedGroup
@@ -324,7 +331,7 @@ export function FilterPanel({ filter, sort, isLoggedIn, variant = 'default' }: F
           onToggle={() => setOpenPill(openPill === 'region' ? null : 'region')}
           onClose={() => setOpenPill(null)}
         >
-          <RegionGroup selected={filter.regions} onToggle={toggleRegion} />
+          <RegionGroup regions={regions} selected={filter.regions} onToggle={toggleRegion} />
         </FilterPill>
 
         <FilterPill
@@ -485,17 +492,20 @@ function RatedGroup({ checked, onToggle }: { checked: boolean; onToggle: () => v
 }
 
 function RegionGroup({
+  regions,
   selected,
   onToggle,
 }: {
+  regions: string[]
   selected: string[]
   onToggle: (r: string) => void
 }) {
+  if (regions.length === 0) return null
   return (
     <fieldset>
       <legend className="mb-2 text-sm font-medium">지역</legend>
       <div className="grid grid-cols-3 gap-x-4 gap-y-2.5">
-        {REGIONS.map((r) => (
+        {regions.map((r) => (
           <div key={r} className="flex items-center gap-1.5">
             <Checkbox
               id={`region-${r}`}

--- a/src/components/roastery/FilterPanel.tsx
+++ b/src/components/roastery/FilterPanel.tsx
@@ -500,12 +500,13 @@ function RegionGroup({
   selected: string[]
   onToggle: (r: string) => void
 }) {
-  if (regions.length === 0) return null
+  const options = [...new Set([...regions, ...selected])]
+  if (options.length === 0) return null
   return (
     <fieldset>
       <legend className="mb-2 text-sm font-medium">지역</legend>
       <div className="grid grid-cols-3 gap-x-4 gap-y-2.5">
-        {regions.map((r) => (
+        {options.map((r) => (
           <div key={r} className="flex items-center gap-1.5">
             <Checkbox
               id={`region-${r}`}

--- a/src/components/roastery/RoasteryPageHeader.tsx
+++ b/src/components/roastery/RoasteryPageHeader.tsx
@@ -6,14 +6,15 @@ interface Props {
   filter: FilterParams
   sort: SortOption
   isLoggedIn: boolean
+  regions: string[]
 }
 
-export function RoasteryPageHeader({ filter, sort, isLoggedIn }: Props) {
+export function RoasteryPageHeader({ filter, sort, isLoggedIn, regions }: Props) {
   return (
     <div className="flex flex-col gap-4">
       <h1 className="text-xl font-semibold">로스터리</h1>
       <Suspense fallback={null}>
-        <FilterPanel filter={filter} sort={sort} isLoggedIn={isLoggedIn} />
+        <FilterPanel filter={filter} sort={sort} isLoggedIn={isLoggedIn} regions={regions} />
       </Suspense>
     </div>
   )

--- a/src/components/roastery/map/RoasteryMapLayout.tsx
+++ b/src/components/roastery/map/RoasteryMapLayout.tsx
@@ -59,6 +59,7 @@ interface Props {
   listUrl: string
   filter: FilterParams
   sort: SortOption
+  regionOptions: string[]
 }
 
 // ─── Session-level card position memory ──────────────────────────────────────
@@ -83,6 +84,7 @@ export function RoasteryMapLayout({
   listUrl,
   filter,
   sort,
+  regionOptions,
 }: Props) {
   const router = useRouter()
   const searchParams = useSearchParams()
@@ -344,7 +346,13 @@ export function RoasteryMapLayout({
         <div className="w-[360px] xl:w-[400px] shrink-0 flex flex-col border-r overflow-hidden">
           {/* 검색 */}
           <div className="shrink-0 px-4 py-4 border-b">
-            <FilterPanel filter={filter} sort={sort} isLoggedIn={isLoggedIn} variant="map-search" />
+            <FilterPanel
+              filter={filter}
+              sort={sort}
+              isLoggedIn={isLoggedIn}
+              variant="map-search"
+              regions={regionOptions}
+            />
           </div>
           <div className="flex items-center justify-between px-4 py-3 border-b shrink-0">
             {nearbyMode ? (
@@ -443,6 +451,7 @@ export function RoasteryMapLayout({
                 sort={sort}
                 isLoggedIn={isLoggedIn}
                 variant="map-pills"
+                regions={regionOptions}
               />
               <button
                 onClick={handleGpsClick}

--- a/src/lib/queries/roastery.ts
+++ b/src/lib/queries/roastery.ts
@@ -135,6 +135,18 @@ function flattenChannels(
   }))
 }
 
+export async function getRegionOptions(): Promise<string[]> {
+  const tags = await prisma.tag.findMany({
+    where: {
+      category: 'REGION',
+      roasteries: { some: { roastery: { deletedAt: null, hidden: false, closedAt: null } } },
+    },
+    select: { name: true },
+    orderBy: { name: 'asc' },
+  })
+  return tags.map((t) => t.name)
+}
+
 export async function getRoasteryById(id: string): Promise<RoasteryDetail | null> {
   const [roastery, avgRating] = await Promise.all([
     prisma.roastery.findUnique({


### PR DESCRIPTION
## 변경 사항
- `getRegionOptions()` 쿼리 추가: 실제 로스터리가 있는 REGION 태그만 DB에서 조회 (삭제/숨김 제외)
- `RoasteriesContent`에서 병렬 조회 후 FilterPanel까지 prop으로 전달
- `FilterPanel`의 `RegionGroup`이 하드코딩된 `REGIONS` 상수 대신 서버에서 받은 목록 사용
- `RoasteryPageHeader`, `RoasteryMapLayout`에 `regions` prop 추가

## 테스트 방법
- [ ] 로스터리 목록 페이지 접속 → 지역 필터에 DB에 실제 존재하는 지역만 표시되는지 확인
- [ ] 지역 필터 선택 후 결과가 올바르게 필터링되는지 확인
- [ ] 지도 뷰에서도 지역 필터가 동일하게 동작하는지 확인