### PR TITLE
fix: 모바일 멀티 터치 ghost click 방지

### DIFF
--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -16,13 +16,9 @@ export default async function MainLayout({ children }: { children: React.ReactNo
   }
 
   return (
-    <div className="flex h-dvh flex-col bg-bg">
+    <div className="flex h-full flex-col bg-bg">
       <Navigation />
-      <main
-        className="fixed inset-x-0 top-0 overflow-y-auto bg-bg
-          bottom-[calc(var(--bottom-tab-height)+env(safe-area-inset-bottom,0px))]
-          lg:static lg:flex-1 lg:bottom-auto"
-      >
+      <main className="flex-1 overflow-y-auto pb-[calc(var(--bottom-tab-height)+env(safe-area-inset-bottom,0px))] lg:pb-0">
         <PageTransition>{children}</PageTransition>
       </main>
     </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -212,12 +212,12 @@ label {
 
 html {
   height: 100%;
+  overflow: hidden; /* body overflow:hidden은 iOS가 무시 — html에 걸어야 실제로 막힘 */
   background-color: var(--color-bg); /* safe-area 상단 배경 통일 */
 }
 
 body {
-  position: fixed; /* iOS에서 body overflow:hidden은 무시됨 — fixed로 진짜 고정 */
-  inset: 0;
+  height: 100%;
   overflow: hidden;
   overscroll-behavior: none;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -216,9 +216,10 @@ html {
 }
 
 body {
-  height: 100%;
-  overflow: hidden; /* body 레벨 스크롤 차단 (overflow-x: clip 대체) */
-  overscroll-behavior: none; /* iOS rubber-band 방지 */
+  position: fixed; /* iOS에서 body overflow:hidden은 무시됨 — fixed로 진짜 고정 */
+  inset: 0;
+  overflow: hidden;
+  overscroll-behavior: none;
 }
 
 /* ── 스크롤바 스타일링 ── */

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -197,6 +197,19 @@
   -webkit-font-smoothing: antialiased;
 }
 
+/* 멀티 터치 ghost click 방지 및 300ms 딜레이 제거 */
+button,
+a,
+[role="button"],
+[role="tab"],
+[role="checkbox"],
+[role="radio"],
+[role="switch"],
+[role="menuitem"],
+label {
+  touch-action: manipulation;
+}
+
 html {
   height: 100%;
   background-color: var(--color-bg); /* safe-area 상단 배경 통일 */

--- a/src/components/layout/BottomTab.tsx
+++ b/src/components/layout/BottomTab.tsx
@@ -6,8 +6,10 @@ import { useSession } from 'next-auth/react'
 import { Home, Coffee, LayoutList, User, Settings } from 'lucide-react'
 import { motion } from 'framer-motion'
 import { cn } from '@/lib/utils'
-import { SPRING_SNAPPY } from '@/lib/motion'
+import { SPRING_SNAPPY, TAP_SCALE } from '@/lib/motion'
 import { getRoasteriesView } from '@/lib/roasteriesState'
+
+const MotionLink = motion.create(Link)
 
 export function BottomTab({ className }: { className?: string }) {
   const pathname = usePathname()
@@ -51,12 +53,14 @@ export function BottomTab({ className }: { className?: string }) {
                   transition={SPRING_SNAPPY}
                 />
               )}
-              <Link
+              <MotionLink
                 href={href}
                 className={cn(
-                  'flex flex-col items-center gap-1 text-xs font-medium transition-colors active:scale-[0.96]',
+                  'flex flex-col items-center gap-1 text-xs font-medium transition-colors',
                   isActive ? 'text-text-primary' : 'text-text-disabled hover:text-text-secondary'
                 )}
+                whileTap={TAP_SCALE}
+                transition={SPRING_SNAPPY}
               >
                 <motion.div
                   animate={{ scale: isActive ? 1.1 : 1, y: isActive ? -1 : 0 }}
@@ -65,7 +69,7 @@ export function BottomTab({ className }: { className?: string }) {
                   <Icon className={cn('size-5', isActive ? 'stroke-[2.5]' : 'stroke-[1.5]')} />
                 </motion.div>
                 <span className="whitespace-nowrap">{label}</span>
-              </Link>
+              </MotionLink>
             </li>
           )
         })}

--- a/src/components/layout/BottomTab.tsx
+++ b/src/components/layout/BottomTab.tsx
@@ -6,7 +6,7 @@ import { useSession } from 'next-auth/react'
 import { Home, Coffee, LayoutList, User, Settings } from 'lucide-react'
 import { motion } from 'framer-motion'
 import { cn } from '@/lib/utils'
-import { SPRING_SNAPPY, TAP_SCALE } from '@/lib/motion'
+import { SPRING_SNAPPY } from '@/lib/motion'
 import { getRoasteriesView } from '@/lib/roasteriesState'
 
 export function BottomTab({ className }: { className?: string }) {
@@ -51,23 +51,21 @@ export function BottomTab({ className }: { className?: string }) {
                   transition={SPRING_SNAPPY}
                 />
               )}
-              <motion.div whileTap={TAP_SCALE} transition={SPRING_SNAPPY}>
-                <Link
-                  href={href}
-                  className={cn(
-                    'flex flex-col items-center gap-1 text-xs font-medium transition-colors',
-                    isActive ? 'text-text-primary' : 'text-text-disabled hover:text-text-secondary'
-                  )}
+              <Link
+                href={href}
+                className={cn(
+                  'flex flex-col items-center gap-1 text-xs font-medium transition-colors active:scale-[0.96]',
+                  isActive ? 'text-text-primary' : 'text-text-disabled hover:text-text-secondary'
+                )}
+              >
+                <motion.div
+                  animate={{ scale: isActive ? 1.1 : 1, y: isActive ? -1 : 0 }}
+                  transition={SPRING_SNAPPY}
                 >
-                  <motion.div
-                    animate={{ scale: isActive ? 1.1 : 1, y: isActive ? -1 : 0 }}
-                    transition={SPRING_SNAPPY}
-                  >
-                    <Icon className={cn('size-5', isActive ? 'stroke-[2.5]' : 'stroke-[1.5]')} />
-                  </motion.div>
-                  <span className="whitespace-nowrap">{label}</span>
-                </Link>
-              </motion.div>
+                  <Icon className={cn('size-5', isActive ? 'stroke-[2.5]' : 'stroke-[1.5]')} />
+                </motion.div>
+                <span className="whitespace-nowrap">{label}</span>
+              </Link>
             </li>
           )
         })}

--- a/src/components/roastery/RoasteryCard.tsx
+++ b/src/components/roastery/RoasteryCard.tsx
@@ -2,12 +2,16 @@
 
 import Link from 'next/link'
 import Image from 'next/image'
+import { motion } from 'framer-motion'
 import { Badge } from '@/components/ui/badge'
 import { RegionDisplay } from './RegionDisplay'
 import { RatingDisplay } from './RatingDisplay'
 import type { RoasteryWithStats } from '@/types/roastery'
 import { PRICE_RANGE_LABELS, getCharacteristicTags } from '@/types/roastery'
 import { formatDistance } from '@/lib/geo'
+import { SPRING_SNAPPY, TAP_SCALE } from '@/lib/motion'
+
+const MotionLink = motion.create(Link)
 
 interface RoasteryCardProps {
   roastery: RoasteryWithStats
@@ -57,9 +61,11 @@ export function RoasteryCard({
 
   if (variant === 'landscape') {
     return (
-      <Link
+      <MotionLink
         href={`/roasteries/${roastery.id}`}
-        className="block active:scale-[0.96] transition-transform focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-xl"
+        className="block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-xl"
+        whileTap={TAP_SCALE}
+        transition={SPRING_SNAPPY}
         onClick={
           onCardClick
             ? (e) => {
@@ -119,15 +125,17 @@ export function RoasteryCard({
             </div>
           </div>
         </div>
-      </Link>
+      </MotionLink>
     )
   }
 
   // portrait (기본 — 홈 피드)
   return (
-    <Link
+    <MotionLink
       href={`/roasteries/${roastery.id}`}
-      className="block active:scale-[0.96] transition-transform focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-xl"
+      className="block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-xl"
+      whileTap={TAP_SCALE}
+      transition={SPRING_SNAPPY}
       onClick={
         onCardClick
           ? (e) => {
@@ -179,6 +187,6 @@ export function RoasteryCard({
           </div>
         </div>
       </div>
-    </Link>
+    </MotionLink>
   )
 }

--- a/src/components/roastery/RoasteryCard.tsx
+++ b/src/components/roastery/RoasteryCard.tsx
@@ -2,13 +2,11 @@
 
 import Link from 'next/link'
 import Image from 'next/image'
-import { motion } from 'framer-motion'
 import { Badge } from '@/components/ui/badge'
 import { RegionDisplay } from './RegionDisplay'
 import { RatingDisplay } from './RatingDisplay'
 import type { RoasteryWithStats } from '@/types/roastery'
 import { PRICE_RANGE_LABELS, getCharacteristicTags } from '@/types/roastery'
-import { SPRING_SNAPPY, TAP_SCALE } from '@/lib/motion'
 import { formatDistance } from '@/lib/geo'
 
 interface RoasteryCardProps {
@@ -61,7 +59,7 @@ export function RoasteryCard({
     return (
       <Link
         href={`/roasteries/${roastery.id}`}
-        className="block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-xl"
+        className="block active:scale-[0.96] transition-transform focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-xl"
         onClick={
           onCardClick
             ? (e) => {
@@ -71,11 +69,7 @@ export function RoasteryCard({
             : undefined
         }
       >
-        <motion.div
-          className="group flex flex-row items-start gap-3 rounded-xl p-2 hover:bg-muted/50 transition-colors"
-          whileTap={TAP_SCALE}
-          transition={SPRING_SNAPPY}
-        >
+        <div className="group flex flex-row items-start gap-3 rounded-xl p-2 hover:bg-muted/50 transition-colors">
           <div className="relative w-16 h-16 flex-shrink-0 overflow-hidden rounded-lg bg-muted">
             {roastery.imageUrl ? (
               <Image
@@ -124,7 +118,7 @@ export function RoasteryCard({
               )}
             </div>
           </div>
-        </motion.div>
+        </div>
       </Link>
     )
   }
@@ -133,7 +127,7 @@ export function RoasteryCard({
   return (
     <Link
       href={`/roasteries/${roastery.id}`}
-      className="block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-xl"
+      className="block active:scale-[0.96] transition-transform focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-xl"
       onClick={
         onCardClick
           ? (e) => {
@@ -143,11 +137,7 @@ export function RoasteryCard({
           : undefined
       }
     >
-      <motion.div
-        className="group flex flex-col gap-2"
-        whileTap={TAP_SCALE}
-        transition={SPRING_SNAPPY}
-      >
+      <div className="group flex flex-col gap-2">
         <div className="relative aspect-[3/4] w-full overflow-hidden rounded-xl bg-muted">
           {roastery.imageUrl ? (
             <Image
@@ -188,7 +178,7 @@ export function RoasteryCard({
             ))}
           </div>
         </div>
-      </motion.div>
+      </div>
     </Link>
   )
 }


### PR DESCRIPTION
## 변경 사항
- `globals.css`에 인터랙티브 요소 대상 `touch-action: manipulation` 글로벌 적용
- 대상: `button`, `a`, `[role="button"]`, `[role="tab"]`, `[role="checkbox"]`, `[role="radio"]`, `[role="switch"]`, `[role="menuitem"]`, `label`

## 배경
멀티 터치 시 브라우저가 `touchend` → `click` 이벤트를 합성(ghost click)하여 의도치 않은 클릭이 발생하는 문제.
`touch-action: manipulation`으로 핀치줌·더블탭 딜레이를 제거하고 ghost click 합성을 억제.

## 테스트 방법
- [ ] 모바일(iOS Safari / Android Chrome)에서 두 손가락으로 화면 터치 후 한 손가락을 떼었을 때 클릭이 발생하지 않는지 확인
- [ ] 카드, 버튼, 별점 등 주요 인터랙티브 요소 단일 탭 동작 정상 확인