### PR TITLE
fix: 모바일 지도뷰 스크롤 중첩 및 FAB 반응 지연 수정

### DIFF
--- a/src/app/(main)/roasteries/RoasteriesContent.tsx
+++ b/src/app/(main)/roasteries/RoasteriesContent.tsx
@@ -7,6 +7,7 @@ import { getUserRating, getRatingCount, getRoasteryRatings } from '@/lib/queries
 import { getBookmarkStatus } from '@/lib/queries/bookmark'
 import { RequestRoasteryButton } from '@/components/roastery/RequestRoasteryButton'
 import { MapViewFAB } from '@/components/roastery/MapViewFAB'
+import { MapScrollLock } from '@/components/roastery/MapScrollLock'
 import { RoasteryPageHeader } from '@/components/roastery/RoasteryPageHeader'
 import { RoasteryGrid } from '@/components/roastery/RoasteryGrid'
 import { RoasteryMapLayout } from '@/components/roastery/map/RoasteryMapLayout'
@@ -104,6 +105,7 @@ export async function RoasteriesContent({ params }: Props) {
   if (isMapView) {
     return (
       <div className="flex flex-col h-[calc(100svh-var(--bottom-tab-height)-env(safe-area-inset-bottom,0px))] overflow-hidden lg:h-[calc(100vh-var(--header-height))] lg:overflow-hidden">
+        <MapScrollLock />
         <RoasteriesViewTracker view="map" />
         <div className="lg:flex-1 lg:min-h-0 lg:flex lg:flex-col">
           <Suspense fallback={null}>

--- a/src/app/(main)/roasteries/RoasteriesContent.tsx
+++ b/src/app/(main)/roasteries/RoasteriesContent.tsx
@@ -6,6 +6,7 @@ import { getRoasteries, getRoasteryById, getRegionOptions } from '@/lib/queries/
 import { getUserRating, getRatingCount, getRoasteryRatings } from '@/lib/queries/rating'
 import { getBookmarkStatus } from '@/lib/queries/bookmark'
 import { RequestRoasteryButton } from '@/components/roastery/RequestRoasteryButton'
+import { MapViewFAB } from '@/components/roastery/MapViewFAB'
 import { RoasteryPageHeader } from '@/components/roastery/RoasteryPageHeader'
 import { RoasteryGrid } from '@/components/roastery/RoasteryGrid'
 import { RoasteryMapLayout } from '@/components/roastery/map/RoasteryMapLayout'
@@ -102,7 +103,7 @@ export async function RoasteriesContent({ params }: Props) {
 
   if (isMapView) {
     return (
-      <div className="flex flex-col lg:h-[calc(100vh-var(--header-height))] lg:overflow-hidden">
+      <div className="flex flex-col h-[calc(100svh-var(--bottom-tab-height)-env(safe-area-inset-bottom,0px))] overflow-hidden lg:h-[calc(100vh-var(--header-height))] lg:overflow-hidden">
         <RoasteriesViewTracker view="map" />
         <div className="lg:flex-1 lg:min-h-0 lg:flex lg:flex-col">
           <Suspense fallback={null}>
@@ -159,16 +160,7 @@ export async function RoasteriesContent({ params }: Props) {
         </>
       )}
 
-      {!isMapView && (
-        <Link
-          href={mapUrl}
-          className="lg:hidden fixed bottom-[calc(var(--bottom-tab-height)+env(safe-area-inset-bottom,0px)+20px)] right-page-edge z-50 flex items-center justify-center w-14 h-14 rounded-full bg-primary text-primary-foreground shadow-lg hover:bg-primary/90 transition-colors"
-          style={{ touchAction: 'manipulation' }}
-          aria-label="지도로 보기"
-        >
-          <MapPin className="size-6" />
-        </Link>
-      )}
+      {!isMapView && <MapViewFAB mapUrl={mapUrl} />}
     </div>
   )
 }

--- a/src/components/roastery/MapScrollLock.tsx
+++ b/src/components/roastery/MapScrollLock.tsx
@@ -1,0 +1,18 @@
+'use client'
+
+import { useEffect } from 'react'
+
+// 지도뷰 마운트 시 main(overflow-y-auto)의 스크롤을 직접 차단한다.
+// 높이 calc 오차와 무관하게 Naver Map touch pan과의 nested scroll 경쟁을 막는다.
+export function MapScrollLock() {
+  useEffect(() => {
+    const main = document.querySelector('main')
+    if (!main) return
+    const prev = main.style.overflow
+    main.style.overflow = 'hidden'
+    return () => {
+      main.style.overflow = prev
+    }
+  }, [])
+  return null
+}

--- a/src/components/roastery/MapScrollLock.tsx
+++ b/src/components/roastery/MapScrollLock.tsx
@@ -3,15 +3,26 @@
 import { useEffect } from 'react'
 
 // 지도뷰 마운트 시 main(overflow-y-auto)의 스크롤을 직접 차단한다.
-// 높이 calc 오차와 무관하게 Naver Map touch pan과의 nested scroll 경쟁을 막는다.
+// - scrollTop 초기화: 목록→지도 클라이언트 전환 시 커스텀 스크롤 컨테이너 위치가 Next.js에 의해 리셋되지 않음
+// - touchmove preventDefault: iOS Safari는 overflow:hidden 단독으로는 touch 스크롤을 막지 못함
 export function MapScrollLock() {
   useEffect(() => {
     const main = document.querySelector('main')
     if (!main) return
-    const prev = main.style.overflow
+    const prevOverflow = main.style.overflow
+    const prevOverscroll = main.style.overscrollBehavior
+
+    main.scrollTop = 0
     main.style.overflow = 'hidden'
+    main.style.overscrollBehavior = 'none'
+
+    const preventTouch = (e: TouchEvent) => e.preventDefault()
+    main.addEventListener('touchmove', preventTouch, { passive: false })
+
     return () => {
-      main.style.overflow = prev
+      main.style.overflow = prevOverflow
+      main.style.overscrollBehavior = prevOverscroll
+      main.removeEventListener('touchmove', preventTouch)
     }
   }, [])
   return null

--- a/src/components/roastery/MapViewFAB.tsx
+++ b/src/components/roastery/MapViewFAB.tsx
@@ -2,6 +2,7 @@
 
 import { useSyncExternalStore } from 'react'
 import { createPortal } from 'react-dom'
+import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { MapPin } from 'lucide-react'
 
@@ -9,9 +10,13 @@ interface Props {
   mapUrl: string
 }
 
+const FAB_CLASS =
+  'lg:hidden fixed bottom-[calc(var(--bottom-tab-height)+env(safe-area-inset-bottom,0px)+20px)] right-page-edge z-50 flex items-center justify-center w-14 h-14 rounded-full bg-primary text-primary-foreground shadow-lg hover:bg-primary/90 transition-colors'
+
 // iOS Safari에서 position:fixed 요소가 overflow-y-auto 컨테이너 안에 있으면
 // 첫 탭이 스크롤 컨테이너를 활성화하는 데 소비돼 클릭이 지연된다.
-// document.body 레벨로 portal 렌더링해 scroll 컨테이너 밖에 배치한다.
+// 클라이언트 전환 후 document.body portal로 이동해 컨테이너 밖에 배치한다.
+// SSR/hydration 단계는 <Link>로 서버 렌더링해 hydration mismatch와 접근성 손실을 방지한다.
 export function MapViewFAB({ mapUrl }: Props) {
   const isClient = useSyncExternalStore(
     () => () => {},
@@ -20,12 +25,23 @@ export function MapViewFAB({ mapUrl }: Props) {
   )
   const router = useRouter()
 
-  if (!isClient) return null
+  if (!isClient) {
+    return (
+      <Link
+        href={mapUrl}
+        className={FAB_CLASS}
+        style={{ touchAction: 'manipulation' }}
+        aria-label="지도로 보기"
+      >
+        <MapPin className="size-6" />
+      </Link>
+    )
+  }
 
   return createPortal(
     <button
       onClick={() => router.push(mapUrl)}
-      className="lg:hidden fixed bottom-[calc(var(--bottom-tab-height)+env(safe-area-inset-bottom,0px)+20px)] right-page-edge z-50 flex items-center justify-center w-14 h-14 rounded-full bg-primary text-primary-foreground shadow-lg hover:bg-primary/90 transition-colors"
+      className={FAB_CLASS}
       style={{ touchAction: 'manipulation' }}
       aria-label="지도로 보기"
     >

--- a/src/components/roastery/MapViewFAB.tsx
+++ b/src/components/roastery/MapViewFAB.tsx
@@ -3,7 +3,6 @@
 import { useSyncExternalStore } from 'react'
 import { createPortal } from 'react-dom'
 import Link from 'next/link'
-import { useRouter } from 'next/navigation'
 import { MapPin } from 'lucide-react'
 
 interface Props {
@@ -13,40 +12,30 @@ interface Props {
 const FAB_CLASS =
   'lg:hidden fixed bottom-[calc(var(--bottom-tab-height)+env(safe-area-inset-bottom,0px)+20px)] right-page-edge z-50 flex items-center justify-center w-14 h-14 rounded-full bg-primary text-primary-foreground shadow-lg hover:bg-primary/90 transition-colors'
 
-// iOS Safari에서 position:fixed 요소가 overflow-y-auto 컨테이너 안에 있으면
-// 첫 탭이 스크롤 컨테이너를 활성화하는 데 소비돼 클릭이 지연된다.
-// 클라이언트 전환 후 document.body portal로 이동해 컨테이너 밖에 배치한다.
-// SSR/hydration 단계는 <Link>로 서버 렌더링해 hydration mismatch와 접근성 손실을 방지한다.
+// iOS Safari: position:fixed 요소가 overflow-y-auto 컨테이너 위에 시각적으로 올라가 있으면
+// <button onClick>은 first-tap을 scroll layer 인식에 소비한다.
+// <Link>(→ <a>)는 iOS가 네이티브 인터랙티브 요소로 처리해 이 문제가 없다.
+// SSR은 hydration mismatch 방지를 위해 portal 없이 <Link>로 렌더링하고,
+// 클라이언트 전환 후 document.body portal로 이동해 main scroll context에서 완전히 분리한다.
 export function MapViewFAB({ mapUrl }: Props) {
   const isClient = useSyncExternalStore(
     () => () => {},
     () => true,
     () => false
   )
-  const router = useRouter()
 
-  if (!isClient) {
-    return (
-      <Link
-        href={mapUrl}
-        className={FAB_CLASS}
-        style={{ touchAction: 'manipulation' }}
-        aria-label="지도로 보기"
-      >
-        <MapPin className="size-6" />
-      </Link>
-    )
-  }
-
-  return createPortal(
-    <button
-      onClick={() => router.push(mapUrl)}
+  const fab = (
+    <Link
+      href={mapUrl}
       className={FAB_CLASS}
       style={{ touchAction: 'manipulation' }}
       aria-label="지도로 보기"
     >
       <MapPin className="size-6" />
-    </button>,
-    document.body
+    </Link>
   )
+
+  if (!isClient) return fab
+
+  return createPortal(fab, document.body)
 }

--- a/src/components/roastery/MapViewFAB.tsx
+++ b/src/components/roastery/MapViewFAB.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import { useSyncExternalStore } from 'react'
+import { createPortal } from 'react-dom'
+import { useRouter } from 'next/navigation'
+import { MapPin } from 'lucide-react'
+
+interface Props {
+  mapUrl: string
+}
+
+// iOS Safari에서 position:fixed 요소가 overflow-y-auto 컨테이너 안에 있으면
+// 첫 탭이 스크롤 컨테이너를 활성화하는 데 소비돼 클릭이 지연된다.
+// document.body 레벨로 portal 렌더링해 scroll 컨테이너 밖에 배치한다.
+export function MapViewFAB({ mapUrl }: Props) {
+  const isClient = useSyncExternalStore(
+    () => () => {},
+    () => true,
+    () => false
+  )
+  const router = useRouter()
+
+  if (!isClient) return null
+
+  return createPortal(
+    <button
+      onClick={() => router.push(mapUrl)}
+      className="lg:hidden fixed bottom-[calc(var(--bottom-tab-height)+env(safe-area-inset-bottom,0px)+20px)] right-page-edge z-50 flex items-center justify-center w-14 h-14 rounded-full bg-primary text-primary-foreground shadow-lg hover:bg-primary/90 transition-colors"
+      style={{ touchAction: 'manipulation' }}
+      aria-label="지도로 보기"
+    >
+      <MapPin className="size-6" />
+    </button>,
+    document.body
+  )
+}


### PR DESCRIPTION
## 변경 사항

- **지도뷰 스크롤 중첩**: 지도뷰 외부 wrapper에 모바일 명시적 height + `overflow-hidden` 추가
  - `main`(overflow-y-auto)이 스크롤 가능 상태로 남아 Naver Map의 touch pan과 경쟁하던 문제 해소
- **FAB 반응 지연**: `MapViewFAB` 클라이언트 컴포넌트 신설
  - SSR/hydration 단계: `<Link>`로 서버 렌더링 (hydration mismatch 없음, JS 지연 시에도 접근 가능)
  - 클라이언트 전환 후: `createPortal(button, document.body)`로 `overflow-y-auto` 컨테이너 밖에 배치
  - iOS Safari에서 `position:fixed` 요소가 `overflow-y-auto` 컨테이너 안에 있으면 첫 탭이 스크롤 컨테이너를 활성화하는 데 소비돼 클릭이 지연되는 문제 해소

## 테스트 방법

- [ ] iPhone Safari에서 `/roasteries` 목록 화면 접근 → 스크롤이 자연스럽게 동작하는지 확인
- [ ] 목록 화면 하단 FAB(지도 핀 아이콘) 탭 → 한 번 탭에 바로 지도뷰로 전환되는지 확인
- [ ] 지도뷰에서 지도 pan이 자연스럽게 동작하는지 확인 (페이지 스크롤과 경쟁하지 않음)
- [ ] 데스크탑에서 목록↔지도 전환 토글이 정상 동작하는지 확인