### PR TITLE
feat: 지역 데이터를 위치 주소 기반으로 전환

### DIFF
--- a/src/actions/admin.ts
+++ b/src/actions/admin.ts
@@ -84,11 +84,12 @@ export async function createRoastery(
   try {
     const tagIds = await upsertTags(input.tags)
 
+    const addr = input.address.trim() || null
     const roastery = await prisma.roastery.create({
       data: {
         name: input.name.trim(),
         description: input.description.trim() || null,
-        address: input.address.trim() || null,
+        address: addr,
         priceRange: input.priceRange,
         decaf: input.decaf,
         imageUrl: input.imageUrl.trim() || null,
@@ -99,6 +100,9 @@ export async function createRoastery(
             .filter((c) => c.channelKey && c.url.trim())
             .map((c) => ({ channelKey: c.channelKey, url: c.url.trim() })),
         },
+        ...(addr && {
+          locations: { create: { address: addr, isPrimary: true } },
+        }),
       },
       select: { id: true },
     })
@@ -242,6 +246,19 @@ export async function updateRoastery(
         })
       )
     )
+
+    // 주소가 입력됐고 대표 위치가 아직 없는 경우에만 생성 (기존 위치 데이터 보호)
+    const addr = input.address.trim()
+    if (addr) {
+      const hasPrimaryLoc = await prisma.roasteryLocation.count({
+        where: { roasteryId: id, isPrimary: true },
+      })
+      if (hasPrimaryLoc === 0) {
+        await prisma.roasteryLocation.create({
+          data: { roasteryId: id, address: addr, isPrimary: true },
+        })
+      }
+    }
 
     return { success: true, data: { id: roastery.id } }
   } catch {
@@ -498,6 +515,11 @@ export async function getAdminRoasteries() {
       name: true,
       tags: {
         select: { isPrimary: true, tag: { select: { id: true, name: true, category: true } } },
+      },
+      locations: {
+        where: { isPrimary: true },
+        select: { address: true },
+        take: 1,
       },
       priceRange: true,
       decaf: true,

--- a/src/actions/admin.ts
+++ b/src/actions/admin.ts
@@ -34,7 +34,6 @@ export interface CreateRoasteryInput {
   name: string
   description: string
   address: string
-  regions: string[]
   tags: string[] // CHARACTERISTIC 태그
   priceRange: PriceRange
   decaf: boolean
@@ -43,35 +42,25 @@ export interface CreateRoasteryInput {
   isOnboardingCandidate: boolean
 }
 
-/** 지역 + 특성 태그를 upsert하고 ID + isPrimary 배열을 반환 */
+/** 특성 태그를 upsert하고 ID 배열을 반환 */
 async function upsertTags(
-  regions: string[],
   characteristicTags: string[]
 ): Promise<{ id: string; isPrimary: boolean }[]> {
-  const tagData = [
-    ...regions.map((name, i) => ({
-      name: name.trim(),
-      category: 'REGION' as const,
-      isPrimary: i === 0,
-    })),
-    ...characteristicTags.map((name) => ({
-      name: name.trim(),
-      category: 'CHARACTERISTIC' as const,
-      isPrimary: false,
-    })),
-  ].filter((t) => t.name)
+  const tagData = characteristicTags
+    .map((name) => ({ name: name.trim(), category: 'CHARACTERISTIC' as const }))
+    .filter((t) => t.name)
 
   if (tagData.length === 0) return []
 
   const tags = await Promise.all(
-    tagData.map(async ({ isPrimary, ...tagFields }) => {
+    tagData.map(async (tagFields) => {
       const tag = await prisma.tag.upsert({
         where: { name_category: { name: tagFields.name, category: tagFields.category } },
         create: tagFields,
         update: {},
         select: { id: true },
       })
-      return { id: tag.id, isPrimary }
+      return { id: tag.id, isPrimary: false }
     })
   )
   return tags
@@ -88,15 +77,12 @@ export async function createRoastery(
   if (!input.name.trim()) {
     return { success: false, error: '로스터리 이름은 필수입니다', code: 'VALIDATION' }
   }
-  if (input.regions.length === 0) {
-    return { success: false, error: '지역을 1개 이상 입력해주세요', code: 'VALIDATION' }
-  }
   if (!['LOW', 'MID', 'HIGH'].includes(input.priceRange)) {
     return { success: false, error: '가격대가 올바르지 않습니다', code: 'VALIDATION' }
   }
 
   try {
-    const tagIds = await upsertTags(input.regions, input.tags)
+    const tagIds = await upsertTags(input.tags)
 
     const roastery = await prisma.roastery.create({
       data: {
@@ -212,15 +198,12 @@ export async function updateRoastery(
   if (!input.name.trim()) {
     return { success: false, error: '로스터리 이름은 필수입니다', code: 'VALIDATION' }
   }
-  if (input.regions.length === 0) {
-    return { success: false, error: '지역을 1개 이상 입력해주세요', code: 'VALIDATION' }
-  }
   if (!['LOW', 'MID', 'HIGH'].includes(input.priceRange)) {
     return { success: false, error: '가격대가 올바르지 않습니다', code: 'VALIDATION' }
   }
 
   try {
-    const tagIds = await upsertTags(input.regions, input.tags)
+    const tagIds = await upsertTags(input.tags)
 
     const newChannels = input.channels.filter((c) => c.channelKey && c.url.trim())
     const newChannelKeys = newChannels.map((c) => c.channelKey)

--- a/src/actions/roastery.integration.test.ts
+++ b/src/actions/roastery.integration.test.ts
@@ -14,34 +14,16 @@ const DEFAULT_FILTER = {
 let r1Id: string
 let r2Id: string
 let r3Id: string
-let seoulTagId: string
-let busanTagId: string
 
 beforeAll(async () => {
-  // 서울, 부산 태그 생성
-  const [seoulTag, busanTag] = await Promise.all([
-    testPrisma.tag.upsert({
-      where: { name_category: { name: '서울', category: 'REGION' } },
-      create: { name: '서울', category: 'REGION' },
-      update: {},
-    }),
-    testPrisma.tag.upsert({
-      where: { name_category: { name: '부산', category: 'REGION' } },
-      create: { name: '부산', category: 'REGION' },
-      update: {},
-    }),
-  ])
-  seoulTagId = seoulTag.id
-  busanTagId = busanTag.id
-
-  // 로스터리 3개 생성
+  // 로스터리 3개 생성 (지역은 RoasteryLocation.address로 결정)
   const [r1, r2, r3] = await Promise.all([
     testPrisma.roastery.create({
       data: {
         name: '서울LOW',
         priceRange: 'LOW',
         decaf: false,
-        tags: { create: { tagId: seoulTagId, isPrimary: true } },
+        locations: { create: { address: '서울 마포구 도화동 1', isPrimary: true } },
       },
     }),
     testPrisma.roastery.create({
@@ -49,7 +31,7 @@ beforeAll(async () => {
         name: '서울MID디카페인',
         priceRange: 'MID',
         decaf: true,
-        tags: { create: { tagId: seoulTagId, isPrimary: true } },
+        locations: { create: { address: '서울 강남구 역삼동 1', isPrimary: true } },
       },
     }),
     testPrisma.roastery.create({
@@ -57,7 +39,7 @@ beforeAll(async () => {
         name: '부산HIGH',
         priceRange: 'HIGH',
         decaf: false,
-        tags: { create: { tagId: busanTagId, isPrimary: true } },
+        locations: { create: { address: '부산 해운대구 우동 1', isPrimary: true } },
       },
     }),
   ])
@@ -95,7 +77,7 @@ describe('getRoasteries (integration)', () => {
   })
 
   // I-20: 지역 필터
-  it('I-20: 지역 필터는 해당 지역 태그를 가진 로스터리만 반환한다', async () => {
+  it('I-20: 지역 필터는 해당 지역 주소를 가진 로스터리만 반환한다', async () => {
     const result = await getRoasteries('name', { ...DEFAULT_FILTER, regions: ['부산'] })
     const ids = result.map((r) => r.id)
     expect(ids).toContain(r3Id)

--- a/src/app/(main)/roasteries/RoasteriesContent.tsx
+++ b/src/app/(main)/roasteries/RoasteriesContent.tsx
@@ -2,7 +2,7 @@ import { Suspense } from 'react'
 import Link from 'next/link'
 import { MapPin, List } from 'lucide-react'
 import { auth } from '@/lib/auth'
-import { getRoasteries, getRoasteryById } from '@/lib/queries/roastery'
+import { getRoasteries, getRoasteryById, getRegionOptions } from '@/lib/queries/roastery'
 import { getUserRating, getRatingCount, getRoasteryRatings } from '@/lib/queries/rating'
 import { getBookmarkStatus } from '@/lib/queries/bookmark'
 import { RequestRoasteryButton } from '@/components/roastery/RequestRoasteryButton'
@@ -61,10 +61,11 @@ export async function RoasteriesContent({ params }: Props) {
   const mapUrl = `/roasteries?${mapUrlParams.toString()}`
   const listUrl = filterParams.toString() ? `/roasteries?${filterParams.toString()}` : '/roasteries'
 
-  const [roasteries, selectedRoastery, ratingCount] = await Promise.all([
+  const [roasteries, selectedRoastery, ratingCount, regionOptions] = await Promise.all([
     getRoasteries(sort, filter, userId),
     selectedId ? getRoasteryById(selectedId) : null,
     isMapView && userId && selectedId ? getRatingCount(userId) : 0,
+    getRegionOptions(),
   ])
 
   const mapRoasteries = isMapView
@@ -95,7 +96,9 @@ export async function RoasteriesContent({ params }: Props) {
     }
   }
 
-  const pageHeader = <RoasteryPageHeader filter={filter} sort={sort} isLoggedIn={!!userId} />
+  const pageHeader = (
+    <RoasteryPageHeader filter={filter} sort={sort} isLoggedIn={!!userId} regions={regionOptions} />
+  )
 
   if (isMapView) {
     return (
@@ -113,6 +116,7 @@ export async function RoasteriesContent({ params }: Props) {
               listUrl={listUrl}
               filter={filter}
               sort={sort}
+              regionOptions={regionOptions}
             />
           </Suspense>
         </div>

--- a/src/app/admin/roasteries/page.tsx
+++ b/src/app/admin/roasteries/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import { getAdminRoasteries } from '@/actions/admin'
 import { RoasteryStatusButtons } from '@/components/admin/RoasteryStatusButtons'
+import { getRegionFromAddress } from '@/lib/utils'
 
 const PRICE_RANGE_LABEL: Record<string, string> = {
   LOW: '2만원 미만',
@@ -60,7 +61,7 @@ export default async function AdminRoasteriesPage() {
                       </Link>
                     </td>
                     <td className="px-4 py-3 text-text-sub">
-                      {r.tags.find((t) => t.category === 'REGION')?.name ?? '—'}
+                      {getRegionFromAddress(r.locations[0]?.address ?? null) ?? '—'}
                     </td>
                     <td className="px-4 py-3 text-text-sub">{PRICE_RANGE_LABEL[r.priceRange]}</td>
                     <td className="px-4 py-3 text-text-sub">{r.decaf ? 'O' : '—'}</td>

--- a/src/app/admin/sections/[id]/edit/page.tsx
+++ b/src/app/admin/sections/[id]/edit/page.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { getAdminSection, getAdminRoasteries } from '@/actions/admin'
 import { SectionForm } from '@/components/admin/SectionForm'
-import { getRegions } from '@/types/roastery'
+import { getRegionFromAddress } from '@/lib/utils'
 import { DeleteSectionButton } from '../../_components/DeleteSectionButton'
 
 interface Props {
@@ -18,7 +18,7 @@ export default async function EditSectionPage({ params }: Props) {
   const options = roasteries.map((r) => ({
     id: r.id,
     name: r.name,
-    primaryRegion: getRegions(r.tags)[0] ?? null,
+    primaryRegion: getRegionFromAddress(r.locations[0]?.address ?? null) ?? null,
   }))
 
   const isSystem = section.type !== 'CUSTOM'

--- a/src/app/admin/sections/new/page.tsx
+++ b/src/app/admin/sections/new/page.tsx
@@ -1,14 +1,14 @@
 import Link from 'next/link'
 import { getAdminRoasteries } from '@/actions/admin'
 import { SectionForm } from '@/components/admin/SectionForm'
-import { getRegions } from '@/types/roastery'
+import { getRegionFromAddress } from '@/lib/utils'
 
 export default async function NewSectionPage() {
   const roasteries = await getAdminRoasteries()
   const options = roasteries.map((r) => ({
     id: r.id,
     name: r.name,
-    primaryRegion: getRegions(r.tags)[0] ?? null,
+    primaryRegion: getRegionFromAddress(r.locations[0]?.address ?? null) ?? null,
   }))
 
   return (

--- a/src/components/admin/RoasteryForm.tsx
+++ b/src/components/admin/RoasteryForm.tsx
@@ -9,12 +9,7 @@ import { TagInput } from './TagInput'
 import { ImageUpload } from './ImageUpload'
 import type { PriceRange } from '@prisma/client'
 import type { TagItem } from '@/types/roastery'
-import {
-  getRegions,
-  getCharacteristicTags,
-  CHARACTERISTIC_TAGS,
-  CHANNEL_DEFS,
-} from '@/types/roastery'
+import { getCharacteristicTags, CHARACTERISTIC_TAGS, CHANNEL_DEFS } from '@/types/roastery'
 
 interface RoasteryFormProps {
   roasteryId?: string
@@ -39,7 +34,6 @@ export function RoasteryForm({ roasteryId, initialData }: RoasteryFormProps) {
   const [name, setName] = useState(initialData?.name ?? '')
   const [description, setDescription] = useState(initialData?.description ?? '')
   const [address, setAddress] = useState(initialData?.address ?? '')
-  const [regions, setRegions] = useState<string[]>(initialData ? getRegions(initialData.tags) : [])
   const [characteristicTags, setCharacteristicTags] = useState<string[]>(
     initialData ? getCharacteristicTags(initialData.tags) : []
   )
@@ -75,7 +69,6 @@ export function RoasteryForm({ roasteryId, initialData }: RoasteryFormProps) {
       name,
       description,
       address,
-      regions,
       tags: characteristicTags,
       priceRange,
       decaf,
@@ -140,15 +133,6 @@ export function RoasteryForm({ roasteryId, initialData }: RoasteryFormProps) {
           placeholder="예: 마포구 도화동 179-9"
         />
       </div>
-
-      {/* 지역 (태그) */}
-      <TagInput
-        label="지역"
-        tags={regions}
-        onChange={setRegions}
-        placeholder="예: 서울 (첫 번째 = 대표 지역)"
-        required
-      />
 
       {/* 특성 태그 */}
       <TagInput

--- a/src/components/roastery/FilterPanel.tsx
+++ b/src/components/roastery/FilterPanel.tsx
@@ -6,7 +6,7 @@ import { SlidersHorizontal, RotateCcw, ChevronDown } from 'lucide-react'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Label } from '@/components/ui/label'
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet'
-import { PRICE_RANGE_LABELS, PRICE_OPTIONS, REGIONS, CHARACTERISTIC_TAGS } from '@/types/roastery'
+import { PRICE_RANGE_LABELS, PRICE_OPTIONS, CHARACTERISTIC_TAGS } from '@/types/roastery'
 import type { FilterParams, PriceRange, SortOption } from '@/types/roastery'
 import { SortSelector } from './SortSelector'
 
@@ -15,11 +15,18 @@ interface FilterPanelProps {
   sort: SortOption
   isLoggedIn: boolean
   variant?: 'default' | 'map-search' | 'map-pills'
+  regions?: string[]
 }
 
 type PillId = 'price' | 'region' | 'tag'
 
-export function FilterPanel({ filter, sort, isLoggedIn, variant = 'default' }: FilterPanelProps) {
+export function FilterPanel({
+  filter,
+  sort,
+  isLoggedIn,
+  variant = 'default',
+  regions = [],
+}: FilterPanelProps) {
   const router = useRouter()
   const pathname = usePathname()
   const searchParams = useSearchParams()
@@ -169,7 +176,7 @@ export function FilterPanel({ filter, sort, isLoggedIn, variant = 'default' }: F
           onClose={() => setOpenPill(null)}
           shadow
         >
-          <RegionGroup selected={filter.regions} onToggle={toggleRegion} />
+          <RegionGroup regions={regions} selected={filter.regions} onToggle={toggleRegion} />
         </FilterPill>
 
         <FilterPill
@@ -251,7 +258,7 @@ export function FilterPanel({ filter, sort, isLoggedIn, variant = 'default' }: F
                 checked={filter.decaf}
                 onToggle={() => navigate({ decaf: !filter.decaf })}
               />
-              <RegionGroup selected={filter.regions} onToggle={toggleRegion} />
+              <RegionGroup regions={regions} selected={filter.regions} onToggle={toggleRegion} />
               <TagGroup selected={filter.tags} onToggle={toggleTag} />
               {isLoggedIn && (
                 <RatedGroup
@@ -324,7 +331,7 @@ export function FilterPanel({ filter, sort, isLoggedIn, variant = 'default' }: F
           onToggle={() => setOpenPill(openPill === 'region' ? null : 'region')}
           onClose={() => setOpenPill(null)}
         >
-          <RegionGroup selected={filter.regions} onToggle={toggleRegion} />
+          <RegionGroup regions={regions} selected={filter.regions} onToggle={toggleRegion} />
         </FilterPill>
 
         <FilterPill
@@ -485,17 +492,21 @@ function RatedGroup({ checked, onToggle }: { checked: boolean; onToggle: () => v
 }
 
 function RegionGroup({
+  regions,
   selected,
   onToggle,
 }: {
+  regions: string[]
   selected: string[]
   onToggle: (r: string) => void
 }) {
+  const options = [...new Set([...regions, ...selected])]
+  if (options.length === 0) return null
   return (
     <fieldset>
       <legend className="mb-2 text-sm font-medium">지역</legend>
       <div className="grid grid-cols-3 gap-x-4 gap-y-2.5">
-        {REGIONS.map((r) => (
+        {options.map((r) => (
           <div key={r} className="flex items-center gap-1.5">
             <Checkbox
               id={`region-${r}`}

--- a/src/components/roastery/RoasteryCard.test.tsx
+++ b/src/components/roastery/RoasteryCard.test.tsx
@@ -33,6 +33,7 @@ function makeRoastery(overrides: Partial<RoasteryWithStats> = {}): RoasteryWithS
     description: null,
     tags: [],
     locations: [],
+    regions: [],
     priceRange: 'MID',
     decaf: false,
     imageUrl: null,
@@ -40,15 +41,6 @@ function makeRoastery(overrides: Partial<RoasteryWithStats> = {}): RoasteryWithS
     avgRating: null,
     ratingCount: 0,
     ...overrides,
-  }
-}
-
-function makeTagItem(name: string, category: 'REGION' | 'CHARACTERISTIC', isPrimary = true) {
-  return {
-    id: `tag-${name}`,
-    name,
-    category: category as import('@/types/roastery').TagCategory,
-    isPrimary,
   }
 }
 
@@ -61,22 +53,14 @@ describe('RoasteryCard', () => {
 
   // C-02: 단일 지역 표시
   it('C-02: 단일 지역이 그대로 표시된다', () => {
-    const roastery = makeRoastery({
-      tags: [makeTagItem('서울', 'REGION', true)],
-    })
+    const roastery = makeRoastery({ regions: ['서울'] })
     render(<RoasteryCard roastery={roastery} />)
     expect(screen.getByText('서울')).toBeInTheDocument()
   })
 
   // C-03: 복수 지역 "서울 외 N곳" 표시
   it('C-03: 복수 지역이면 "서울 외 N곳" 형식으로 표시된다', () => {
-    const roastery = makeRoastery({
-      tags: [
-        makeTagItem('서울', 'REGION', true),
-        makeTagItem('부산', 'REGION', false),
-        makeTagItem('제주', 'REGION', false),
-      ],
-    })
+    const roastery = makeRoastery({ regions: ['서울', '부산', '제주'] })
     render(<RoasteryCard roastery={roastery} />)
     expect(screen.getByText('서울 외 2곳')).toBeInTheDocument()
   })

--- a/src/components/roastery/RoasteryCard.tsx
+++ b/src/components/roastery/RoasteryCard.tsx
@@ -7,7 +7,7 @@ import { Badge } from '@/components/ui/badge'
 import { RegionDisplay } from './RegionDisplay'
 import { RatingDisplay } from './RatingDisplay'
 import type { RoasteryWithStats } from '@/types/roastery'
-import { PRICE_RANGE_LABELS, getRegions, getCharacteristicTags } from '@/types/roastery'
+import { PRICE_RANGE_LABELS, getCharacteristicTags } from '@/types/roastery'
 import { SPRING_SNAPPY, TAP_SCALE } from '@/lib/motion'
 import { formatDistance } from '@/lib/geo'
 
@@ -54,7 +54,7 @@ export function RoasteryCard({
   nearbyAddress,
   nearbyDistance,
 }: RoasteryCardProps) {
-  const regions = getRegions(roastery.tags)
+  const regions = roastery.regions
   const charTags = getCharacteristicTags(roastery.tags)
 
   if (variant === 'landscape') {

--- a/src/components/roastery/RoasteryDetail.tsx
+++ b/src/components/roastery/RoasteryDetail.tsx
@@ -7,7 +7,7 @@ import { RatingButton } from '@/components/rating/RatingButton'
 import { BookmarkButton } from '@/components/bookmark/BookmarkButton'
 import { RatingList } from '@/components/rating/RatingList'
 import type { RoasteryDetail as RoasteryDetailType } from '@/types/roastery'
-import { PRICE_RANGE_LABELS, getRegions, getCharacteristicTags } from '@/types/roastery'
+import { PRICE_RANGE_LABELS, getCharacteristicTags } from '@/types/roastery'
 import { RoasteryLocationSection } from './RoasteryLocationSection'
 import type { RatingListItem, RatingSortOption } from '@/types/rating'
 
@@ -32,7 +32,7 @@ export function RoasteryDetail({
   initialSort,
   hideBackButton = false,
 }: RoasteryDetailProps) {
-  const regions = getRegions(roastery.tags)
+  const regions = roastery.regions
   const charTags = getCharacteristicTags(roastery.tags)
   const primaryLocation =
     roastery.locations.find((l) => l.isPrimary) ?? roastery.locations[0] ?? null

--- a/src/components/roastery/RoasteryPageHeader.tsx
+++ b/src/components/roastery/RoasteryPageHeader.tsx
@@ -6,14 +6,15 @@ interface Props {
   filter: FilterParams
   sort: SortOption
   isLoggedIn: boolean
+  regions: string[]
 }
 
-export function RoasteryPageHeader({ filter, sort, isLoggedIn }: Props) {
+export function RoasteryPageHeader({ filter, sort, isLoggedIn, regions }: Props) {
   return (
     <div className="flex flex-col gap-4">
       <h1 className="text-xl font-semibold">로스터리</h1>
       <Suspense fallback={null}>
-        <FilterPanel filter={filter} sort={sort} isLoggedIn={isLoggedIn} />
+        <FilterPanel filter={filter} sort={sort} isLoggedIn={isLoggedIn} regions={regions} />
       </Suspense>
     </div>
   )

--- a/src/components/roastery/map/RoasteryMapLayout.tsx
+++ b/src/components/roastery/map/RoasteryMapLayout.tsx
@@ -21,6 +21,7 @@ import { RoasteryDetail } from '@/components/roastery/RoasteryDetail'
 import { FilterPanel } from '@/components/roastery/FilterPanel'
 import { useMediaQuery } from '@/hooks/useMediaQuery'
 import { getNearbyLocations, formatDistance } from '@/lib/geo'
+import { getRegionFromAddress } from '@/lib/utils'
 import type { NearbyLocation } from '@/lib/geo'
 import type {
   RoasteryWithStats,
@@ -181,6 +182,12 @@ export function RoasteryMapLayout({
     for (const r of roasteries) {
       for (const loc of r.locations) {
         if (loc.lat !== null && loc.lng !== null) {
+          if (
+            activeRegions.length > 0 &&
+            !activeRegions.includes(getRegionFromAddress(loc.address) ?? '')
+          ) {
+            continue
+          }
           result.push({
             roasteryId: r.id,
             roasteryName: r.name,
@@ -193,7 +200,7 @@ export function RoasteryMapLayout({
       }
     }
     return result
-  }, [roasteries])
+  }, [roasteries, activeRegions])
 
   const nearbyMarkers = useMemo<MapMarkerData[]>(
     () =>

--- a/src/components/roastery/map/RoasteryMapLayout.tsx
+++ b/src/components/roastery/map/RoasteryMapLayout.tsx
@@ -59,6 +59,7 @@ interface Props {
   listUrl: string
   filter: FilterParams
   sort: SortOption
+  regionOptions: string[]
 }
 
 // ─── Session-level card position memory ──────────────────────────────────────
@@ -83,6 +84,7 @@ export function RoasteryMapLayout({
   listUrl,
   filter,
   sort,
+  regionOptions,
 }: Props) {
   const router = useRouter()
   const searchParams = useSearchParams()
@@ -344,7 +346,13 @@ export function RoasteryMapLayout({
         <div className="w-[360px] xl:w-[400px] shrink-0 flex flex-col border-r overflow-hidden">
           {/* 검색 */}
           <div className="shrink-0 px-4 py-4 border-b">
-            <FilterPanel filter={filter} sort={sort} isLoggedIn={isLoggedIn} variant="map-search" />
+            <FilterPanel
+              filter={filter}
+              sort={sort}
+              isLoggedIn={isLoggedIn}
+              variant="map-search"
+              regions={regionOptions}
+            />
           </div>
           <div className="flex items-center justify-between px-4 py-3 border-b shrink-0">
             {nearbyMode ? (
@@ -443,6 +451,7 @@ export function RoasteryMapLayout({
                 sort={sort}
                 isLoggedIn={isLoggedIn}
                 variant="map-pills"
+                regions={regionOptions}
               />
               <button
                 onClick={handleGpsClick}

--- a/src/lib/queries/bookmark.ts
+++ b/src/lib/queries/bookmark.ts
@@ -64,6 +64,7 @@ export async function getBookmarks(
       ...b.roastery,
       tags: flattenTags(b.roastery.tags),
       locations: [],
+      regions: [],
       ratingCount: b.roastery._count.ratings,
       avgRating: avgMap.get(b.roasteryId) ?? null,
     },

--- a/src/lib/queries/recommendation.ts
+++ b/src/lib/queries/recommendation.ts
@@ -59,6 +59,7 @@ export async function getPopularRoasteries(
       ...r,
       tags: flattenTags(r.tags),
       locations: [] as never[],
+      regions: [] as string[],
       ratingCount: r._count.ratings,
       avgRating: avgMap.get(r.id) ?? null,
     }))
@@ -127,6 +128,7 @@ export async function getFeaturedSections(): Promise<FeaturedSectionData[]> {
       ...r,
       tags: flattenTags(r.tags),
       locations: [] as never[],
+      regions: [] as string[],
       ratingCount: r._count.ratings,
       avgRating: avgMap.get(r.id) ?? null,
     })),
@@ -185,6 +187,7 @@ export async function getStoredRecommendations(userId: string): Promise<StoredRe
       ...rec.roastery,
       tags: flattenTags(rec.roastery.tags),
       locations: [] as never[],
+      regions: [] as string[],
       ratingCount: rec.roastery._count.ratings,
       avgRating: avgMap.get(rec.roasteryId) ?? null,
     },

--- a/src/lib/queries/roastery.ts
+++ b/src/lib/queries/roastery.ts
@@ -9,6 +9,7 @@ import type {
   LocationItem,
 } from '@/types/roastery'
 import { flattenTags } from '@/types/roastery'
+import { getRegionFromAddress, getRegionsFromLocations, regionToAddressPrefixes } from '@/lib/utils'
 
 const DEFAULT_FILTER: FilterParams = {
   q: '',
@@ -39,9 +40,14 @@ export async function getRoasteries(
   const andConditions: Prisma.RoasteryWhereInput[] = []
 
   if (filter.regions.length > 0) {
-    andConditions.push({
-      tags: { some: { tag: { category: 'REGION', name: { in: filter.regions } } } },
-    })
+    const regionOrConditions = filter.regions.flatMap((region) =>
+      regionToAddressPrefixes(region).map((prefix) => ({
+        locations: { some: { isPrimary: true, address: { startsWith: prefix } } },
+      }))
+    )
+    if (regionOrConditions.length > 0) {
+      andConditions.push({ OR: regionOrConditions })
+    }
   }
   if (filter.tags.length > 0) {
     andConditions.push({
@@ -85,13 +91,17 @@ export async function getRoasteries(
 
   const avgMap = new Map(avgRatings.map((r) => [r.roasteryId, r._avg.score]))
 
-  const result = roasteries.map((r) => ({
-    ...r,
-    tags: flattenTags(r.tags),
-    locations: r.locations as LocationItem[],
-    ratingCount: r._count.ratings,
-    avgRating: avgMap.get(r.id) ?? null,
-  }))
+  const result = roasteries.map((r) => {
+    const locations = r.locations as LocationItem[]
+    return {
+      ...r,
+      tags: flattenTags(r.tags),
+      locations,
+      regions: getRegionsFromLocations(locations),
+      ratingCount: r._count.ratings,
+      avgRating: avgMap.get(r.id) ?? null,
+    }
+  })
 
   if (sort === 'popular') {
     result.sort((a, b) => {
@@ -133,6 +143,20 @@ function flattenChannels(
     price: priceByChannelId ? (priceByChannelId.get(c.id) ?? null) : null,
     order: c.definition.order,
   }))
+}
+
+export async function getRegionOptions(): Promise<string[]> {
+  const locations = await prisma.roasteryLocation.findMany({
+    where: {
+      isPrimary: true,
+      roastery: { deletedAt: null, hidden: false, closedAt: null },
+    },
+    select: { address: true },
+  })
+  const regions = [
+    ...new Set(locations.map((l) => getRegionFromAddress(l.address)).filter(Boolean)),
+  ] as string[]
+  return regions.sort()
 }
 
 export async function getRoasteryById(id: string): Promise<RoasteryDetail | null> {
@@ -229,11 +253,13 @@ export async function getRoasteryById(id: string): Promise<RoasteryDetail | null
     }
   })
 
+  const locations = roastery.locations as LocationItem[]
   return {
     ...roastery,
     closedAt: roastery.closedAt,
     tags: flattenTags(roastery.tags),
-    locations: roastery.locations as LocationItem[],
+    locations,
+    regions: getRegionsFromLocations(locations),
     ratingCount: roastery._count.ratings,
     avgRating: avgRating._avg.score ?? null,
     channels: baseChannels,

--- a/src/lib/queries/roastery.ts
+++ b/src/lib/queries/roastery.ts
@@ -42,7 +42,7 @@ export async function getRoasteries(
   if (filter.regions.length > 0) {
     const regionOrConditions = filter.regions.flatMap((region) =>
       regionToAddressPrefixes(region).map((prefix) => ({
-        locations: { some: { isPrimary: true, address: { startsWith: prefix } } },
+        locations: { some: { address: { startsWith: prefix } } },
       }))
     )
     if (regionOrConditions.length > 0) {

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { cn, formatRegions } from './utils'
+import { cn, formatRegions, getRegionFromAddress, getRegionsFromLocations } from './utils'
 
 describe('cn', () => {
   it('클래스를 합친다', () => {
@@ -44,5 +44,53 @@ describe('formatRegions', () => {
   // U-06: 단일 지역이 필터에 해당 (대표 지역 = 필터 지역)
   it('단일 지역이고 그 지역이 필터에 해당하면 지역명만 반환한다', () => {
     expect(formatRegions(['서울'], ['서울'])).toBe('서울')
+  })
+})
+
+describe('getRegionFromAddress', () => {
+  it('서울특별시 주소에서 "서울"을 반환한다', () => {
+    expect(getRegionFromAddress('서울특별시 마포구 도화동 179-9')).toBe('서울')
+  })
+  it('경기도 주소에서 "경기"를 반환한다', () => {
+    expect(getRegionFromAddress('경기도 고양시 일산동구 정발산로')).toBe('경기')
+  })
+  it('충청북도 주소에서 "충북"을 반환한다', () => {
+    expect(getRegionFromAddress('충청북도 청주시 흥덕구')).toBe('충북')
+  })
+  it('전북특별자치도 주소에서 "전북"을 반환한다', () => {
+    expect(getRegionFromAddress('전북특별자치도 전주시 완산구')).toBe('전북')
+  })
+  it('전라북도 주소에서 "전북"을 반환한다', () => {
+    expect(getRegionFromAddress('전라북도 전주시 완산구')).toBe('전북')
+  })
+  it('null 입력 시 null을 반환한다', () => {
+    expect(getRegionFromAddress(null)).toBeNull()
+  })
+  it('매핑 불가 주소는 null을 반환한다', () => {
+    expect(getRegionFromAddress('알 수 없는 주소')).toBeNull()
+  })
+})
+
+describe('getRegionsFromLocations', () => {
+  it('대표 지점 지역이 먼저 온다', () => {
+    const locations = [
+      { address: '부산광역시 해운대구', isPrimary: false },
+      { address: '서울특별시 강남구', isPrimary: true },
+    ]
+    expect(getRegionsFromLocations(locations)).toEqual(['서울', '부산'])
+  })
+  it('같은 지역의 복수 지점은 중복 제거한다', () => {
+    const locations = [
+      { address: '서울특별시 강남구', isPrimary: true },
+      { address: '서울특별시 마포구', isPrimary: false },
+    ]
+    expect(getRegionsFromLocations(locations)).toEqual(['서울'])
+  })
+  it('주소가 null인 지점은 무시한다', () => {
+    const locations = [
+      { address: null, isPrimary: true },
+      { address: '부산광역시 해운대구', isPrimary: false },
+    ]
+    expect(getRegionsFromLocations(locations)).toEqual(['부산'])
   })
 })

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -5,6 +5,82 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
+// 한국 주소 첫 부분 → 광역시/도 약어 매핑 (긴 prefix 먼저)
+const ADDRESS_PREFIX_MAP: [prefix: string, region: string][] = [
+  ['충청북도', '충북'],
+  ['충청남도', '충남'],
+  ['전북특별자치도', '전북'],
+  ['전라북도', '전북'],
+  ['전라남도', '전남'],
+  ['경상북도', '경북'],
+  ['경상남도', '경남'],
+  ['강원특별자치도', '강원'],
+  ['제주특별자치도', '제주'],
+  ['서울', '서울'],
+  ['부산', '부산'],
+  ['대구', '대구'],
+  ['인천', '인천'],
+  ['광주', '광주'],
+  ['대전', '대전'],
+  ['울산', '울산'],
+  ['세종', '세종'],
+  ['경기', '경기'],
+  ['강원', '강원'],
+  ['제주', '제주'],
+]
+
+// 광역시/도 약어 → 주소 prefix 역방향 매핑 (필터 쿼리용)
+const REGION_TO_PREFIXES: Record<string, string[]> = {
+  서울: ['서울'],
+  부산: ['부산'],
+  대구: ['대구'],
+  인천: ['인천'],
+  광주: ['광주'],
+  대전: ['대전'],
+  울산: ['울산'],
+  세종: ['세종'],
+  경기: ['경기'],
+  강원: ['강원특별자치도', '강원'],
+  충북: ['충청북도'],
+  충남: ['충청남도'],
+  전북: ['전북특별자치도', '전라북도'],
+  전남: ['전라남도'],
+  경북: ['경상북도'],
+  경남: ['경상남도'],
+  제주: ['제주특별자치도', '제주'],
+}
+
+/** 한국 도로명/지번 주소에서 광역시/도 약어를 추출한다. 매핑 실패 시 null. */
+export function getRegionFromAddress(address: string | null): string | null {
+  if (!address) return null
+  for (const [prefix, region] of ADDRESS_PREFIX_MAP) {
+    if (address.startsWith(prefix)) return region
+  }
+  return null
+}
+
+/** 지역 약어를 Prisma address startsWith 조건용 prefix 배열로 변환한다. */
+export function regionToAddressPrefixes(region: string): string[] {
+  return REGION_TO_PREFIXES[region] ?? []
+}
+
+/** locations 배열에서 지역 약어 배열을 추출한다 (대표 지점 먼저). */
+export function getRegionsFromLocations(
+  locations: { address: string | null; isPrimary: boolean }[]
+): string[] {
+  const sorted = [...locations].sort((a, b) => Number(b.isPrimary) - Number(a.isPrimary))
+  const seen = new Set<string>()
+  const result: string[] = []
+  for (const loc of sorted) {
+    const region = getRegionFromAddress(loc.address)
+    if (region && !seen.has(region)) {
+      seen.add(region)
+      result.push(region)
+    }
+  }
+  return result
+}
+
 /**
  * 로스터리 지역 목록을 표시용 문자열로 변환
  *

--- a/src/types/roastery.ts
+++ b/src/types/roastery.ts
@@ -31,6 +31,7 @@ export interface RoasteryWithStats {
   name: string
   description: string | null
   tags: TagItem[]
+  regions: string[] // locations에서 파생 — 대표 지점 먼저
   priceRange: PriceRange
   decaf: boolean
   imageUrl: string | null


### PR DESCRIPTION
## 변경 사항
- 한국 주소 → 지역 약어 파싱 유틸 추가 (`getRegionFromAddress`, `getRegionsFromLocations`, `regionToAddressPrefixes`)
- `RoasteryWithStats`에 `regions: string[]` 추가 — `RoasteryLocation.address`에서 자동 파생
- 지역 필터를 REGION 태그 → 위치 주소 기반으로 변경 (모든 지점 대상)
- `getRegionOptions()`: 실제 서비스 중인 지역 목록을 DB에서 동적 조회
- Admin 로스터리 등록/수정 시 address 입력 → primary `RoasteryLocation` 자동 생성
- Admin 로스터리 목록 / 섹션 페이지: REGION 태그 → 위치 주소 기반 지역 표시
- Admin 폼에서 수동 지역 태그 입력 제거

## 테스트 방법
- [x] 로스터리 목록 페이지 → 지역 필터 동작 확인 (실제 DB에 있는 지역만 표시)
- [x] 다점포 로스터리의 경우 비대표 지점 지역으로도 필터 검색 가능한지 확인
- [x] Admin에서 새 로스터리 등록 시 주소 입력 → 지역 필터에 반영되는지 확인
- [x] Admin 로스터리 목록에서 지역 컬럼이 주소 기반으로 표시되는지 확인