### PR TITLE
refactor: BottomTab을 fixed에서 flex item으로 전환

### DIFF
--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -17,7 +17,7 @@ export default async function MainLayout({ children }: { children: React.ReactNo
   }
 
   return (
-    <div className="flex h-[100svh] flex-col bg-bg">
+    <div className="flex h-[100svh] flex-col bg-surface lg:bg-bg">
       <Header className="hidden lg:flex" />
       <main className="flex-1 overflow-y-auto">
         <PageTransition>{children}</PageTransition>

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -17,10 +17,7 @@ export default async function MainLayout({ children }: { children: React.ReactNo
   }
 
   return (
-    <div
-      className="flex flex-col bg-bg"
-      style={{ height: 'calc(100svh + env(safe-area-inset-bottom, 0px))' }}
-    >
+    <div className="flex h-[100svh] flex-col bg-bg">
       <Header className="hidden lg:flex" />
       <main className="flex-1 overflow-y-auto">
         <PageTransition>{children}</PageTransition>

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -1,7 +1,8 @@
 import { redirect } from 'next/navigation'
 import { auth } from '@/lib/auth'
 import { prisma } from '@/lib/prisma'
-import { Navigation } from '@/components/layout/Navigation'
+import { Header } from '@/components/layout/Header'
+import { BottomTab } from '@/components/layout/BottomTab'
 import { PageTransition } from '@/components/motion/PageTransition'
 
 export default async function MainLayout({ children }: { children: React.ReactNode }) {
@@ -17,11 +18,11 @@ export default async function MainLayout({ children }: { children: React.ReactNo
 
   return (
     <div className="flex h-[100svh] flex-col bg-bg">
-      <Navigation />
-      {/* 모바일: BottomTab 높이(64px)만큼 하단 패딩 */}
-      <main className="flex-1 overflow-y-auto pb-[calc(var(--bottom-tab-height)+env(safe-area-inset-bottom,0px))] lg:pb-0">
+      <Header className="hidden lg:flex" />
+      <main className="flex-1 overflow-y-auto">
         <PageTransition>{children}</PageTransition>
       </main>
+      <BottomTab className="flex lg:hidden" />
     </div>
   )
 }

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -17,7 +17,10 @@ export default async function MainLayout({ children }: { children: React.ReactNo
   }
 
   return (
-    <div className="flex h-[100svh] flex-col bg-bg">
+    <div
+      className="flex flex-col bg-bg"
+      style={{ height: 'calc(100svh + env(safe-area-inset-bottom, 0px))' }}
+    >
       <Header className="hidden lg:flex" />
       <main className="flex-1 overflow-y-auto">
         <PageTransition>{children}</PageTransition>

--- a/src/components/layout/BottomTab.tsx
+++ b/src/components/layout/BottomTab.tsx
@@ -33,7 +33,7 @@ export function BottomTab({ className }: { className?: string }) {
   return (
     <nav
       className={cn(
-        'fixed bottom-0 left-0 right-0 z-40 border-t border-border bg-surface',
+        'border-t border-border bg-surface',
         'pb-[env(safe-area-inset-bottom,0px)]',
         className
       )}

--- a/src/components/layout/BottomTab.tsx
+++ b/src/components/layout/BottomTab.tsx
@@ -37,6 +37,7 @@ export function BottomTab({ className }: { className?: string }) {
         'pb-[env(safe-area-inset-bottom,0px)]',
         className
       )}
+      style={{ boxShadow: '0 100px 0 100px var(--color-surface)' }}
     >
       <ul className="flex h-16 w-full">
         {tabs.map(({ key, href, label, Icon }) => {

--- a/src/components/layout/BottomTab.tsx
+++ b/src/components/layout/BottomTab.tsx
@@ -37,7 +37,6 @@ export function BottomTab({ className }: { className?: string }) {
         'pb-[env(safe-area-inset-bottom,0px)]',
         className
       )}
-      style={{ boxShadow: '0 100px 0 100px var(--color-surface)' }}
     >
       <ul className="flex h-16 w-full">
         {tabs.map(({ key, href, label, Icon }) => {

--- a/src/components/layout/Navigation.test.tsx
+++ b/src/components/layout/Navigation.test.tsx
@@ -35,8 +35,9 @@ describe('Navigation', () => {
   // C-26: lg 이상 화면 — Header 표시, BottomTab 숨김
   it('BottomTab은 lg 이상에서 hidden 클래스를 갖는다', () => {
     const { container } = render(<Navigation />)
-    // BottomTab은 fixed bottom-0 클래스를 가진 nav — Header 내부 nav와 구분
-    const bottomTabNav = container.querySelector('nav[class*="fixed"]')
+    // BottomTab nav는 lg:hidden 클래스를 가짐 — Header 내부 nav와 구분
+    const navs = Array.from(container.querySelectorAll('nav'))
+    const bottomTabNav = navs.find((nav) => nav.className.includes('lg:hidden'))
     expect(bottomTabNav?.className).toContain('lg:hidden')
   })
 })


### PR DESCRIPTION
## 변경 사항
- `BottomTab`의 `fixed bottom-0 left-0 right-0 z-40` 제거 → flex item으로 전환
- `layout.tsx`에서 `Navigation` 래퍼 제거, `Header`를 main 위에, `BottomTab`을 main 아래에 직접 배치
- `main`의 `pb-[calc(var(--bottom-tab-height)+env(safe-area-inset-bottom))]` 보정 패딩 제거
- `safe-area-inset-bottom`은 BottomTab 자체에 유지 (iPhone 홈 인디케이터 대응)
- `Navigation.test.tsx`: `fixed` 클래스 기반 셀렉터를 `lg:hidden` 기반으로 수정

## 테스트 방법
- [ ] 모바일 뷰에서 BottomTab이 화면 하단에 정상 표시되는지 확인
- [ ] BottomTab 위 컨텐츠가 탭에 가려지지 않는지 확인
- [ ] `/roasteries?view=map` 지도 뷰에서 지도 높이가 정상인지 확인
- [ ] iPhone safe-area 환경에서 홈 인디케이터와 탭이 겹치지 않는지 확인
- [ ] 데스크탑(lg 이상)에서 Header/네비게이션 정상 표시 확인