### PR TITLE
fix: 데스크탑 지도뷰 카드 클릭 시 사이드 패널 + 마커 클릭 동작 안정화

### DIFF
--- a/src/components/roastery/RoasteryCard.tsx
+++ b/src/components/roastery/RoasteryCard.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import type { MouseEvent } from 'react'
 import Link from 'next/link'
 import Image from 'next/image'
 import { Badge } from '@/components/ui/badge'
@@ -14,7 +15,7 @@ interface RoasteryCardProps {
   priority?: boolean
   activeRegions?: string[]
   variant?: 'portrait' | 'landscape'
-  onCardClick?: (id: string) => void
+  onCardClick?: (id: string, e: MouseEvent<HTMLAnchorElement>) => void
   nearbyAddress?: string
   nearbyDistance?: number
 }
@@ -60,7 +61,7 @@ export function RoasteryCard({
       <Link
         href={`/roasteries/${roastery.id}`}
         className="block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-xl active:scale-[0.97] transition-transform duration-100"
-        onClick={onCardClick ? () => onCardClick(roastery.id) : undefined}
+        onClick={onCardClick ? (e) => onCardClick(roastery.id, e) : undefined}
       >
         <div className="group flex flex-row items-start gap-3 rounded-xl p-2 hover:bg-muted/50 transition-colors">
           <div className="relative w-16 h-16 flex-shrink-0 overflow-hidden rounded-lg bg-muted">
@@ -121,7 +122,7 @@ export function RoasteryCard({
     <Link
       href={`/roasteries/${roastery.id}`}
       className="block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-xl active:scale-[0.97] transition-transform duration-100"
-      onClick={onCardClick ? () => onCardClick(roastery.id) : undefined}
+      onClick={onCardClick ? (e) => onCardClick(roastery.id, e) : undefined}
     >
       <div className="group flex flex-col gap-2">
         <div className="relative aspect-[3/4] w-full overflow-hidden rounded-xl bg-muted">

--- a/src/components/roastery/RoasteryGrid.tsx
+++ b/src/components/roastery/RoasteryGrid.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import type { MouseEvent } from 'react'
 import { RoasteryCard } from './RoasteryCard'
 import type { RoasteryWithStats } from '@/types/roastery'
 
@@ -7,7 +8,7 @@ interface RoasteryGridProps {
   roasteries: RoasteryWithStats[]
   activeRegions?: string[]
   variant?: 'portrait' | 'landscape'
-  onCardClick?: (id: string) => void
+  onCardClick?: (id: string, e: MouseEvent<HTMLAnchorElement>) => void
   singleCol?: boolean
 }
 

--- a/src/components/roastery/map/RoasteryMapLayout.tsx
+++ b/src/components/roastery/map/RoasteryMapLayout.tsx
@@ -8,6 +8,7 @@ import {
   useEffect,
   type ReactNode,
   type TouchEvent,
+  type MouseEvent,
 } from 'react'
 import dynamic from 'next/dynamic'
 import Link from 'next/link'
@@ -301,8 +302,9 @@ export function RoasteryMapLayout({
   }, [router, buildUrl])
 
   const handleCardClick = useCallback(
-    (roasteryId: string) => {
+    (roasteryId: string, e: MouseEvent<HTMLAnchorElement>) => {
       if (isDesktop && !nearbyMode) {
+        e.preventDefault()
         zoomRef.current?.clearSelection()
         router.push(buildUrl(roasteryId), { scroll: false })
       }
@@ -311,13 +313,14 @@ export function RoasteryMapLayout({
   )
 
   const handleNearbyCardClick = useCallback(
-    (roasteryId: string, lat: number, lng: number) => {
+    (roasteryId: string, lat: number, lng: number, e: MouseEvent<HTMLAnchorElement>) => {
       const idx = nearbyLocations.findIndex(
         (item) =>
           item.roastery.id === roasteryId && item.location.lat === lat && item.location.lng === lng
       )
       if (idx === -1) return
       const item = nearbyLocations[idx]!
+      e.preventDefault()
       setNearbyIndex(idx)
       setNearbySelectedId(roasteryId)
       zoomRef.current?.panTo(item.location.lat!, item.location.lng!, 15)
@@ -395,11 +398,12 @@ export function RoasteryMapLayout({
                     variant="landscape"
                     nearbyAddress={item.location.address ?? undefined}
                     nearbyDistance={item.distance}
-                    onCardClick={() =>
+                    onCardClick={(_, e) =>
                       handleNearbyCardClick(
                         item.roastery.id,
                         item.location.lat!,
-                        item.location.lng!
+                        item.location.lng!,
+                        e
                       )
                     }
                   />

--- a/src/components/roastery/map/RoasteryMapLayout.tsx
+++ b/src/components/roastery/map/RoasteryMapLayout.tsx
@@ -110,7 +110,7 @@ export function RoasteryMapLayout({
   const [clickedAddress, setClickedAddress] = useState<string | null>(null)
   const touchStartX = useRef(0)
   const zoomRef = useRef<ZoomHandle | null>(null)
-  const wasCardClickRef = useRef(false)
+  const pendingCardFitIdRef = useRef<string | null>(null)
   const handleMapReady = useCallback((handle: ZoomHandle) => {
     zoomRef.current = handle
   }, [])
@@ -269,7 +269,7 @@ export function RoasteryMapLayout({
   const selectRoastery = useCallback(
     (roasteryId: string, lat: number, lng: number) => {
       // 마커 클릭은 카드 클릭 의도(전체 fit)를 무효화
-      wasCardClickRef.current = false
+      pendingCardFitIdRef.current = null
       // 클릭한 마커의 주소 추적 (스냅 카드용)
       const clicked = markers.find(
         (m) => m.roasteryId === roasteryId && m.lat === lat && m.lng === lng
@@ -299,6 +299,7 @@ export function RoasteryMapLayout({
   )
 
   const clearSelection = useCallback(() => {
+    pendingCardFitIdRef.current = null
     router.push(buildUrl(null), { scroll: false })
     setSnapId(undefined)
     setNearbySelectedId(undefined)
@@ -313,7 +314,7 @@ export function RoasteryMapLayout({
       if (!isDesktop || nearbyMode) return
       if (!isPlainPrimaryClick(e)) return
       e.preventDefault()
-      wasCardClickRef.current = true
+      pendingCardFitIdRef.current = roasteryId
       zoomRef.current?.clearSelection()
       router.push(buildUrl(roasteryId), { scroll: false })
       // 즉시 fit (overlayWidth는 직전 값으로 적용). selectedDetail 도착 시 아래 useEffect가 보정 호출.
@@ -340,11 +341,11 @@ export function RoasteryMapLayout({
     [nearbyLocations, router, buildUrl]
   )
 
-  // selectedDetail이 도착(또는 변경)되면 카드 클릭이었던 경우 overlayWidth 반영해 다시 fit
+  // 카드 클릭으로 요청된 fit 의도가 selectedDetail 도착과 일치하는 경우에만 보정 fit 실행
   useEffect(() => {
     if (!selectedDetail) return
-    if (!wasCardClickRef.current) return
-    wasCardClickRef.current = false
+    if (pendingCardFitIdRef.current !== selectedDetail.roastery.id) return
+    pendingCardFitIdRef.current = null
     zoomRef.current?.fitToRoastery(selectedDetail.roastery.id)
   }, [selectedDetail])
 

--- a/src/components/roastery/map/RoasteryMapLayout.tsx
+++ b/src/components/roastery/map/RoasteryMapLayout.tsx
@@ -110,6 +110,7 @@ export function RoasteryMapLayout({
   const [clickedAddress, setClickedAddress] = useState<string | null>(null)
   const touchStartX = useRef(0)
   const zoomRef = useRef<ZoomHandle | null>(null)
+  const wasCardClickRef = useRef(false)
   const handleMapReady = useCallback((handle: ZoomHandle) => {
     zoomRef.current = handle
   }, [])
@@ -267,6 +268,8 @@ export function RoasteryMapLayout({
 
   const selectRoastery = useCallback(
     (roasteryId: string, lat: number, lng: number) => {
+      // 마커 클릭은 카드 클릭 의도(전체 fit)를 무효화
+      wasCardClickRef.current = false
       // 클릭한 마커의 주소 추적 (스냅 카드용)
       const clicked = markers.find(
         (m) => m.roasteryId === roasteryId && m.lat === lat && m.lng === lng
@@ -301,19 +304,27 @@ export function RoasteryMapLayout({
     setNearbySelectedId(undefined)
   }, [router, buildUrl])
 
+  // 새 탭/창 열기(Cmd/Ctrl/Shift/Alt + 클릭, 보조 버튼)는 그대로 두기 위한 가드
+  const isPlainPrimaryClick = (e: MouseEvent<HTMLAnchorElement>) =>
+    e.button === 0 && !e.metaKey && !e.ctrlKey && !e.shiftKey && !e.altKey
+
   const handleCardClick = useCallback(
     (roasteryId: string, e: MouseEvent<HTMLAnchorElement>) => {
-      if (isDesktop && !nearbyMode) {
-        e.preventDefault()
-        zoomRef.current?.clearSelection()
-        router.push(buildUrl(roasteryId), { scroll: false })
-      }
+      if (!isDesktop || nearbyMode) return
+      if (!isPlainPrimaryClick(e)) return
+      e.preventDefault()
+      wasCardClickRef.current = true
+      zoomRef.current?.clearSelection()
+      router.push(buildUrl(roasteryId), { scroll: false })
+      // 즉시 fit (overlayWidth는 직전 값으로 적용). selectedDetail 도착 시 아래 useEffect가 보정 호출.
+      zoomRef.current?.fitToRoastery(roasteryId)
     },
     [isDesktop, nearbyMode, router, buildUrl]
   )
 
   const handleNearbyCardClick = useCallback(
     (roasteryId: string, lat: number, lng: number, e: MouseEvent<HTMLAnchorElement>) => {
+      if (!isPlainPrimaryClick(e)) return
       const idx = nearbyLocations.findIndex(
         (item) =>
           item.roastery.id === roasteryId && item.location.lat === lat && item.location.lng === lng
@@ -328,6 +339,14 @@ export function RoasteryMapLayout({
     },
     [nearbyLocations, router, buildUrl]
   )
+
+  // selectedDetail이 도착(또는 변경)되면 카드 클릭이었던 경우 overlayWidth 반영해 다시 fit
+  useEffect(() => {
+    if (!selectedDetail) return
+    if (!wasCardClickRef.current) return
+    wasCardClickRef.current = false
+    zoomRef.current?.fitToRoastery(selectedDetail.roastery.id)
+  }, [selectedDetail])
 
   const handleTouchStart = useCallback((e: TouchEvent<HTMLDivElement>) => {
     touchStartX.current = e.touches[0].clientX

--- a/src/components/roastery/map/RoasteryMapView.tsx
+++ b/src/components/roastery/map/RoasteryMapView.tsx
@@ -70,6 +70,7 @@ export interface ZoomHandle {
   panTo: (lat: number, lng: number, zoom?: number) => void
   skipNextFlyTo: () => void
   clearSelection: () => void
+  fitToRoastery: (roasteryId: string) => void
 }
 
 interface Props {
@@ -180,6 +181,14 @@ export function RoasteryMapView({
   const justFitBoundsRef = useRef(false)
   const prevSelectedIdRef = useRef<string | undefined>(undefined)
   const restoredFromSavedRef = useRef(!!savedMapView)
+  const markersRef = useRef(markers)
+  const overlayWidthRef = useRef(overlayWidth)
+  useEffect(() => {
+    markersRef.current = markers
+  }, [markers])
+  useEffect(() => {
+    overlayWidthRef.current = overlayWidth
+  }, [overlayWidth])
   const [selection, setSelection] = useState<{
     roasteryId: string
     lat: number
@@ -226,6 +235,18 @@ export function RoasteryMapView({
         justFitBoundsRef.current = true
       },
       clearSelection: () => clearSelectionRef.current(),
+      fitToRoastery: (roasteryId: string) => {
+        if (!containerRef.current) return
+        const roasteryMarkers = markersRef.current.filter((m) => m.roasteryId === roasteryId)
+        if (roasteryMarkers.length === 0) return
+        const { lat, lng, zoom } = computeFitView(
+          roasteryMarkers,
+          containerRef.current,
+          overlayWidthRef.current
+        )
+        map.morph(new nv.LatLng(lat, lng), zoom)
+        justFitBoundsRef.current = true
+      },
     })
     setMapReady(true)
   }, [])

--- a/src/components/roastery/map/RoasteryMapView.tsx
+++ b/src/components/roastery/map/RoasteryMapView.tsx
@@ -359,7 +359,12 @@ export function RoasteryMapView({
     const nv = window.naver.maps
 
     const pos = clickedPosRef.current
-    clickedPosRef.current = null
+
+    // 마커 클릭으로 pos가 설정됐지만 selectedId 갱신이 다른 commit으로 분리된 경우,
+    // selectedId가 새 selection을 따라잡을 때까지 pos를 보존하고 대기 (fit bounds 회귀 방지)
+    if (pos && selection?.roasteryId !== selectedId) {
+      return
+    }
 
     const selectedIdChanged = prevSelectedIdRef.current !== selectedId
 
@@ -369,6 +374,7 @@ export function RoasteryMapView({
     prevSelectedIdRef.current = selectedId
 
     if (pos) {
+      clickedPosRef.current = null
       // 지도 마커 클릭: 클릭한 마커 위치로 fly (오버레이 오프셋 적용)
       const currentZoom = mapRef.current.getZoom()
       const targetZoom = currentZoom < 16 ? 16 : currentZoom

--- a/src/components/roastery/map/RoasteryMapView.tsx
+++ b/src/components/roastery/map/RoasteryMapView.tsx
@@ -344,6 +344,12 @@ export function RoasteryMapView({
 
   // Fly to selected marker
   useEffect(() => {
+    // selection이 비어 있는데 clickedPosRef가 남아있다면 비-마커 경로(카드/URL)로 선택이
+    // 갱신된 상태 — 마커 클릭 의도는 더 이상 유효하지 않으므로 즉시 폐기 (stale pos 제거)
+    if (clickedPosRef.current && !selection) {
+      clickedPosRef.current = null
+    }
+
     // fitBounds가 막 실행됐으면 fly 건너뜀 — selectedId 유무와 무관하게 먼저 소비
     if (justFitBoundsRef.current) {
       justFitBoundsRef.current = false


### PR DESCRIPTION
## 변경 사항
- 데스크탑 지도뷰 왼쪽 리스트의 카드 클릭 시 상세 페이지로 이동하지 않고 마커 클릭과 동일하게 **왼쪽 사이드 패널 오버레이**가 열리도록 변경
- 카드 클릭 → 해당 로스터리의 **모든 매장 마커가 보이도록 fit bounds** (오버레이 폭 반영)
- 마커 클릭 → 그 **마커 한 개만 중앙으로 fly** (오버레이 폭 반영, zoom 16+)
- 마커를 연속 클릭(A→B)했을 때 두 번째 마커가 fit bounds로 빠지던 회귀 수정
- modifier 키(Cmd/Ctrl/Shift/Alt) 또는 보조 버튼 클릭은 그대로 두어 **새 탭/창 열기 가능**
- 카드 클릭 후 다른 인터랙션이 끼면 stale `clickedPosRef` / 보정 fit이 발동되지 않도록 차단

## 구현 요약
- `RoasteryCard.onCardClick` 시그니처에 `MouseEvent`를 추가해 호출자가 navigation 제어
- `RoasteryMapView`에 `fitToRoastery(roasteryId)` 메서드를 신규 추가 (markers/overlayWidth ref 기반)
- `RoasteryMapLayout`이 `pendingCardFitIdRef`로 카드 fit 의도를 추적하고 `selectedDetail` 도착 시 일치할 때만 보정 fit 호출

## 테스트 방법
- [ ] 데스크탑(>=1024px)에서 로스터리 리스트 → 지도뷰 진입
- [ ] 왼쪽 리스트의 로스터리 카드 클릭 → 상세 페이지로 이동하지 않고 좌측 패널 오버레이가 열리며, 지도는 해당 로스터리의 모든 매장이 fit bounds 되는지 확인
- [ ] 지도의 개별 마커 클릭 → 해당 마커만 중앙(오버레이 반영)으로 fly + zoom 되는지 확인
- [ ] 마커 A1 클릭 후 마커 B1 클릭 → B1이 가운데로 fly (fit bounds로 빠지지 않는지) 확인
- [ ] 마커 A1 클릭 후 카드 A 클릭 → 같은 로스터리 전체 매장 fit bounds로 전환되는지 확인
- [ ] Cmd+클릭(맥) 또는 Ctrl+클릭(윈) → 새 탭에서 상세 페이지가 열리는지 확인
- [ ] 홈 피드 / 일반 리스트 페이지에서 카드 클릭 → 기존대로 상세 페이지로 이동하는지 회귀 없음 확인
- [ ] nearbyMode(내 주변)에서 카드 클릭 동작 회귀 없음 확인 (모바일은 상세 페이지 이동, 데스크탑은 마커 fly)