### PR TITLE
fix: iOS 스크롤 후 클릭 이벤트 좌표 오류 수정

### DIFF
--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -18,12 +18,10 @@ export default async function MainLayout({ children }: { children: React.ReactNo
   return (
     <div className="flex h-dvh flex-col bg-bg">
       <Navigation />
-      <main
-        className="fixed inset-x-0 top-0 overflow-y-auto bg-bg
-          bottom-[calc(var(--bottom-tab-height)+env(safe-area-inset-bottom,0px))]
-          lg:static lg:flex-1 lg:bottom-auto"
-      >
-        <PageTransition>{children}</PageTransition>
+      <main className="flex-1 min-h-0 overflow-y-auto overscroll-y-contain bg-bg">
+        <div className="pb-[calc(var(--bottom-tab-height)+env(safe-area-inset-bottom,0px))] lg:pb-0">
+          <PageTransition>{children}</PageTransition>
+        </div>
       </main>
     </div>
   )


### PR DESCRIPTION
## 변경 사항
- `<main>` 레이아웃을 `position:fixed + overflow-y:auto` → `flex-1 min-h-0 + overflow-y:auto` 구조로 변경

## 원인
iOS WebKit 버그: `position:fixed` + `overflow-y:auto` 조합에서 스크롤 후 click 이벤트의 좌표가 스크롤 이전 document 좌표로 발화됨
- `pointerdown` (interaction) → 시각적 좌표 기준 정상 처리 ✓
- 합성 `click` → 스크롤 이전 좌표로 발화 → 엉뚱한 요소 히트 → 클릭 무반응 ✗

## 테스트 방법
- [ ] 아이폰 Safari에서 로스터리 목록 스크롤 후 카드 클릭 → 상세 페이지 이동 확인
- [ ] 홈 피드 스크롤 후 카드 클릭 → 이동 확인
- [ ] 하단 탭 네비게이션 정상 동작 확인
- [ ] 데스크탑에서 기존 레이아웃 깨짐 없는지 확인 (header + 본문 높이 정상)