### PR TITLE
fix: iOS safe area·이중 스크롤 수정

### DIFF
--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -1,6 +1,6 @@
 export default function AuthLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-bg px-4">
+    <div className="flex min-h-full flex-col items-center justify-center overflow-y-auto bg-bg px-4">
       {children}
     </div>
   )

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -1,7 +1,7 @@
 export default function AuthLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="h-full overflow-y-auto bg-bg px-4">
-      <div className="flex min-h-full flex-col items-center justify-center py-8">{children}</div>
+    <div className="flex min-h-full flex-col items-center justify-center overflow-y-auto bg-bg px-4">
+      {children}
     </div>
   )
 }

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -1,7 +1,7 @@
 export default function AuthLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="flex min-h-full flex-col items-center justify-center overflow-y-auto bg-bg px-4">
-      {children}
+    <div className="h-full overflow-y-auto bg-bg px-4">
+      <div className="flex min-h-full flex-col items-center justify-center py-8">{children}</div>
     </div>
   )
 }

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -18,15 +18,13 @@ export default async function MainLayout({ children }: { children: React.ReactNo
   return (
     <div className="flex h-dvh flex-col bg-bg">
       <Navigation />
-      <main className="flex-1 overflow-y-auto">
+      <main
+        className="fixed inset-x-0 top-0 overflow-y-auto bg-bg
+          bottom-[calc(var(--bottom-tab-height)+env(safe-area-inset-bottom,0px))]
+          lg:static lg:flex-1 lg:bottom-auto"
+      >
         <PageTransition>{children}</PageTransition>
       </main>
-      {/* 모바일 BottomTab 스페이서 — flex 레이아웃에서 탭 높이만큼 공간 확보,
-          main 스크롤바가 BottomTab 뒤로 들어가지 않도록 함 */}
-      <div
-        className="flex-none lg:hidden h-[calc(var(--bottom-tab-height)+env(safe-area-inset-bottom,0px))]"
-        aria-hidden="true"
-      />
     </div>
   )
 }

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -18,10 +18,15 @@ export default async function MainLayout({ children }: { children: React.ReactNo
   return (
     <div className="flex h-dvh flex-col bg-bg">
       <Navigation />
-      {/* 모바일: BottomTab 높이(64px)만큼 하단 패딩 */}
-      <main className="flex-1 overflow-y-auto pb-[calc(var(--bottom-tab-height)+env(safe-area-inset-bottom,0px))] lg:pb-0">
+      <main className="flex-1 overflow-y-auto">
         <PageTransition>{children}</PageTransition>
       </main>
+      {/* 모바일 BottomTab 스페이서 — flex 레이아웃에서 탭 높이만큼 공간 확보,
+          main 스크롤바가 BottomTab 뒤로 들어가지 않도록 함 */}
+      <div
+        className="flex-none lg:hidden h-[calc(var(--bottom-tab-height)+env(safe-area-inset-bottom,0px))]"
+        aria-hidden="true"
+      />
     </div>
   )
 }

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -16,7 +16,7 @@ export default async function MainLayout({ children }: { children: React.ReactNo
   }
 
   return (
-    <div className="flex h-[100svh] flex-col bg-bg">
+    <div className="flex h-dvh flex-col bg-bg">
       <Navigation />
       {/* 모바일: BottomTab 높이(64px)만큼 하단 패딩 */}
       <main className="flex-1 overflow-y-auto pb-[calc(var(--bottom-tab-height)+env(safe-area-inset-bottom,0px))] lg:pb-0">

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -8,7 +8,7 @@ export default async function AdminLayout({ children }: { children: React.ReactN
   if (session?.user?.role !== 'ADMIN') redirect('/')
 
   return (
-    <div className="min-h-screen bg-bg">
+    <div className="h-full overflow-y-auto bg-bg">
       <header className="border-b border-border bg-surface">
         <div className="mx-auto flex max-w-5xl items-center justify-between px-4 py-3">
           <nav className="flex items-center gap-6">

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -197,8 +197,15 @@
   -webkit-font-smoothing: antialiased;
 }
 
+html {
+  height: 100%;
+  background-color: var(--color-bg); /* safe-area 상단 배경 통일 */
+}
+
 body {
-  overflow-x: clip; /* edge-to-edge 스크롤 섹션의 가로 스크롤바 방지 */
+  height: 100%;
+  overflow: hidden; /* body 레벨 스크롤 차단 (overflow-x: clip 대체) */
+  overscroll-behavior: none; /* iOS rubber-band 방지 */
 }
 
 /* ── 스크롤바 스타일링 ── */


### PR DESCRIPTION
## 변경 사항
- `globals.css`: `html`에 `height: 100%` + `background-color: var(--color-bg)` 추가 (상단 safe area 배경색 통일), `body`에 `overflow: hidden` + `overscroll-behavior: none` 적용 (body 레벨 스크롤 및 iOS rubber-band 차단)
- `(main)/layout.tsx`: 래퍼 높이 `h-[100svh]` → `h-dvh` (URL바 숨겨질 때 뷰포트에 정확히 매칭)
- `admin/layout.tsx`: `min-h-screen` → `h-full overflow-y-auto` (body overflow:hidden 이후 admin 스크롤 복구)
- `(auth)/layout.tsx`: 스크롤 컨테이너(outer `h-full`)와 센터링 레이어(inner `min-h-full justify-center`) 분리 — `overflow-y-auto + justify-center` 조합의 상단 잘림 버그 수정

## 테스트 방법
- [ ] iPhone Safari에서 홈/로스터리/활동 페이지 스크롤 시 스크롤이 1개만 동작하는지 확인
- [ ] iPhone Safari에서 하단 네비게이션 바 아래 safe area(홈 인디케이터 영역) 배경색이 네비게이션 색상과 일치하는지 확인
- [ ] URL바 스크롤로 숨긴 뒤 레이아웃 틈/색상 불일치 없는지 확인
- [ ] 로그인 페이지 화면 중앙 정렬 유지 확인
- [ ] 온보딩 페이지 긴 콘텐츠 스크롤 가능 확인
- [ ] 관리자 페이지 스크롤 정상 동작 확인