### PR TITLE
fix: iOS 터치 씹힘 현상 수정 (touch-action: manipulation)

### DIFF
--- a/src/components/bookmark/BookmarkButton.tsx
+++ b/src/components/bookmark/BookmarkButton.tsx
@@ -47,6 +47,7 @@ export function BookmarkButton({
       onClick={handleClick}
       whileTap={TAP_SCALE}
       transition={SPRING_SNAPPY}
+      style={{ touchAction: 'manipulation' }}
       className={cn(
         'flex items-center justify-center rounded-full p-1.5',
         'hover:bg-muted disabled:pointer-events-none',

--- a/src/components/home/DecafToggle.tsx
+++ b/src/components/home/DecafToggle.tsx
@@ -16,6 +16,7 @@ export function DecafToggle({ decafOn, onToggle }: DecafToggleProps) {
       onClick={onToggle}
       whileTap={TAP_SCALE}
       transition={SPRING_SNAPPY}
+      style={{ touchAction: 'manipulation' }}
       className={`inline-flex items-center gap-2 rounded-full border px-4 py-1.5 text-sm font-medium transition-colors cursor-pointer ${
         decafOn
           ? 'border-primary bg-primary text-primary-foreground'

--- a/src/components/layout/BottomTab.tsx
+++ b/src/components/layout/BottomTab.tsx
@@ -51,7 +51,11 @@ export function BottomTab({ className }: { className?: string }) {
                   transition={SPRING_SNAPPY}
                 />
               )}
-              <motion.div whileTap={TAP_SCALE} transition={SPRING_SNAPPY}>
+              <motion.div
+                whileTap={TAP_SCALE}
+                transition={SPRING_SNAPPY}
+                style={{ touchAction: 'manipulation' }}
+              >
                 <Link
                   href={href}
                   className={cn(

--- a/src/components/rating/StarSelector.tsx
+++ b/src/components/rating/StarSelector.tsx
@@ -34,6 +34,7 @@ export function StarSelector({ value, onChange }: StarSelectorProps) {
             whileHover={{ scale: 1.3 }}
             whileTap={TAP_SCALE}
             transition={SPRING_SNAPPY}
+            style={{ touchAction: 'manipulation' }}
             onMouseEnter={() => setHovered(star)}
             onMouseLeave={() => setHovered(0)}
             onClick={() => onChange(star)}

--- a/src/components/roastery/RoasteryCard.tsx
+++ b/src/components/roastery/RoasteryCard.tsx
@@ -75,6 +75,7 @@ export function RoasteryCard({
           className="group flex flex-row items-start gap-3 rounded-xl p-2 hover:bg-muted/50 transition-colors"
           whileTap={TAP_SCALE}
           transition={SPRING_SNAPPY}
+          style={{ touchAction: 'manipulation' }}
         >
           <div className="relative w-16 h-16 flex-shrink-0 overflow-hidden rounded-lg bg-muted">
             {roastery.imageUrl ? (
@@ -147,6 +148,7 @@ export function RoasteryCard({
         className="group flex flex-col gap-2"
         whileTap={TAP_SCALE}
         transition={SPRING_SNAPPY}
+        style={{ touchAction: 'manipulation' }}
       >
         <div className="relative aspect-[3/4] w-full overflow-hidden rounded-xl bg-muted">
           {roastery.imageUrl ? (


### PR DESCRIPTION
## 변경 사항
- Framer Motion v12가 Pointer Events API로 전환하면서 iOS Safari에서 `whileTap` 제스처 인식 도중 `click` 이벤트가 씹히는 문제 수정
- `whileTap`이 있는 모든 `motion` 요소에 `style={{ touchAction: 'manipulation' }}` 추가
  - `BottomTab` — 탭 네비게이션 전체가 씹히는 가장 치명적인 케이스
  - `RoasteryCard` (portrait/landscape 두 variant)
  - `BookmarkButton`
  - `DecafToggle`
  - `StarSelector`

## 테스트 방법
- [ ] 아이폰 Safari에서 하단 탭 네비게이션 탭 → 페이지 이동 확인
- [ ] 아이폰 Safari에서 로스터리 카드 탭 → 상세 페이지 이동 확인
- [ ] 아이폰 Safari에서 북마크 버튼 탭 → 즐겨찾기 토글 확인