### PR TITLE
feat: 데스크탑 헤더에 지도 nav 링크 추가

### DIFF
--- a/src/app/(main)/roasteries/RoasteriesContent.tsx
+++ b/src/app/(main)/roasteries/RoasteriesContent.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from 'react'
 import Link from 'next/link'
-import { MapPin, List } from 'lucide-react'
+import { MapPin } from 'lucide-react'
 import { auth } from '@/lib/auth'
 import { getRoasteries, getRoasteryById, getRegionOptions } from '@/lib/queries/roastery'
 import { getUserRating, getRatingCount } from '@/lib/queries/rating'
@@ -146,18 +146,6 @@ export async function RoasteriesContent({ params }: Props) {
         <>
           <div className="flex items-center justify-between">
             <span className="text-sm text-muted-foreground">{roasteries.length}개 로스터리</span>
-            <div className="hidden lg:flex items-center gap-0.5 rounded-lg bg-muted p-0.5">
-              <span className="flex items-center justify-center w-7 h-6 rounded-md bg-background shadow-sm text-foreground">
-                <List className="size-3.5" />
-              </span>
-              <Link
-                href={mapUrl}
-                className="flex items-center justify-center w-7 h-6 rounded-md text-muted-foreground hover:text-foreground transition-colors"
-                aria-label="지도로 보기"
-              >
-                <MapPin className="size-3.5" />
-              </Link>
-            </div>
           </div>
           <RoasteryGrid roasteries={roasteries} activeRegions={filter.regions} />
           <div className="flex justify-center pt-4 pb-2">

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react'
 import Link from 'next/link'
-import { usePathname } from 'next/navigation'
+import { usePathname, useSearchParams } from 'next/navigation'
 import { useSession, signOut } from 'next-auth/react'
 import Image from 'next/image'
 import { MoreVertical } from 'lucide-react'
@@ -19,19 +19,49 @@ import { FeedbackButton } from '@/components/feedback/FeedbackButton'
 import { FeedbackForm } from '@/components/feedback/FeedbackForm'
 import { cn } from '@/lib/utils'
 
-const authNavLinks = [
-  { href: '/', label: '홈' },
-  { href: '/roasteries', label: '로스터리' },
-  { href: '/activity', label: '내 활동' },
+type NavLink = {
+  href: string
+  label: string
+  isActive: (ctx: { pathname: string; isMapView: boolean }) => boolean
+}
+
+const authNavLinks: NavLink[] = [
+  { href: '/', label: '홈', isActive: ({ pathname }) => pathname === '/' },
+  {
+    href: '/roasteries',
+    label: '로스터리',
+    isActive: ({ pathname, isMapView }) => pathname.startsWith('/roasteries') && !isMapView,
+  },
+  {
+    href: '/roasteries?view=map',
+    label: '지도',
+    isActive: ({ pathname, isMapView }) => pathname.startsWith('/roasteries') && isMapView,
+  },
+  {
+    href: '/activity',
+    label: '내 활동',
+    isActive: ({ pathname }) => pathname.startsWith('/activity'),
+  },
 ]
 
-const guestNavLinks = [
-  { href: '/', label: '홈' },
-  { href: '/roasteries', label: '로스터리' },
+const guestNavLinks: NavLink[] = [
+  { href: '/', label: '홈', isActive: ({ pathname }) => pathname === '/' },
+  {
+    href: '/roasteries',
+    label: '로스터리',
+    isActive: ({ pathname, isMapView }) => pathname.startsWith('/roasteries') && !isMapView,
+  },
+  {
+    href: '/roasteries?view=map',
+    label: '지도',
+    isActive: ({ pathname, isMapView }) => pathname.startsWith('/roasteries') && isMapView,
+  },
 ]
 
 export function Header({ className }: { className?: string }) {
   const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const isMapView = searchParams.get('view') === 'map'
   const { data: session } = useSession()
   const navLinks = session?.user ? authNavLinks : guestNavLinks
   const [feedbackOpen, setFeedbackOpen] = useState(false)
@@ -63,15 +93,13 @@ export function Header({ className }: { className?: string }) {
 
           {/* 네비게이션 링크 */}
           <nav className="flex items-center gap-6">
-            {navLinks.map(({ href, label }) => (
+            {navLinks.map(({ href, label, isActive }) => (
               <Link
                 key={href}
                 href={href}
                 className={cn(
                   'text-sm font-medium transition-colors hover:text-text-primary',
-                  (href === '/' ? pathname === '/' : pathname.startsWith(href))
-                    ? 'text-text-primary'
-                    : 'text-text-secondary'
+                  isActive({ pathname, isMapView }) ? 'text-text-primary' : 'text-text-secondary'
                 )}
               >
                 {label}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -19,24 +19,56 @@ import { FeedbackButton } from '@/components/feedback/FeedbackButton'
 import { FeedbackForm } from '@/components/feedback/FeedbackForm'
 import { cn } from '@/lib/utils'
 
+type NavLinkContext = {
+  pathname: string
+  isMapView: boolean
+  searchParams: URLSearchParams
+}
+
 type NavLink = {
   href: string
   label: string
-  isActive: (ctx: { pathname: string; isMapView: boolean }) => boolean
+  isActive: (ctx: NavLinkContext) => boolean
+  buildHref?: (ctx: NavLinkContext) => string
+}
+
+// /roasteries 안에서 list ↔ map을 오갈 때 검색·필터·정렬 쿼리는 유지하고, view/id만 갱신
+function buildRoasteryHref(searchParams: URLSearchParams, options: { mapView: boolean }) {
+  const next = new URLSearchParams(searchParams)
+  next.delete('id')
+  if (options.mapView) {
+    next.set('view', 'map')
+  } else {
+    next.delete('view')
+  }
+  const qs = next.toString()
+  return qs ? `/roasteries?${qs}` : '/roasteries'
+}
+
+const listLink: NavLink = {
+  href: '/roasteries',
+  label: '로스터리',
+  isActive: ({ pathname, isMapView }) => pathname.startsWith('/roasteries') && !isMapView,
+  buildHref: ({ pathname, searchParams }) =>
+    pathname.startsWith('/roasteries')
+      ? buildRoasteryHref(searchParams, { mapView: false })
+      : '/roasteries',
+}
+
+const mapLink: NavLink = {
+  href: '/roasteries?view=map',
+  label: '지도',
+  isActive: ({ pathname, isMapView }) => pathname.startsWith('/roasteries') && isMapView,
+  buildHref: ({ pathname, searchParams }) =>
+    pathname.startsWith('/roasteries')
+      ? buildRoasteryHref(searchParams, { mapView: true })
+      : '/roasteries?view=map',
 }
 
 const authNavLinks: NavLink[] = [
   { href: '/', label: '홈', isActive: ({ pathname }) => pathname === '/' },
-  {
-    href: '/roasteries',
-    label: '로스터리',
-    isActive: ({ pathname, isMapView }) => pathname.startsWith('/roasteries') && !isMapView,
-  },
-  {
-    href: '/roasteries?view=map',
-    label: '지도',
-    isActive: ({ pathname, isMapView }) => pathname.startsWith('/roasteries') && isMapView,
-  },
+  listLink,
+  mapLink,
   {
     href: '/activity',
     label: '내 활동',
@@ -46,16 +78,8 @@ const authNavLinks: NavLink[] = [
 
 const guestNavLinks: NavLink[] = [
   { href: '/', label: '홈', isActive: ({ pathname }) => pathname === '/' },
-  {
-    href: '/roasteries',
-    label: '로스터리',
-    isActive: ({ pathname, isMapView }) => pathname.startsWith('/roasteries') && !isMapView,
-  },
-  {
-    href: '/roasteries?view=map',
-    label: '지도',
-    isActive: ({ pathname, isMapView }) => pathname.startsWith('/roasteries') && isMapView,
-  },
+  listLink,
+  mapLink,
 ]
 
 export function Header({ className }: { className?: string }) {
@@ -93,18 +117,22 @@ export function Header({ className }: { className?: string }) {
 
           {/* 네비게이션 링크 */}
           <nav className="flex items-center gap-6">
-            {navLinks.map(({ href, label, isActive }) => (
-              <Link
-                key={href}
-                href={href}
-                className={cn(
-                  'text-sm font-medium transition-colors hover:text-text-primary',
-                  isActive({ pathname, isMapView }) ? 'text-text-primary' : 'text-text-secondary'
-                )}
-              >
-                {label}
-              </Link>
-            ))}
+            {navLinks.map(({ href, label, isActive, buildHref }) => {
+              const ctx = { pathname, isMapView, searchParams }
+              const resolvedHref = buildHref ? buildHref(ctx) : href
+              return (
+                <Link
+                  key={href}
+                  href={resolvedHref}
+                  className={cn(
+                    'text-sm font-medium transition-colors hover:text-text-primary',
+                    isActive(ctx) ? 'text-text-primary' : 'text-text-secondary'
+                  )}
+                >
+                  {label}
+                </Link>
+              )
+            })}
           </nav>
 
           {/* 우측 영역 */}

--- a/src/components/layout/Navigation.test.tsx
+++ b/src/components/layout/Navigation.test.tsx
@@ -5,6 +5,7 @@ import { Navigation } from './Navigation'
 // next/navigation 모킹
 vi.mock('next/navigation', () => ({
   usePathname: () => '/',
+  useSearchParams: () => new URLSearchParams(),
 }))
 
 // next-auth/react 모킹


### PR DESCRIPTION
## 변경 사항

- 데스크탑 헤더 네비에 **"지도"** 항목 추가 (홈 / 로스터리 / 지도 / 내 활동)
- 로그인/비로그인 모두 노출 (비로그인: 홈 / 로스터리 / 지도)
- `view=map` 쿼리 기준으로 활성 표시 분기 (로스터리 vs 지도)
- `/roasteries` 리스트 뷰의 데스크탑 List/MapPin 토글 박스 제거 (모바일 플로팅 버튼은 유지)
- list ↔ map 전환 시 검색·필터·정렬 쿼리 보존, `view`/`id`만 갱신
- `Navigation.test`의 `next/navigation` 모킹에 `useSearchParams` 추가

## 테스트 방법

- [ ] 데스크탑(`lg` 이상)에서 `/roasteries` 진입 → 헤더에 "지도" 항목 보임, "로스터리"가 활성
- [ ] 헤더 "지도" 클릭 → `/roasteries?view=map`으로 이동, "지도"가 활성 / "로스터리" 비활성
- [ ] "{N}개 로스터리" 옆에 있던 List/Map 토글 박스가 사라짐
- [ ] `/roasteries`에서 필터(가격대/지역 등) 적용 → 헤더 "지도" 클릭 시 필터가 보존된 채로 지도 뷰 진입
- [ ] 지도 뷰에서 헤더 "로스터리" 클릭 시 동일 필터로 리스트 복귀
- [ ] 모바일(`lg` 미만)에서는 우하단 플로팅 지도 버튼이 그대로 동작
- [ ] 비로그인 상태에서 헤더에 "지도" 노출, 클릭 시 정상 동작