### PR TITLE
feat: 모바일 스크롤 구조를 YouTube 패턴으로 채택

### DIFF
--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -1,7 +1,5 @@
 export default function AuthLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="flex min-h-full flex-col items-center justify-center overflow-y-auto bg-bg px-4">
-      {children}
-    </div>
+    <div className="flex min-h-dvh flex-col items-center justify-center bg-bg px-4">{children}</div>
   )
 }

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -18,7 +18,7 @@ export default async function MainLayout({ children }: { children: React.ReactNo
   return (
     <div className="bg-bg">
       <Navigation />
-      <main className="pb-[var(--bottom-tab-height)] lg:pt-[var(--header-height)] lg:pb-0">
+      <main className="pb-[var(--bottom-tab-height)] lg:pb-0">
         <PageTransition>{children}</PageTransition>
       </main>
     </div>

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -16,13 +16,9 @@ export default async function MainLayout({ children }: { children: React.ReactNo
   }
 
   return (
-    <div className="flex h-dvh flex-col bg-bg">
+    <div className="bg-bg">
       <Navigation />
-      <main
-        className="fixed inset-x-0 top-0 overflow-y-auto bg-bg
-          bottom-[calc(var(--bottom-tab-height)+env(safe-area-inset-bottom,0px))]
-          lg:static lg:flex-1 lg:bottom-auto"
-      >
+      <main className="pb-[var(--bottom-tab-height)] lg:pt-[var(--header-height)] lg:pb-0">
         <PageTransition>{children}</PageTransition>
       </main>
     </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -202,6 +202,7 @@ html {
 }
 
 body {
+  background-color: var(--color-bg); /* iOS 26+ Safari가 body bg를 safe-area 색으로 사용 (theme-color 메타는 deprecated) */
   overflow-x: clip; /* clip은 scroll context를 만들지 않아 iOS window scroll 정상 동작 */
   overscroll-behavior: none;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -202,7 +202,8 @@ html {
 }
 
 body {
-  overflow-x: hidden; /* 가로 스크롤만 차단 — body가 세로 스크롤 컨테이너 (iOS 상단 탭 → 맨 위 동작) */
+  overflow-x: clip; /* clip은 scroll context를 만들지 않아 iOS window scroll 정상 동작 */
+  overscroll-behavior: none;
 }
 
 /* ── 스크롤바 스타일링 ── */

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -144,7 +144,7 @@
   --container-max: 1440px;
 
   /* 네비게이션 높이 */
-  --header-height: 3.5rem;   /* 데스크탑 헤더 (h-14) */
+  --header-height: calc(3.5rem + 1px);   /* 데스크탑 헤더 (h-14 + border-b 1px) */
   --bottom-tab-height: 4rem; /* 모바일 하단 탭 (h-16) */
 
   /* 브레이크포인트 */

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -198,14 +198,11 @@
 }
 
 html {
-  height: 100%;
   background-color: var(--color-bg); /* safe-area 상단 배경 통일 */
 }
 
 body {
-  height: 100%;
-  overflow: hidden; /* body 레벨 스크롤 차단 (overflow-x: clip 대체) */
-  overscroll-behavior: none; /* iOS rubber-band 방지 */
+  overflow-x: hidden; /* 가로 스크롤만 차단 — body가 세로 스크롤 컨테이너 (iOS 상단 탭 → 맨 위 동작) */
 }
 
 /* ── 스크롤바 스타일링 ── */

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -302,8 +302,10 @@ body {
 }
 
 @keyframes page-enter {
-  from { opacity: 0; transform: translateY(8px); }
-  to   { opacity: 1; transform: translateY(0); }
+  from { opacity: 0; }
+  to   { opacity: 1; }
+  /* transform은 사용 금지 — animation fill-mode 후에도 identity matrix가 남아
+     자손 position:fixed의 containing block이 viewport가 아닌 이 요소가 됨 (FAB 깨짐) */
 }
 
 @layer utilities {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata, Viewport } from 'next'
+import type { Metadata } from 'next'
 import { Analytics } from '@vercel/analytics/next'
 import { SpeedInsights } from '@vercel/speed-insights/next'
 import { GoogleAnalytics } from '@next/third-parties/google'
@@ -8,10 +8,6 @@ import { SessionProvider } from '@/components/layout/SessionProvider'
 import { ThemeProvider } from '@/components/layout/ThemeProvider'
 import { Toaster } from '@/components/ui/sonner'
 import './globals.css'
-
-export const viewport: Viewport = {
-  viewportFit: 'cover',
-}
 
 export const metadata: Metadata = {
   metadataBase: new URL('https://rocommend.com'),

--- a/src/components/layout/BottomTab.tsx
+++ b/src/components/layout/BottomTab.tsx
@@ -32,7 +32,6 @@ export function BottomTab({ className }: { className?: string }) {
     <nav
       className={cn(
         'fixed bottom-0 left-0 right-0 z-40 border-t border-border bg-surface',
-        'pb-[env(safe-area-inset-bottom,0px)]',
         className
       )}
     >

--- a/src/components/roastery/map/RoasteryMapLayout.tsx
+++ b/src/components/roastery/map/RoasteryMapLayout.tsx
@@ -534,7 +534,7 @@ export function RoasteryMapLayout({
     >
       {/* 페이지 헤더 (h1 + 필터) */}
       {mobileHeader && (
-        <div className="shrink-0 bg-background border-b pt-8 pb-3 px-[var(--page-padding)]">
+        <div className="shrink-0 bg-bg border-b pt-8 pb-3 px-[var(--page-padding)]">
           {mobileHeader}
         </div>
       )}


### PR DESCRIPTION
## Summary
모바일 레이아웃을 YouTube 모바일 웹과 동일한 구조로 전환하여 iOS Safari의 네이티브 제스처(상단바 탭 → 맨 위), safe-area 자연 처리, 스크롤바 연장을 모두 해결.

- **body가 세로 스크롤 컨테이너** (wrapper div 스크롤 → body 스크롤)
- **viewport-fit cover 제거** → iOS Safari가 safe-area를 viewport bound로 자동 처리
- **fixed nav 클리어런스를 main padding으로** (margin이 아닌 padding이라 컨텐츠가 nav 뒤로 자연 스크롤)
- **데스크탑 헤더의 border 1px overflow** 보정 (--header-height 값 정밀화)
- **PageTransition의 transform이 FAB containing block을 가로채던 문제** 해결 (opacity-only 입장 애니메이션)

## 커밋
1. `feat`: YouTube 패턴 채택 — body 스크롤 컨테이너, viewport-fit 제거, main padding으로 클리어런스
2. `fix`: body overflow-x를 `clip`으로 (hidden은 scroll context를 만들어 iOS window scroll 간섭)
3. `fix`: 데스크탑 헤더 빈칸 및 맵 페이지 1px overflow 제거
4. `fix`: PageTransition transform이 FAB containing block을 가로채는 문제 해결

## Test plan
- [ ] **모바일 (실기기)**: iPhone Safari에서 상단바 탭 → 페이지 맨 위로 이동
- [ ] **모바일 (실기기)**: 하단 메뉴바가 home indicator 위에 정확히 위치
- [ ] **모바일 (실기기)**: 컨텐츠 스크롤이 하단 메뉴바 뒤까지 연장됨
- [ ] **모바일 (브라우저)**: 로스터리 페이지 FAB(지도 버튼)이 우하단에 정상 표시
- [ ] **데스크탑 1280+**: 헤더 위 빈 공간 없음
- [ ] **데스크탑 1280+**: `/roasteries?view=map` 스크롤 없음
- [ ] **데스크탑 1280+**: 페이지 전환 시 fade-in 정상 동작